### PR TITLE
Regenerate toy project artifacts locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Generated demo workspace and binaries
+/demo/Project_Toy/
+/dist/AdminApp.exe
+/dist/ClientApp.exe
+**/assignment.db
+**/client.exe

--- a/docs/ADMIN_RUNBOOK.md
+++ b/docs/ADMIN_RUNBOOK.md
@@ -1,0 +1,72 @@
+# Admin Runbook — Project Toy
+
+## Hydrate the Toy Workspace
+> The demo workspace and executables are generated on demand (no binaries are tracked in Git).
+
+1. From the repo root, run `python tools\seed_toy_project.py`, **or** double-click `scripts\new_toy_project.ps1` from Windows.
+2. The script rebuilds `demo/Project_Toy/`, creates reviewer assignments, and places placeholder clients into each assignment folder.
+3. When you build real executables, copy them into `dist/` before sharing the project.
+
+## Overview of Folder Layout
+- `corpus/` — canonical patient/document SQLite database (**do not edit directly**).
+- `project.db` — metadata database (phenotypes, reviewers, rounds).
+- `phenotypes/ph_diabetes/rounds/round_1/` — Round 1 workspace with manifests, assignments, reports.
+- `reports/` — export targets (`reports/exports/` holds gold data after finalization).
+- `scripts/` — helper PowerShell launchers (keep with the project).
+- `dist/` — locally built Admin and Client executables.
+
+> **Do not** move or rename `project.db`, `corpus/`, or anything inside `phenotypes/` once assignments are distributed.
+
+## Launching the Admin App
+1. From Windows, open PowerShell.
+2. Run `scripts\run_admin.ps1 -Project \\server\share\Project_Toy`.
+   - Alternatively, launch directly via `dist\AdminApp.exe --project \\server\share\Project_Toy` (after building the executable locally).
+3. The Admin application opens against the provided UNC project path.
+
+## Target Corpus Summary
+- Navigate to the **Corpus** or **Phenotypes** tabs to review seeded patients (ICNs 1001–1003).
+- Notes span 2018–2024 with mixed STA3Ns (506, 515).
+
+## Round Wizard Walkthrough
+- Open **Rounds → ph_diabetes → Round 1**.
+- Review stored configuration (`round_config.json`) showing:
+  - Patient filters: years 2018–2024, STA3Ns 506/515.
+  - Note filters: PRIMARY CARE and ENDOCRINOLOGY notes matching `(metformin|insulin|hba1c\s*\d+(\.\d+)?)` (case-insensitive).
+  - Stratification by `note_year`, two samples per stratum.
+  - Reviewers `r_alex`, `r_blake` with overlap of 1 unit (independent reviews).
+- Confirm deterministic RNG seed `133742`.
+
+## Reviewer Folders
+- Each reviewer assignment lives under `phenotypes/ph_diabetes/rounds/round_1/assignments/<reviewer_id>/`.
+- Contents per reviewer:
+- `assignment.db` — SQLite assignment package.
+- `label_schema.json` — label metadata for the client.
+- `client.exe` — placeholder annotator app (regenerated from `dist/ClientApp.exe`; replace with your real build if available).
+- `scripts/run_client.ps1` — helper launcher for that folder.
+  - `logs/` — client runtime logs.
+
+### Sharing with Annotators
+- Provide the UNC path to each reviewer folder.
+- Annotators will see only `assignment.db`, `client.exe`, `label_schema.json`, `scripts/`, and `logs/`.
+
+## Importing Submissions
+1. Collect `assignment.db` from reviewers (or let the Admin app pull directly from shared folders).
+2. In Admin → Rounds → Round 1, choose **Import assignment** for each reviewer.
+3. Watch for integrity messages:
+   - *"Text hash mismatch"* indicates the corpus changed; regenerate the round before proceeding.
+   - *"Assignment locked"* means a client is still open; verify and remove stale `.lock` files only after closure.
+
+## Reviewing Disagreements
+1. After imports, open the **Disagreements** tab.
+2. The overlapped unit is intentionally split (Has_phenotype Yes vs No) to demonstrate adjudication.
+3. Review evidence, select final values, and record adjudicator notes if needed.
+
+## Finalizing the Round
+1. Confirm all assignments show **Imported** status.
+2. Resolve every disagreement, then choose **Finalize round**.
+3. Final adjudications are stored in `round_aggregate.db`.
+
+## Exporting Gold Data
+- Use the **Exports** button to generate CSV/JSON outputs.
+- Exports are written to `phenotypes/ph_diabetes/rounds/round_1/reports/exports/`.
+- Share or archive the exports as the project gold standard.

--- a/docs/ANNOTATOR_RUNBOOK.md
+++ b/docs/ANNOTATOR_RUNBOOK.md
@@ -1,0 +1,17 @@
+# Annotator Runbook — Project Toy
+
+> Admins prepare your folder by running `python tools\seed_toy_project.py` (or `scripts\new_toy_project.ps1`).
+
+1. Navigate to your assignment folder on the shared drive:
+   `.../phenotypes/ph_diabetes/rounds/round_1/assignments/<your_id>/`.
+2. Inside the folder, open `scripts` and double-click `run_client.ps1`.
+   - Alternatively, double-click `client.exe` directly.
+3. The client opens with three panes:
+   - **Left**: list of notes/patients (bold = not yet viewed).
+   - **Middle**: note text. Scroll to read the entire document.
+   - **Right**: label form.
+4. Use the **Rules** button to review label definitions at any time.
+5. Highlight text in the middle pane and **right-click** to attach supporting evidence to a label.
+6. Fill in every required field. The **Next** button stays disabled until all required labels are satisfied (or marked N/A where allowed).
+7. Move through each unit until the progress bar hits 100%.
+8. Select **Submit** when complete, then close the app. The assignment database updates in place.

--- a/docs/BUILDING_WINDOWS.md
+++ b/docs/BUILDING_WINDOWS.md
@@ -1,0 +1,37 @@
+# Building Portable Windows Executables
+
+> After cloning, run `python tools\seed_toy_project.py` (or `scripts\new_toy_project.ps1`) to regenerate `demo/Project_Toy/` and placeholders — binaries are not committed to Git.
+
+1. **Prerequisites**
+   - Windows 10 or later
+   - Python 3.11 installed (`py -3.11`)
+2. **Create a virtual environment**
+   ```powershell
+   py -3.11 -m venv .venv
+   ```
+3. **Activate the environment**
+   ```powershell
+   .venv\Scripts\activate
+   ```
+4. **Install dependencies**
+   ```powershell
+   pip install -r requirements.txt
+   ```
+5. **Build AdminApp**
+   ```powershell
+   pyinstaller --noconfirm --clean --name AdminApp --onefile --windowed ^
+     --add-data "Shared;Shared" --add-data "DataAccess;DataAccess" ^
+     AdminApp\main.py
+   ```
+6. **Build ClientApp**
+   ```powershell
+   pyinstaller --noconfirm --clean --name ClientApp --onefile --windowed ^
+     --add-data "Shared;Shared" --add-data "DataAccess;DataAccess" ^
+     ClientApp\main.py
+   ```
+7. **Locate the outputs**
+   - Executables are written to `dist\AdminApp.exe` and `dist\ClientApp.exe`.
+8. **Deploy to reviewers**
+   - Copy `ClientApp.exe` into each assignment folder and rename to `client.exe`.
+   - Share `AdminApp.exe` with the admin team or keep it in `dist/` for the launch scripts.
+   - Re-run `python tools\seed_toy_project.py` after building to refresh placeholder assignments if needed.

--- a/docs/QUICKSTART.txt
+++ b/docs/QUICKSTART.txt
@@ -1,0 +1,17 @@
+WORKED TOY EXAMPLE QUICKSTART
+=============================
+
+1. Download or copy this folder to a shared network location accessible to reviewers.
+   *Example: \\server\share\Project_Toy\*
+2. Unzip the archive if needed.
+3. Hydrate the toy workspace (binaries are not stored in Git):
+   - Double-click `scripts\new_toy_project.ps1`, **or**
+   - Run `python tools\seed_toy_project.py` from a terminal.
+   The script recreates `demo\Project_Toy\`, the reviewer assignments, and placeholder clients.
+4. In the Admin window (opens automatically from the PowerShell script), browse the project to review the seeded round.
+5. For annotation, have each reviewer open their assignment folder under
+   `phenotypes\ph_diabetes\rounds\round_1\assignments\<reviewer_id>\`.
+6. Inside that folder, double-click `scripts\run_client.ps1` (or `client.exe` directly).
+   - The annotator client launches and loads the assignment database.
+7. Annotate all units. The **Next** button remains disabled until every required label is set (or N/A when allowed).
+8. When 100% complete, click **Submit** in the client and close the application.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,8 @@
+# Troubleshooting — VA Share Quick Tips
+
+| Issue | Fix |
+| ----- | --- |
+| **"Next" button stays disabled** | Ensure every required label has a value or N/A (when allowed). | 
+| **"Cannot save" message** | Verify the reviewer has write permissions to the assignment folder; the client caches locally and retries automatically once access is restored. |
+| **"Text hash mismatch" during import** | The corpus changed after assignment creation. Re-run the round generation with the canonical corpus. |
+| **Assignment marked "Locked"** | Confirm no reviewer has the client open. If safe, delete the stale `.lock` file inside the assignment folder. |

--- a/scripts/build_admin.ps1
+++ b/scripts/build_admin.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+
+Push-Location $repoRoot
+try {
+    pyinstaller --noconfirm --clean --name AdminApp --onefile --windowed ^
+        --add-data "Shared;Shared" --add-data "DataAccess;DataAccess" ^
+        AdminApp\main.py
+} finally {
+    Pop-Location
+}

--- a/scripts/build_client.ps1
+++ b/scripts/build_client.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+
+Push-Location $repoRoot
+try {
+    pyinstaller --noconfirm --clean --name ClientApp --onefile --windowed ^
+        --add-data "Shared;Shared" --add-data "DataAccess;DataAccess" ^
+        ClientApp\main.py
+} finally {
+    Pop-Location
+}

--- a/scripts/new_toy_project.ps1
+++ b/scripts/new_toy_project.ps1
@@ -1,0 +1,26 @@
+Param(
+    [string]$ProjectRelative = "demo/Project_Toy"
+)
+
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+$projectPath = Join-Path $repoRoot $ProjectRelative
+
+if (Test-Path $projectPath) {
+    Write-Host "Removing existing project at $projectPath"
+    Remove-Item $projectPath -Recurse -Force
+}
+
+$seedScript = Join-Path $repoRoot "tools\seed_toy_project.py"
+Write-Host "Seeding project via $seedScript"
+python $seedScript --project $ProjectRelative
+
+$adminExe = Join-Path $repoRoot "dist\AdminApp.exe"
+if (Test-Path $adminExe) {
+    $absProject = (Resolve-Path $projectPath).Path
+    Write-Host "Launching AdminApp for $absProject"
+    Start-Process -FilePath $adminExe -ArgumentList "--project `"$absProject`"" -WorkingDirectory (Split-Path $adminExe)
+} else {
+    Write-Warning "AdminApp.exe not found in dist/. Build the executables first."
+}

--- a/scripts/run_admin.ps1
+++ b/scripts/run_admin.ps1
@@ -1,0 +1,16 @@
+Param(
+    [Parameter(Mandatory = $true)]
+    [string]$Project
+)
+
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+$adminExe = Join-Path $repoRoot "dist\AdminApp.exe"
+
+if (-not (Test-Path $adminExe)) {
+    throw "AdminApp.exe not found at $adminExe. Build the binaries before launching."
+}
+
+Write-Host "Launching AdminApp for project path $Project"
+Start-Process -FilePath $adminExe -ArgumentList "--project `"$Project`"" -WorkingDirectory (Split-Path $adminExe)

--- a/scripts/run_client.ps1
+++ b/scripts/run_client.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$assignmentDir = Split-Path -Parent $scriptRoot
+
+$assignmentDb = Join-Path $assignmentDir "assignment.db"
+if (-not (Test-Path $assignmentDb)) {
+    throw "assignment.db not found at $assignmentDb"
+}
+
+$clientExe = Join-Path $assignmentDir "client.exe"
+if (-not (Test-Path $clientExe)) {
+    throw "client.exe not found at $clientExe"
+}
+
+Write-Host "Launching annotator client for $assignmentDb"
+Start-Process -FilePath $clientExe -ArgumentList "`"$assignmentDb`"" -WorkingDirectory $assignmentDir

--- a/tools/seed_toy_project.py
+++ b/tools/seed_toy_project.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python
+"""Seed a fully-populated toy project for demonstrations."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vaannotate.project import (
+    add_labelset,
+    add_phenotype,
+    fetch_labelset,
+    get_connection,
+    init_project,
+    register_reviewer,
+)
+from vaannotate.rounds import RoundBuilder
+from vaannotate.utils import canonical_json, ensure_dir
+
+
+@dataclass
+class Note:
+    doc_id: str
+    patient_icn: str
+    sta3n: str
+    notetype: str
+    date: str
+    text: str
+
+    @property
+    def note_year(self) -> int:
+        return int(self.date.split("-")[0])
+
+
+PATIENTS = [
+    {"patient_icn": "1001", "sta3n": "506"},
+    {"patient_icn": "1002", "sta3n": "515"},
+    {"patient_icn": "1003", "sta3n": "506"},
+]
+
+NOTES: List[Note] = [
+    Note(
+        doc_id="1001_2018_primary",
+        patient_icn="1001",
+        sta3n="506",
+        notetype="PRIMARY CARE NOTE",
+        date="2018-02-14",
+        text="""
+        Patient started metformin. HbA1c 7.9.
+        Lifestyle adjustments discussed and follow up arranged.
+        """,
+    ),
+    Note(
+        doc_id="1001_2020_endo",
+        patient_icn="1001",
+        sta3n="506",
+        notetype="ENDOCRINOLOGY NOTE",
+        date="2020-08-01",
+        text="""
+        Insulin initiated; prior HbA1c 8.2.
+        Patient counseled on self monitoring.
+        """,
+    ),
+    Note(
+        doc_id="1002_2019_primary",
+        patient_icn="1002",
+        sta3n="515",
+        notetype="PRIMARY CARE NOTE",
+        date="2019-04-22",
+        text="""
+        No evidence of diabetes; lifestyle discussed.
+        Annual lab review pending.
+        """,
+    ),
+    Note(
+        doc_id="1002_2021_endo",
+        patient_icn="1002",
+        sta3n="515",
+        notetype="ENDOCRINOLOGY NOTE",
+        date="2021-11-10",
+        text="""
+        Lab today: HBA1C 6.4; continue metformin.
+        No medication changes required.
+        """,
+    ),
+    Note(
+        doc_id="1003_2023_primary",
+        patient_icn="1003",
+        sta3n="506",
+        notetype="PRIMARY CARE NOTE",
+        date="2023-05-19",
+        text="""
+        Patient started metformin. HbA1c 8.1.
+        Nutrition counseling reinforced.
+        """,
+    ),
+    Note(
+        doc_id="1003_2024_endo",
+        patient_icn="1003",
+        sta3n="506",
+        notetype="ENDOCRINOLOGY NOTE",
+        date="2024-01-09",
+        text="""
+        Insulin initiated; prior HbA1c 8.2.
+        Basal dose titrated; follow-up scheduled.
+        """,
+    ),
+]
+
+REVIEWERS = [
+    {"reviewer_id": "r_alex", "name": "Alex Reviewer", "email": "alex@example.test"},
+    {"reviewer_id": "r_blake", "name": "Blake Reviewer", "email": "blake@example.test"},
+]
+
+LABEL_RULES = {
+    "Has_phenotype": (
+        "Mark Yes when the chart shows diabetes (diagnosis, diabetes meds, or A1c ≥ 6.5). "
+        "Select No when diabetes is explicitly ruled out. Choose Unknown when evidence is inconclusive."
+    ),
+    "Evidence_type": (
+        "Check all supporting evidence types when Has_phenotype is Yes. "
+        "Medication = diabetes medications noted; Lab = abnormal HbA1c; Radiology = imaging describing diabetes complications."
+    ),
+    "HbA1c_value": (
+        "Record the most recent HbA1c value mentioned (3.0–20.0). Use decimals exactly as written. "
+        "Leave blank or mark N/A if not provided."
+    ),
+    "Notes": "Add any clarifying comments for adjudication or context.",
+}
+
+ROUND_CONFIG = {
+    "pheno_id": "ph_diabetes",
+    "labelset_id": "ls_diabetes_v1",
+    "round_number": 1,
+    "round_id": "ph_diabetes_r1",
+    "created_by": "toy_seed",
+    "filters": {
+        "patient": {
+            "year_range": [2018, 2024],
+            "sta3n_in": ["506", "515"],
+        },
+        "note": {
+            "notetype_in": ["PRIMARY CARE NOTE", "ENDOCRINOLOGY NOTE"],
+            "regex": r"(metformin|insulin|hba1c\\s*\\d+(\\.\\d+)?)",
+            "regex_flags": "i",
+        },
+    },
+    "stratification": {
+        "keys": ["note_year"],
+        "sample_per_stratum": 2,
+    },
+    "reviewers": [
+        {"id": "r_alex", "name": "Alex Reviewer"},
+        {"id": "r_blake", "name": "Blake Reviewer"},
+    ],
+    "overlap_n": 1,
+    "independent": True,
+    "rng_seed": 133742,
+}
+
+
+def normalize_text(text: str) -> str:
+    """Return normalized text for hashing and storage."""
+    stripped = "\n".join(line.strip() for line in text.strip().splitlines())
+    return stripped
+
+
+def compute_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def seed_corpus(corpus_db: Path, notes: Sequence[Note]) -> None:
+    with get_connection(corpus_db) as conn:
+        for patient in PATIENTS:
+            conn.execute(
+                "INSERT OR REPLACE INTO patients(patient_icn, sta3n, date_index, softlabel) VALUES (?,?,?,?)",
+                (patient["patient_icn"], patient["sta3n"], None, None),
+            )
+        for note in notes:
+            normalized = normalize_text(note.text)
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO documents(
+                    doc_id, patient_icn, notetype, note_year, date_note,
+                    cptname, sta3n, hash, text
+                ) VALUES (?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    note.doc_id,
+                    note.patient_icn,
+                    note.notetype,
+                    note.note_year,
+                    note.date,
+                    None,
+                    note.sta3n,
+                    compute_hash(normalized),
+                    normalized,
+                ),
+            )
+        conn.commit()
+
+
+def seed_metadata(project_db: Path) -> None:
+    with get_connection(project_db) as conn:
+        for reviewer in REVIEWERS:
+            register_reviewer(conn, **reviewer)
+        add_phenotype(
+            conn,
+            pheno_id="ph_diabetes",
+            project_id="Project_Toy",
+            name="Diabetes Phenotyping",
+            level="multi_doc",
+            description="Toy diabetes phenotype for demonstrations",
+        )
+        add_labelset(
+            conn,
+            labelset_id="ls_diabetes_v1",
+            pheno_id="ph_diabetes",
+            version=1,
+            created_by="toy_seed",
+            notes="Initial diabetes labelset for toy project",
+            labels=[
+                {
+                    "label_id": "Has_phenotype",
+                    "name": "Has phenotype",
+                    "type": "categorical_single",
+                    "required": True,
+                    "order_index": 0,
+                    "rules": LABEL_RULES["Has_phenotype"],
+                    "options": [
+                        {"value": "yes", "display": "Yes"},
+                        {"value": "no", "display": "No"},
+                        {"value": "unknown", "display": "Unknown"},
+                    ],
+                },
+                {
+                    "label_id": "Evidence_type",
+                    "name": "Evidence type",
+                    "type": "categorical_multi",
+                    "required": False,
+                    "order_index": 1,
+                    "rules": LABEL_RULES["Evidence_type"],
+                    "gating_expr": "Has_phenotype == 'yes'",
+                    "options": [
+                        {"value": "Medication", "display": "Medication"},
+                        {"value": "Lab", "display": "Lab"},
+                        {"value": "Radiology", "display": "Radiology"},
+                    ],
+                },
+                {
+                    "label_id": "HbA1c_value",
+                    "name": "HbA1c value",
+                    "type": "float",
+                    "required": False,
+                    "order_index": 2,
+                    "rules": LABEL_RULES["HbA1c_value"],
+                    "min": 3.0,
+                    "max": 20.0,
+                    "na_allowed": True,
+                    "unit": None,
+                },
+                {
+                    "label_id": "Notes",
+                    "name": "Notes",
+                    "type": "text",
+                    "required": False,
+                    "order_index": 3,
+                    "rules": LABEL_RULES["Notes"],
+                    "na_allowed": False,
+                },
+            ],
+        )
+        conn.commit()
+
+
+def write_label_schema(project_db: Path, assignment_dir: Path, labelset_id: str) -> None:
+    labelset = None
+    with get_connection(project_db) as conn:
+        labelset = fetch_labelset(conn, labelset_id)
+    schema_labels: List[Dict[str, object]] = []
+    for label in labelset["labels"]:
+        schema_labels.append(
+            {
+                "label_id": label["label_id"],
+                "name": label["name"],
+                "type": label["type"],
+                "required": bool(label["required"]),
+                "na_allowed": bool(label.get("na_allowed")),
+                "rules": label.get("rules"),
+                "unit": label.get("unit"),
+                "range": {"min": label.get("min"), "max": label.get("max")},
+                "gating_expr": label.get("gating_expr"),
+                "options": [
+                    {
+                        "value": option["value"],
+                        "display": option["display"],
+                        "order_index": option.get("order_index", idx),
+                        "weight": option.get("weight"),
+                    }
+                    for idx, option in enumerate(label.get("options", []))
+                ],
+            }
+        )
+    payload = {"labelset_id": labelset_id, "labels": schema_labels}
+    (assignment_dir / "label_schema.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def augment_assignment_db(
+    assignment_path: Path,
+    patient_docs: Dict[str, List[sqlite3.Row]],
+) -> None:
+    with sqlite3.connect(assignment_path) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS documents (doc_id TEXT PRIMARY KEY, hash TEXT NOT NULL, text TEXT NOT NULL)"
+        )
+        units = conn.execute("SELECT unit_id, patient_icn FROM units").fetchall()
+        for unit_id, patient_icn in units:
+            docs = patient_docs.get(patient_icn)
+            if not docs:
+                continue
+            conn.execute("DELETE FROM unit_notes WHERE unit_id=?", (unit_id,))
+            for order_index, doc_row in enumerate(docs):
+                conn.execute(
+                    "INSERT OR REPLACE INTO unit_notes(unit_id, doc_id, order_index) VALUES (?,?,?)",
+                    (unit_id, doc_row["doc_id"], order_index),
+                )
+                conn.execute(
+                    "INSERT OR REPLACE INTO documents(doc_id, hash, text) VALUES (?,?,?)",
+                    (doc_row["doc_id"], doc_row["hash"], doc_row["text"]),
+                )
+        conn.commit()
+
+
+def copy_client_binary(repo_root: Path, assignment_dir: Path) -> None:
+    source = repo_root / "dist" / "ClientApp.exe"
+    ensure_dir(source.parent)
+    if not source.exists():
+        source.write_text("ClientApp placeholder\n", encoding="utf-8")
+    shutil.copy2(source, assignment_dir / "client.exe")
+
+
+def copy_client_script(repo_root: Path, assignment_dir: Path) -> None:
+    script_source = repo_root / "scripts" / "run_client.ps1"
+    if script_source.exists():
+        scripts_dir = ensure_dir(assignment_dir / "scripts")
+        shutil.copy2(script_source, scripts_dir / "run_client.ps1")
+
+
+def seed_disagreement(assignment_path: Path, unit_id: str, reviewer: str) -> None:
+    value_map = {
+        "r_alex": {"Has_phenotype": "yes", "Evidence_type": "Medication,Lab", "HbA1c_value": ("7.9", 7.9)},
+        "r_blake": {"Has_phenotype": "no"},
+    }
+    payload = value_map.get(reviewer)
+    if not payload:
+        return
+    with sqlite3.connect(assignment_path) as conn:
+        if "Has_phenotype" in payload:
+            conn.execute(
+                "UPDATE annotations SET value=? WHERE unit_id=? AND label_id='Has_phenotype'",
+                (payload["Has_phenotype"], unit_id),
+            )
+        if reviewer == "r_alex":
+            conn.execute(
+                "UPDATE annotations SET value=? WHERE unit_id=? AND label_id='Evidence_type'",
+                (payload["Evidence_type"], unit_id),
+            )
+            conn.execute(
+                "UPDATE annotations SET value=?, value_num=? WHERE unit_id=? AND label_id='HbA1c_value'",
+                (payload["HbA1c_value"][0], payload["HbA1c_value"][1], unit_id),
+            )
+            conn.execute(
+                "UPDATE annotations SET value=? WHERE unit_id=? AND label_id='Notes'",
+                ("Metformin start with elevated A1c.", unit_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE annotations SET value=NULL, value_num=NULL WHERE unit_id=? AND label_id='HbA1c_value'",
+                (unit_id,),
+            )
+            conn.execute(
+                "UPDATE annotations SET value=NULL WHERE unit_id=? AND label_id='Evidence_type'",
+                (unit_id,),
+            )
+        conn.commit()
+
+
+def load_patient_docs(corpus_db: Path) -> Dict[str, List[sqlite3.Row]]:
+    mapping: Dict[str, List[sqlite3.Row]] = {}
+    with get_connection(corpus_db) as conn:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(
+            "SELECT doc_id, patient_icn, hash, text, date_note FROM documents ORDER BY patient_icn, date_note"
+        )
+        for row in cursor:
+            mapping.setdefault(row["patient_icn"], []).append(row)
+    return mapping
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed the demo toy project")
+    parser.add_argument("--project", default="demo/Project_Toy", help="Relative path to project root")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    project_root = (repo_root / args.project).resolve()
+    if project_root.exists():
+        shutil.rmtree(project_root)
+
+    paths = init_project(project_root, "Project_Toy", "Project Toy", "toy_seed")
+    seed_corpus(paths.corpus_db, NOTES)
+    seed_metadata(paths.project_db)
+
+    pheno_dir = ensure_dir(project_root / "phenotypes" / ROUND_CONFIG["pheno_id"])
+    ensure_dir(pheno_dir / "rounds")
+
+    config_path = ensure_dir(project_root / "config" ) / "round_1_config.json"
+    config_path.write_text(canonical_json(ROUND_CONFIG), encoding="utf-8")
+
+    builder = RoundBuilder(project_root)
+    builder.generate_round(ROUND_CONFIG["pheno_id"], config_path, created_by="toy_seed")
+
+    patient_docs = load_patient_docs(paths.corpus_db)
+    round_dir = project_root / "phenotypes" / ROUND_CONFIG["pheno_id"] / "rounds" / "round_1"
+
+    overlap_unit_id = None
+    manifest_path = round_dir / "manifest.csv"
+    if manifest_path.exists():
+        with manifest_path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                if row.get("is_overlap") == "1":
+                    overlap_unit_id = row["unit_id"]
+                    break
+
+    for reviewer in ROUND_CONFIG["reviewers"]:
+        assign_dir = round_dir / "assignments" / reviewer["id"]
+        assignment_db = assign_dir / "assignment.db"
+        augment_assignment_db(assignment_db, patient_docs)
+        write_label_schema(paths.project_db, assign_dir, ROUND_CONFIG["labelset_id"])
+        copy_client_binary(repo_root, assign_dir)
+        copy_client_script(repo_root, assign_dir)
+        if overlap_unit_id:
+            seed_disagreement(assignment_db, overlap_unit_id, reviewer["id"])
+
+    print(f"Seeded toy project at {project_root}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove the pre-generated demo workspace and placeholder executables from version control and ignore the regenerated artifacts
- keep copy_client_binary resilient so it recreates a text placeholder client when the real executable is absent
- update the quickstart and runbooks to tell users to run the seeding script or PowerShell helper to hydrate the toy project after cloning

## Testing
- PYTHONDONTWRITEBYTECODE=1 python tools/seed_toy_project.py

------
https://chatgpt.com/codex/tasks/task_e_68ddafbbf76c8327a037b1c0a329680f