### PR TITLE
Enhance IAA workflows, client note browsing, and Conda docs

### DIFF
--- a/docs/ADMIN_RUNBOOK.md
+++ b/docs/ADMIN_RUNBOOK.md
@@ -3,7 +3,7 @@
 ## Hydrate the Toy Workspace
 > The demo workspace and executables are generated on demand (no binaries are tracked in Git).
 
-1. From the repo root, run `python tools\seed_toy_project.py`, **or** double-click `scripts\new_toy_project.ps1` from Windows.
+1. From an activated Conda prompt in the repo root, run `python tools\seed_toy_project.py` to regenerate the workspace.
 2. The script rebuilds `demo/Project_Toy/`, creates reviewer assignments, and places placeholder clients into each assignment folder.
 3. When you build real executables, copy them into `dist/` before sharing the project.
 
@@ -12,20 +12,25 @@
 - `project.db` — metadata database (phenotypes, reviewers, rounds).
 - `phenotypes/ph_diabetes/rounds/round_1/` — Round 1 workspace with manifests, assignments, reports.
 - `reports/` — export targets (`reports/exports/` holds gold data after finalization).
-- `scripts/` — helper PowerShell launchers (keep with the project).
+- `scripts/` — optional helper launchers (not required when running from Conda).
 - `dist/` — locally built Admin and Client executables.
 
 > **Do not** move or rename `project.db`, `corpus/`, or anything inside `phenotypes/` once assignments are distributed.
 
 ## Launching the Admin App
-1. From Windows, open PowerShell.
-2. Run `scripts\run_admin.ps1 -Project \\server\share\Project_Toy`.
-   - Alternatively, launch directly via `dist\AdminApp.exe --project \\server\share\Project_Toy` (after building the executable locally).
-3. The Admin application opens against the provided UNC project path.
+1. Open an Anaconda Prompt and activate the environment used for VAAnnotate:
+   ```
+   conda activate vaannotate
+   ```
+2. Launch the Admin client:
+   ```
+   python -m vaannotate.AdminApp.main
+   ```
+3. Use **File → Open project folder…** to point the application at `\\server\share\Project_Toy`.
 
 ## Target Corpus Summary
-- Navigate to the **Corpus** or **Phenotypes** tabs to review seeded patients (ICNs 1001–1003).
-- Notes span 2018–2024 with mixed STA3Ns (506, 515).
+- Navigate to the **Corpus** or **Phenotypes** tabs to review seeded patients (ICNs 2001–2010).
+- Notes span 2015–2024 with mixed STA3Ns (506, 515) and now include 100 long-form entries.
 
 ## Round Wizard Walkthrough
 - Open **Rounds → ph_diabetes → Round 1**.
@@ -42,7 +47,7 @@
 - `assignment.db` — SQLite assignment package.
 - `label_schema.json` — label metadata for the client.
 - `client.exe` — placeholder annotator app (regenerated from `dist/ClientApp.exe`; replace with your real build if available).
-- `scripts/run_client.ps1` — helper launcher for that folder.
+- `scripts/run_client.ps1` — optional launcher; not required when using Conda commands.
   - `logs/` — client runtime logs.
 
 ### Sharing with Annotators

--- a/docs/ANNOTATOR_RUNBOOK.md
+++ b/docs/ANNOTATOR_RUNBOOK.md
@@ -1,11 +1,12 @@
 # Annotator Runbook — Project Toy
 
-> Admins prepare your folder by running `python tools\seed_toy_project.py` (or `scripts\new_toy_project.ps1`).
+> Admins prepare your folder by running `python tools\seed_toy_project.py` from an activated Conda prompt.
 
 1. Navigate to your assignment folder on the shared drive:
    `.../phenotypes/ph_diabetes/rounds/round_1/assignments/<your_id>/`.
-2. Inside the folder, open `scripts` and double-click `run_client.ps1`.
-   - Alternatively, double-click `client.exe` directly.
+2. Open an Anaconda Prompt, activate the environment with `conda activate vaannotate`,
+   change into your assignment folder, and run `python -m vaannotate.ClientApp.main`.
+   - Alternatively, double-click `client.exe` if a standalone build is provided.
 3. The client opens with three panes:
    - **Left**: list of notes/patients (bold = not yet viewed).
    - **Middle**: note text. Scroll to read the entire document.

--- a/docs/BUILDING_WINDOWS.md
+++ b/docs/BUILDING_WINDOWS.md
@@ -1,33 +1,32 @@
 # Building Portable Windows Executables
 
-> After cloning, run `python tools\seed_toy_project.py` (or `scripts\new_toy_project.ps1`) to regenerate `demo/Project_Toy/` and placeholders — binaries are not committed to Git.
+> After cloning, run `python tools\seed_toy_project.py` from an activated Conda prompt to regenerate `demo/Project_Toy/` and placeholders — binaries are not committed to Git.
 
 1. **Prerequisites**
    - Windows 10 or later
-   - Python 3.11 installed (`py -3.11`)
-2. **Create a virtual environment**
-   ```powershell
-   py -3.11 -m venv .venv
+   - Anaconda or Miniconda with Python 3.11 available
+2. **Create a Conda environment**
+   ```
+   conda create -n vaannotate python=3.11
    ```
 3. **Activate the environment**
-   ```powershell
-   .venv\Scripts\activate
+   ```
+   conda activate vaannotate
    ```
 4. **Install dependencies**
-   ```powershell
+   ```
    pip install -r requirements.txt
+   pip install pyinstaller
    ```
 5. **Build AdminApp**
-   ```powershell
-   pyinstaller --noconfirm --clean --name AdminApp --onefile --windowed ^
-     --add-data "Shared;Shared" --add-data "DataAccess;DataAccess" ^
-     AdminApp\main.py
+   ```
+   pyinstaller --noconfirm --clean --name AdminApp --onefile --windowed \
+     vaannotate/AdminApp/main.py
    ```
 6. **Build ClientApp**
-   ```powershell
-   pyinstaller --noconfirm --clean --name ClientApp --onefile --windowed ^
-     --add-data "Shared;Shared" --add-data "DataAccess;DataAccess" ^
-     ClientApp\main.py
+   ```
+   pyinstaller --noconfirm --clean --name ClientApp --onefile --windowed \
+     vaannotate/ClientApp/main.py
    ```
 7. **Locate the outputs**
    - Executables are written to `dist\AdminApp.exe` and `dist\ClientApp.exe`.

--- a/docs/PROJECT_WALKTHROUGH.md
+++ b/docs/PROJECT_WALKTHROUGH.md
@@ -20,44 +20,50 @@ needing to write code.
      reports\
      scripts\
    ```
-4. Copy the PowerShell helper scripts from the repository (`scripts\*.ps1`) into
-   the new `scripts\` folder so that team members can launch the tools without
-   opening a terminal.
+4. Keep a copy of the repository's `scripts/` folder in the workspace if you
+   still distribute Windows shortcuts, but the steps below assume you will run
+   the tooling from an activated Conda prompt.
 
 ## 2. Build the Admin and Client executables
 
 If you already have fresh copies of `AdminApp.exe` and `ClientApp.exe`, you can
 skip this section. Otherwise:
 
-1. On a Windows workstation with Python 3.11 installed, open PowerShell in the
-   repository root.
-2. Create and activate a virtual environment:
-   ```powershell
-   py -3.11 -m venv .venv
-   .venv\Scripts\activate
+1. On a workstation with Conda (Anaconda or Miniconda) installed, open an
+   **Anaconda Prompt** in the repository root.
+2. Create the environment (run once):
    ```
-3. Install the dependencies:
-   ```powershell
+   conda create -n vaannotate python=3.11
+   ```
+3. Activate the environment and install dependencies:
+   ```
+   conda activate vaannotate
    pip install -r requirements.txt
+   pip install pyinstaller
    ```
-4. Build the Admin executable:
-   ```powershell
-   scripts\build_admin.ps1
+4. Build the Admin executable from the activated environment:
+   ```
+   pyinstaller --noconfirm --clean --name AdminApp --onefile --windowed \
+     vaannotate/AdminApp/main.py
    ```
 5. Build the Client executable:
-   ```powershell
-   scripts\build_client.ps1
    ```
-6. After both commands succeed you will have `dist\AdminApp.exe` and
-   `dist\ClientApp.exe`. Copy these two files into the `dist\` folder you created
+   pyinstaller --noconfirm --clean --name ClientApp --onefile --windowed \
+     vaannotate/ClientApp/main.py
+   ```
+6. After both commands succeed you will have `dist/AdminApp.exe` and
+   `dist/ClientApp.exe`. Copy these two files into the `dist/` folder you created
    inside the project workspace.
 
 ## 3. Launch the Admin app against the new project folder
 
-1. From Windows Explorer, right-click the new `scripts\run_admin.ps1` inside the
-   project folder and choose **Run with PowerShell**. When prompted, supply the
-   UNC path to the project root (for example,
-   `\\\\research-fs01\\Projects\\PH_HeartFailure`).
+1. From the activated Conda prompt, launch the Admin application:
+   ```
+   conda activate vaannotate
+   python -m vaannotate.AdminApp.main
+   ```
+   Use **File → Open project folder…** to browse to the UNC path for the new
+   project (for example, `\\\\research-fs01\\Projects\\PH_HeartFailure`).
 2. On first launch the Admin application will create the SQLite databases:
    - `project.db` at the project root for metadata
    - `corpus\corpus.db` for patient notes
@@ -69,8 +75,9 @@ skip this section. Otherwise:
 
 1. Prepare two CSV files: `patients.csv` (patient ICNs and STA3Ns) and
    `documents.csv` (one row per note, including the full text).
-2. In PowerShell run the import helper, replacing the paths with your files:
-   ```powershell
+2. In the activated Conda prompt run the import helper, replacing the paths with
+   your files:
+   ```
    python -m vaannotate.admin_cli import-corpus \
      "\\research-fs01\Projects\PH_HeartFailure" \
      --patients-csv "C:\Data\patients.csv" \
@@ -93,10 +100,11 @@ skip this section. Otherwise:
 ## 6. Next steps (optional)
 
 - Use the **Rounds** tab to configure reviewers, sampling, and manifests.
-- Copy `dist\ClientApp.exe` into each reviewer assignment folder once rounds are
+- Copy `dist/ClientApp.exe` into each reviewer assignment folder once rounds are
   generated (rename the copy to `client.exe` for convenience).
 - Share the project folder path with the team. Annotators only need their
-  assignment subfolder; admins launch the project via `scripts\run_admin.ps1`.
+  assignment subfolder; admins launch the project from an activated Conda prompt
+  with `python -m vaannotate.AdminApp.main`.
 
 Following the checklist above gets you from an empty network folder to a fully
 initialized VAAnnotate project with at least one phenotype ready for round

--- a/docs/QUICKSTART.txt
+++ b/docs/QUICKSTART.txt
@@ -5,13 +5,15 @@ WORKED TOY EXAMPLE QUICKSTART
    *Example: \\server\share\Project_Toy\*
 2. Unzip the archive if needed.
 3. Hydrate the toy workspace (binaries are not stored in Git):
-   - Double-click `scripts\new_toy_project.ps1`, **or**
-   - Run `python tools\seed_toy_project.py` from a terminal.
+   - Open an Anaconda Prompt, run `conda activate vaannotate`, then execute
+     `python tools\seed_toy_project.py` from the repository root.
    The script recreates `demo\Project_Toy\`, the reviewer assignments, and placeholder clients.
-4. In the Admin window (opens automatically from the PowerShell script), browse the project to review the seeded round.
+4. Launch the Admin app from the same Conda prompt with `python -m vaannotate.AdminApp.main`, then
+   use **File → Open project folder…** to browse to the toy project and review the seeded round.
 5. For annotation, have each reviewer open their assignment folder under
    `phenotypes\ph_diabetes\rounds\round_1\assignments\<reviewer_id>\`.
-6. Inside that folder, double-click `scripts\run_client.ps1` (or `client.exe` directly).
+6. Inside that folder, either run `python -m vaannotate.ClientApp.main` from an activated
+   Conda prompt or double-click `client.exe` if you built the standalone binary.
    - The annotator client launches and loads the assignment database.
 7. Annotate all units. The **Next** button remains disabled until every required label is set (or N/A when allowed).
 8. When 100% complete, click **Submit** in the client and close the application.

--- a/tools/seed_toy_project.py
+++ b/tools/seed_toy_project.py
@@ -44,80 +44,56 @@ class Note:
         return int(self.date.split("-")[0])
 
 
-PATIENTS = [
-    {"patient_icn": "1001", "sta3n": "506"},
-    {"patient_icn": "1002", "sta3n": "515"},
-    {"patient_icn": "1003", "sta3n": "506"},
+PATIENTS: List[Dict[str, str]] = [
+    {"patient_icn": f"20{index:02d}", "sta3n": "506" if index % 2 else "515"}
+    for index in range(1, 11)
 ]
 
-NOTES: List[Note] = [
-    Note(
-        doc_id="1001_2018_primary",
-        patient_icn="1001",
-        sta3n="506",
-        notetype="PRIMARY CARE NOTE",
-        date="2018-02-14",
-        text="""
-        Patient started metformin. HbA1c 7.9.
-        Lifestyle adjustments discussed and follow up arranged.
-        """,
-    ),
-    Note(
-        doc_id="1001_2020_endo",
-        patient_icn="1001",
-        sta3n="506",
-        notetype="ENDOCRINOLOGY NOTE",
-        date="2020-08-01",
-        text="""
-        Insulin initiated; prior HbA1c 8.2.
-        Patient counseled on self monitoring.
-        """,
-    ),
-    Note(
-        doc_id="1002_2019_primary",
-        patient_icn="1002",
-        sta3n="515",
-        notetype="PRIMARY CARE NOTE",
-        date="2019-04-22",
-        text="""
-        No evidence of diabetes; lifestyle discussed.
-        Annual lab review pending.
-        """,
-    ),
-    Note(
-        doc_id="1002_2021_endo",
-        patient_icn="1002",
-        sta3n="515",
-        notetype="ENDOCRINOLOGY NOTE",
-        date="2021-11-10",
-        text="""
-        Lab today: HBA1C 6.4; continue metformin.
-        No medication changes required.
-        """,
-    ),
-    Note(
-        doc_id="1003_2023_primary",
-        patient_icn="1003",
-        sta3n="506",
-        notetype="PRIMARY CARE NOTE",
-        date="2023-05-19",
-        text="""
-        Patient started metformin. HbA1c 8.1.
-        Nutrition counseling reinforced.
-        """,
-    ),
-    Note(
-        doc_id="1003_2024_endo",
-        patient_icn="1003",
-        sta3n="506",
-        notetype="ENDOCRINOLOGY NOTE",
-        date="2024-01-09",
-        text="""
-        Insulin initiated; prior HbA1c 8.2.
-        Basal dose titrated; follow-up scheduled.
-        """,
-    ),
+NOTE_THEMES = [
+    ("PRIMARY CARE NOTE", "Primary care follow-up summarizing comprehensive chronic disease management."),
+    ("ENDOCRINOLOGY NOTE", "Endocrinology consultation focused on medication titration and long-term planning."),
+    ("PHARMACY NOTE", "Pharmacy medication therapy management review concentrating on adherence and refills."),
+    ("NUTRITION NOTE", "Nutrition counseling session highlighting meal planning and lifestyle reinforcement."),
+    ("TELEHEALTH NOTE", "Telehealth touchpoint documenting remote symptom monitoring and coaching."),
 ]
+
+
+def generate_notes(patients: Sequence[Dict[str, str]], total_notes: int) -> List[Note]:
+    notes: List[Note] = []
+    theme_count = len(NOTE_THEMES)
+    for index in range(total_notes):
+        patient = patients[index % len(patients)]
+        notetype, theme = NOTE_THEMES[index % theme_count]
+        year = 2015 + (index % 10)
+        month = (index % 12) + 1
+        day = (index % 28) + 1
+        date = f"{year}-{month:02d}-{day:02d}"
+        doc_id = f"{patient['patient_icn']}_{date.replace('-', '')}_{index:03d}"
+        paragraphs = [
+            f"{theme} Visit date {date} at facility {patient['sta3n']}. Clinicians reviewed vitals, symptoms, and chart history while confirming medication reconciliation for patient {patient['patient_icn']}.",
+            (
+                "Medication adjustments included refreshed metformin guidance, individualized insulin teaching, and"
+                f" reinforcement of home glucose monitoring. Documented HbA1c trend measured {6.4 + (index % 9) * 0.2:.1f}"
+                " with comparison to prior labs to demonstrate progress."
+            ),
+            "Care planning emphasized social support, nutrition, and physical activity goals. The note records resources offered for transportation, pharmacy follow-up, and nursing outreach to close care gaps.",
+            "Structured assessment captured review of systems, motivational interviewing highlights, and next steps for laboratory surveillance with clear thresholds for escalation.",
+        ]
+        text = "\n\n".join(paragraphs)
+        notes.append(
+            Note(
+                doc_id=doc_id,
+                patient_icn=patient["patient_icn"],
+                sta3n=patient["sta3n"],
+                notetype=notetype,
+                date=date,
+                text=text,
+            )
+        )
+    return notes
+
+
+NOTES: List[Note] = generate_notes(PATIENTS, 100)
 
 REVIEWERS = [
     {"reviewer_id": "r_alex", "name": "Alex Reviewer", "email": "alex@example.test"},


### PR DESCRIPTION
## Summary
- update the project walkthrough, runbooks, and build guide to describe Conda-based setup and launch steps instead of PowerShell scripts
- split the client note view into a sortable notes table and detailed viewer while preserving highlight support per document
- extend the admin IAA tab with phenotype/round overviews, configurable metrics, and discordant note review tooling
- expand the toy data seeding script to generate 100 longer notes across additional patients

## Testing
- python -m compileall vaannotate

------
https://chatgpt.com/codex/tasks/task_e_68dddd353b8c8327ba2545aa37bb5f79