### PR TITLE
Refactor admin UI for phenotype-specific corpora

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ pip install -e .
    ```
    Choose or create a project directory. The Admin dashboard exposes project management, phenotype creation, round generation, and agreement metric dashboards.
 
-2. **Stage a corpus** by placing a `corpus.db` file in the project's `/corpus` folder or by using future ingestion tooling. The Admin UI automatically creates the SQLite schema on first open.
+2. **Stage phenotype corpora**. When a phenotype is created in the Admin UI you will be prompted to select the SQLite database that represents its corpus; the tool copies that file into `phenotypes/<pheno_id>/corpus/corpus.db` and keeps it immutable for that phenotype. Reuse a source corpus or prepare new ones per phenotype as needed. You can also generate the corpus ahead of time with the CLI, for example:
+   ```bash
+   python -m vaannotate.admin_cli import-corpus ./MyProject \
+     --patients-csv ./data/patients.csv \
+     --documents-csv ./data/documents.csv \
+     --corpus-db phenotypes/ph_example/corpus/source.db
+   ```
 
 3. **Create phenotypes and label sets** from the Phenotypes tab. Label sets are versioned; newly generated rounds can auto-provision a starter boolean label if a label set is absent.
 

--- a/docs/ADMIN_RUNBOOK.md
+++ b/docs/ADMIN_RUNBOOK.md
@@ -8,14 +8,14 @@
 3. When you build real executables, copy them into `dist/` before sharing the project.
 
 ## Overview of Folder Layout
-- `corpus/` — canonical patient/document SQLite database (**do not edit directly**).
+- `phenotypes/<pheno_id>/corpus/` — phenotype-specific corpus database copied from the source you selected in the Admin UI (**do not edit directly**).
 - `project.db` — metadata database (phenotypes, reviewers, rounds).
 - `phenotypes/ph_diabetes/rounds/round_1/` — Round 1 workspace with manifests, assignments, reports.
 - `reports/` — export targets (`reports/exports/` holds gold data after finalization).
 - `scripts/` — optional helper launchers (not required when running from Conda).
 - `dist/` — locally built Admin and Client executables.
 
-> **Do not** move or rename `project.db`, `corpus/`, or anything inside `phenotypes/` once assignments are distributed.
+> **Do not** move or rename `project.db` or anything inside `phenotypes/` once assignments are distributed.
 
 ## Launching the Admin App
 1. Open an Anaconda Prompt and activate the environment used for VAAnnotate:
@@ -29,11 +29,11 @@
 3. Use **File → Open project folder…** to point the application at `\\server\share\Project_Toy`.
 
 ## Target Corpus Summary
-- Navigate to the **Corpus** or **Phenotypes** tabs to review seeded patients (ICNs 2001–2010).
+- Select a phenotype’s **Corpus** node in the project tree to review seeded patients (ICNs 2001–2010).
 - Notes span 2015–2024 with mixed STA3Ns (506, 515) and now include 100 long-form entries.
 
 ## Round Wizard Walkthrough
-- Open **Rounds → ph_diabetes → Round 1**.
+- In the project tree expand **ph_diabetes** and select **Round 1**.
 - Review stored configuration (`round_config.json`) showing:
   - Patient filters: years 2018–2024, STA3Ns 506/515.
   - Note filters: PRIMARY CARE and ENDOCRINOLOGY notes matching `(metformin|insulin|hba1c\s*\d+(\.\d+)?)` (case-insensitive).
@@ -56,13 +56,13 @@
 
 ## Importing Submissions
 1. Collect `assignment.db` from reviewers (or let the Admin app pull directly from shared folders).
-2. In Admin → Rounds → Round 1, choose **Import assignment** for each reviewer.
+2. Select **Round 1** in the project tree and use the import controls to ingest each reviewer.
 3. Watch for integrity messages:
    - *"Text hash mismatch"* indicates the corpus changed; regenerate the round before proceeding.
    - *"Assignment locked"* means a client is still open; verify and remove stale `.lock` files only after closure.
 
 ## Reviewing Disagreements
-1. After imports, open the **Disagreements** tab.
+1. After imports, select the phenotype’s **IAA** node.
 2. The overlapped unit is intentionally split (Has_phenotype Yes vs No) to demonstrate adjudication.
 3. Review evidence, select final values, and record adjudicator notes if needed.
 

--- a/docs/PROJECT_WALKTHROUGH.md
+++ b/docs/PROJECT_WALKTHROUGH.md
@@ -64,12 +64,13 @@ skip this section. Otherwise:
    ```
    Use **File → Open project folder…** to browse to the UNC path for the new
    project (for example, `\\\\research-fs01\\Projects\\PH_HeartFailure`).
-2. On first launch the Admin application will create the SQLite databases:
-   - `project.db` at the project root for metadata
-   - `corpus\corpus.db` for patient notes
-3. The window will open on the **Projects** tab. Fill in a friendly project name
-   and the “Created by” field, then click **Create Project**. The record appears
-   immediately in the list on the left.
+2. On first launch the Admin application will ensure the project metadata
+   database (`project.db`) exists. Corpora are now tracked per phenotype and are
+   stored within `phenotypes/<pheno_id>/corpus/corpus.db` once you assign one to
+   a phenotype.
+3. The window opens with a project tree on the left and detail views on the
+   right. The top-level node represents the project; right-click it at any time
+   to add new phenotypes.
 
 ## 4. Load or create the corpus
 
@@ -81,25 +82,30 @@ skip this section. Otherwise:
    python -m vaannotate.admin_cli import-corpus \
      "\\research-fs01\Projects\PH_HeartFailure" \
      --patients-csv "C:\Data\patients.csv" \
-     --documents-csv "C:\Data\documents.csv"
-   ```
-3. Return to the Admin app and switch to the **Corpus** tab. You should now see
-   the document counts and a top-50 preview confirming the data loaded
-   correctly.
+     --documents-csv "C:\Data\documents.csv" \
+     --corpus-db "phenotypes/ph_diabetes/corpus/source.db"
+  ```
+   The destination can be any path; relative values are resolved against the project
+   folder so you can stage per-phenotype corpora ahead of time.
+3. After the import, add a phenotype and select this corpus when prompted. Once
+   saved, highlight the phenotype’s **Corpus** node in the project tree to see
+   document counts and a top-50 preview confirming the data loaded correctly.
 
 ## 5. Create a phenotype definition
 
-1. Go to the **Phenotypes** tab.
-2. Choose the project you just created from the drop-down menu.
-3. Enter a descriptive phenotype name, pick the level (`single_doc` for
-   individual notes or `multi_doc` for patient-level reviews), and write a brief
-   description for annotators.
-4. Click **Create phenotype**. The phenotype appears in the list on the left and
-   is now ready for round configuration.
+1. In the project tree, right-click the project node and choose **Add phenotype…**.
+2. Enter a descriptive phenotype name, pick the level (`single_doc` for
+   individual notes or `multi_doc` for patient-level reviews), add a short
+   description, and browse to the corpus database that should back this
+   phenotype. The Admin app copies the selected corpus into the phenotype’s
+   folder and locks it in for that phenotype.
+3. Click **OK**. The phenotype appears under the project node along with child
+   items for the corpus, rounds, and the IAA dashboard.
 
 ## 6. Next steps (optional)
 
-- Use the **Rounds** tab to configure reviewers, sampling, and manifests.
+- Right-click a phenotype in the tree and choose **Add round…** to configure
+  reviewers, sampling, and manifests.
 - Copy `dist/ClientApp.exe` into each reviewer assignment folder once rounds are
   generated (rename the copy to `client.exe` for convenience).
 - Share the project folder path with the team. Annotators only need their

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 import csv
 import json
+import re
 import sqlite3
 import sys
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
@@ -21,9 +23,8 @@ from ..shared.sampling import (
     populate_assignment_db,
     write_manifest,
 )
-from ..utils import copy_sqlite_database, ensure_dir
 from ..shared.statistics import cohens_kappa, fleiss_kappa, percent_agreement
-
+from ..utils import copy_sqlite_database, ensure_dir
 
 PROJECT_MODELS = [
     models.Project,
@@ -45,22 +46,30 @@ class ProjectContext(QtCore.QObject):
         super().__init__()
         self.project_root: Optional[Path] = None
         self.project_db: Optional[Database] = None
-        self.corpus_db: Optional[Database] = None
+        self.project_row: Optional[Dict[str, object]] = None
+        self._corpus_cache: Dict[str, Database] = {}
 
     def open_project(self, directory: Path) -> None:
         directory = directory.resolve()
         project_db = Database(directory / "project.db")
         with project_db.transaction() as conn:
             ensure_schema(conn, PROJECT_MODELS)
-        corpus_dir = directory / "corpus"
-        corpus_dir.mkdir(exist_ok=True)
-        corpus_db = Database(corpus_dir / "corpus.db")
-        with corpus_db.transaction() as conn:
-            ensure_schema(conn, [models.Patient, models.Document])
         self.project_root = directory
         self.project_db = project_db
-        self.corpus_db = corpus_db
+        self._corpus_cache.clear()
+        self.project_row = self._load_project_row()
         self.project_changed.emit()
+
+    def _load_project_row(self) -> Optional[Dict[str, object]]:
+        try:
+            db = self.require_db()
+        except RuntimeError:
+            return None
+        with db.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM projects ORDER BY created_at ASC LIMIT 1"
+            ).fetchone()
+        return dict(row) if row else None
 
     def require_project(self) -> Path:
         if not self.project_root:
@@ -72,245 +81,226 @@ class ProjectContext(QtCore.QObject):
             raise RuntimeError("Project database not initialized")
         return self.project_db
 
-    def require_corpus_db(self) -> Database:
-        if not self.corpus_db:
-            raise RuntimeError("Corpus database not initialized")
-        return self.corpus_db
+    def reload(self) -> None:
+        self.project_row = self._load_project_row()
+        self._corpus_cache.clear()
+        self.project_changed.emit()
 
+    def current_project_id(self) -> Optional[str]:
+        if not self.project_row:
+            self.project_row = self._load_project_row()
+        if not self.project_row:
+            return None
+        return str(self.project_row.get("project_id"))
 
-class ProjectsPage(QtWidgets.QWidget):
-    def __init__(self, ctx: ProjectContext) -> None:
-        super().__init__()
-        self.ctx = ctx
-        self._setup_ui()
-        self.ctx.project_changed.connect(self.refresh)
-
-    def _setup_ui(self) -> None:
-        layout = QtWidgets.QVBoxLayout(self)
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
-        layout.addWidget(splitter)
-
-        self.project_list = QtWidgets.QListWidget()
-        self.project_list.currentItemChanged.connect(self._on_project_selected)
-        splitter.addWidget(self.project_list)
-
-        detail_widget = QtWidgets.QWidget()
-        splitter.addWidget(detail_widget)
-        form = QtWidgets.QFormLayout(detail_widget)
-
-        self.name_edit = QtWidgets.QLineEdit()
-        self.created_by_edit = QtWidgets.QLineEdit()
-        self.create_btn = QtWidgets.QPushButton("Create Project")
-        self.create_btn.clicked.connect(self._create_project)
-
-        form.addRow("Project name", self.name_edit)
-        form.addRow("Created by", self.created_by_edit)
-        form.addRow(self.create_btn)
-
-        self.meta_view = QtWidgets.QTextEdit()
-        self.meta_view.setReadOnly(True)
-        form.addRow("Details", self.meta_view)
-
-        splitter.setStretchFactor(0, 2)
-        splitter.setStretchFactor(1, 3)
-
-    def refresh(self) -> None:
-        self.project_list.clear()
-        try:
-            db = self.ctx.require_db()
-        except RuntimeError:
-            return
+    def list_phenotypes(self) -> List[sqlite3.Row]:
+        db = self.require_db()
+        params: List[object] = []
+        sql = "SELECT * FROM phenotypes"
+        project_id = self.current_project_id()
+        if project_id:
+            sql += " WHERE project_id=?"
+            params.append(project_id)
+        sql += " ORDER BY name"
         with db.connect() as conn:
-            rows = conn.execute("SELECT * FROM projects ORDER BY created_at DESC").fetchall()
-        for row in rows:
-            item = QtWidgets.QListWidgetItem(f"{row['name']} ({row['project_id']})")
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, row)
-            self.project_list.addItem(item)
+            return conn.execute(sql, params).fetchall()
 
-    def _create_project(self) -> None:
-        if not self.name_edit.text().strip():
-            QtWidgets.QMessageBox.warning(self, "Missing data", "Name is required")
-            return
-        created_by = self.created_by_edit.text().strip() or "unknown"
-        project = models.Project(
-            project_id=str(uuid.uuid4()),
-            name=self.name_edit.text().strip(),
-            created_at=QtCore.QDateTime.currentDateTimeUtc().toString(QtCore.Qt.ISODate),
-            created_by=created_by,
-        )
-        db = self.ctx.require_db()
+    def get_phenotype(self, pheno_id: str) -> Optional[sqlite3.Row]:
+        db = self.require_db()
+        with db.connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM phenotypes WHERE pheno_id=?",
+                (pheno_id,),
+            ).fetchone()
+        return row
+
+    def list_rounds(self, pheno_id: str) -> List[sqlite3.Row]:
+        db = self.require_db()
+        with db.connect() as conn:
+            return conn.execute(
+                "SELECT * FROM rounds WHERE pheno_id=? ORDER BY round_number",
+                (pheno_id,),
+            ).fetchall()
+
+    def get_round(self, round_id: str) -> Optional[sqlite3.Row]:
+        db = self.require_db()
+        with db.connect() as conn:
+            return conn.execute(
+                "SELECT * FROM rounds WHERE round_id=?",
+                (round_id,),
+            ).fetchone()
+
+    def get_round_config(self, round_id: str) -> Optional[Dict[str, object]]:
+        db = self.require_db()
+        with db.connect() as conn:
+            row = conn.execute(
+                "SELECT config_json FROM round_configs WHERE round_id=?",
+                (round_id,),
+            ).fetchone()
+        if not row:
+            return None
+        try:
+            return json.loads(row["config_json"])
+        except json.JSONDecodeError:
+            return None
+
+    def resolve_project_path(self, relative: str) -> Path:
+        root = self.require_project()
+        return (root / relative).resolve()
+
+    def resolve_corpus_path(self, pheno_id: str) -> Path:
+        pheno = self.get_phenotype(pheno_id)
+        if not pheno:
+            raise RuntimeError(f"Phenotype {pheno_id} not found")
+        corpus_path = pheno["corpus_path"]
+        if not corpus_path:
+            raise RuntimeError("Phenotype does not define a corpus")
+        root = self.require_project()
+        return (root / corpus_path).resolve()
+
+    def get_corpus_db(self, pheno_id: str) -> Database:
+        if pheno_id in self._corpus_cache:
+            return self._corpus_cache[pheno_id]
+        path = self.resolve_corpus_path(pheno_id)
+        db = Database(path)
         with db.transaction() as conn:
-            project.save(conn)
-        self.name_edit.clear()
-        self.refresh()
+            ensure_schema(conn, [models.Patient, models.Document])
+        self._corpus_cache[pheno_id] = db
+        return db
 
-    def _on_project_selected(self, current: QtWidgets.QListWidgetItem) -> None:
-        if not current:
-            self.meta_view.clear()
-            return
-        row = current.data(QtCore.Qt.ItemDataRole.UserRole)
-        self.meta_view.setPlainText(json.dumps({k: row[k] for k in row.keys()}, indent=2))
+    def create_phenotype(
+        self,
+        *,
+        name: str,
+        level: str,
+        description: str,
+        corpus_source: Path,
+    ) -> models.Phenotype:
+        project_id = self.current_project_id()
+        if not project_id:
+            raise RuntimeError("Project metadata missing; ensure a project record exists")
+        pheno_id = str(uuid.uuid4())
+        project_root = self.require_project()
+        phenotype_dir = ensure_dir(project_root / "phenotypes" / pheno_id)
+        rounds_dir = ensure_dir(phenotype_dir / "rounds")
+        _ = rounds_dir  # make mypy happy about unused variable
+        corpus_dir = ensure_dir(phenotype_dir / "corpus")
+        target_corpus = corpus_dir / "corpus.db"
+        copy_sqlite_database(corpus_source, target_corpus)
+        relative_corpus = target_corpus.relative_to(project_root)
+        record = models.Phenotype(
+            pheno_id=pheno_id,
+            project_id=project_id,
+            name=name,
+            level=level,
+            description=description,
+            corpus_path=str(relative_corpus.as_posix()),
+        )
+        db = self.require_db()
+        with db.transaction() as conn:
+            record.save(conn)
+        self.project_changed.emit()
+        return record
+
+    def update_cache_after_round(self, pheno_id: str) -> None:
+        # Keep API parity with previous refresh pattern
+        self._corpus_cache.pop(pheno_id, None)
+        self.project_changed.emit()
 
 
-class PhenotypePage(QtWidgets.QWidget):
-    def __init__(self, ctx: ProjectContext) -> None:
-        super().__init__()
+class PhenotypeDialog(QtWidgets.QDialog):
+    def __init__(self, ctx: ProjectContext, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
         self.ctx = ctx
+        self.corpus_path: Optional[Path] = None
+        self.setWindowTitle("Add phenotype")
+        self.resize(400, 300)
         self._setup_ui()
-        self.ctx.project_changed.connect(self.refresh)
 
     def _setup_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
-        layout.addWidget(splitter)
-
-        self.list_widget = QtWidgets.QListWidget()
-        splitter.addWidget(self.list_widget)
-
-        right = QtWidgets.QWidget()
-        splitter.addWidget(right)
-        form = QtWidgets.QFormLayout(right)
-
-        self.project_combo = QtWidgets.QComboBox()
+        form = QtWidgets.QFormLayout()
         self.name_edit = QtWidgets.QLineEdit()
         self.level_combo = QtWidgets.QComboBox()
         self.level_combo.addItems(["single_doc", "multi_doc"])
+        corpus_layout = QtWidgets.QHBoxLayout()
+        self.corpus_edit = QtWidgets.QLineEdit()
+        self.corpus_edit.setReadOnly(True)
+        browse_btn = QtWidgets.QPushButton("Browse…")
+        browse_btn.clicked.connect(self._browse_corpus)
+        corpus_layout.addWidget(self.corpus_edit)
+        corpus_layout.addWidget(browse_btn)
         self.description_edit = QtWidgets.QPlainTextEdit()
-        self.save_btn = QtWidgets.QPushButton("Create phenotype")
-        self.save_btn.clicked.connect(self._create_phenotype)
-
-        form.addRow("Project", self.project_combo)
         form.addRow("Name", self.name_edit)
         form.addRow("Level", self.level_combo)
+        form.addRow("Corpus", corpus_layout)
         form.addRow("Description", self.description_edit)
-        form.addRow(self.save_btn)
-
-    def refresh(self) -> None:
-        db = self.ctx.require_db()
-        with db.connect() as conn:
-            projects = conn.execute("SELECT project_id, name FROM projects ORDER BY name").fetchall()
-        self.project_combo.clear()
-        for project in projects:
-            self.project_combo.addItem(project["name"], project["project_id"])
-        self._reload_phenotypes()
-
-    def _reload_phenotypes(self) -> None:
-        db = self.ctx.require_db()
-        with db.connect() as conn:
-            rows = conn.execute(
-                "SELECT phenotypes.*, projects.name as project_name FROM phenotypes "
-                "JOIN projects ON projects.project_id = phenotypes.project_id"
-            ).fetchall()
-        self.list_widget.clear()
-        for row in rows:
-            label = f"{row['name']} ({row['level']}) - {row['project_name']}"
-            item = QtWidgets.QListWidgetItem(label)
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, row)
-            self.list_widget.addItem(item)
-
-    def _create_phenotype(self) -> None:
-        if self.project_combo.currentIndex() < 0:
-            QtWidgets.QMessageBox.warning(self, "Missing project", "Select a project first")
-            return
-        pheno = models.Phenotype(
-            pheno_id=str(uuid.uuid4()),
-            project_id=self.project_combo.currentData(),
-            name=self.name_edit.text().strip(),
-            level=self.level_combo.currentText(),
-            description=self.description_edit.toPlainText().strip() or "",
+        layout.addLayout(form)
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel
         )
-        db = self.ctx.require_db()
-        with db.transaction() as conn:
-            pheno.save(conn)
-        self.name_edit.clear()
-        self.description_edit.clear()
-        self._reload_phenotypes()
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+    def _browse_corpus(self) -> None:
+        start_dir = str(self.ctx.project_root or Path.home())
+        path_str, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select corpus database",
+            start_dir,
+            "SQLite databases (*.db);;All files (*)",
+        )
+        if not path_str:
+            return
+        self.corpus_path = Path(path_str)
+        self.corpus_edit.setText(str(self.corpus_path))
+
+    def accept(self) -> None:  # noqa: D401 - Qt override
+        name = self.name_edit.text().strip()
+        if not name:
+            QtWidgets.QMessageBox.warning(self, "Validation", "Phenotype name is required.")
+            return
+        if not self.corpus_path or not self.corpus_path.exists():
+            QtWidgets.QMessageBox.warning(self, "Validation", "Select a valid corpus database file.")
+            return
+        super().accept()
+
+    def values(self) -> Dict[str, object]:
+        return {
+            "name": self.name_edit.text().strip(),
+            "level": self.level_combo.currentText(),
+            "description": self.description_edit.toPlainText().strip(),
+            "corpus_path": self.corpus_path,
+        }
 
 
-class CorpusOverviewPage(QtWidgets.QWidget):
-    def __init__(self, ctx: ProjectContext) -> None:
-        super().__init__()
+class RoundBuilderDialog(QtWidgets.QDialog):
+    def __init__(
+        self,
+        ctx: ProjectContext,
+        pheno_row: sqlite3.Row,
+        parent: Optional[QtWidgets.QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
         self.ctx = ctx
+        self.pheno_row = pheno_row
+        self.created_round_id: Optional[str] = None
+        self.created_round_number: Optional[int] = None
+        self.setWindowTitle(f"New round • {pheno_row['name']}")
+        self.resize(720, 760)
         self._setup_ui()
-        self.ctx.project_changed.connect(self.refresh)
 
     def _setup_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
-        self.summary_label = QtWidgets.QLabel("Open a project to preview corpus contents.")
-        layout.addWidget(self.summary_label)
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        container = QtWidgets.QWidget()
+        scroll_layout = QtWidgets.QVBoxLayout(container)
+        scroll_layout.setContentsMargins(8, 8, 8, 8)
 
-        self.table = QtWidgets.QTableWidget(0, 5)
-        self.table.setHorizontalHeaderLabels([
-            "Doc ID",
-            "Patient ICN",
-            "Note type",
-            "Date",
-            "Preview",
-        ])
-        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
-        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
-        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
-        self.table.horizontalHeader().setStretchLastSection(True)
-        layout.addWidget(self.table)
-
-    def refresh(self) -> None:
-        try:
-            db = self.ctx.require_corpus_db()
-        except RuntimeError:
-            self.summary_label.setText("Open a project to preview corpus contents.")
-            self.table.setRowCount(0)
-            return
-
-        with db.connect() as conn:
-            patient_count = conn.execute("SELECT COUNT(*) FROM patients").fetchone()[0]
-            document_count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
-            rows = conn.execute(
-                "SELECT doc_id, patient_icn, notetype, date_note, substr(text, 1, 200) AS preview "
-                "FROM documents ORDER BY date_note DESC LIMIT 50"
-            ).fetchall()
-
-        self.summary_label.setText(
-            f"Patients: {patient_count:,} • Documents: {document_count:,} • Showing {len(rows)} most recent notes"
-        )
-        self.table.setRowCount(len(rows))
-        for row_index, row in enumerate(rows):
-            values = [
-                row["doc_id"],
-                row["patient_icn"],
-                row["notetype"],
-                row["date_note"],
-                (row["preview"] or "").replace("\n", " ") + ("…" if row["preview"] and len(row["preview"]) == 200 else ""),
-            ]
-            for col_index, value in enumerate(values):
-                item = QtWidgets.QTableWidgetItem(str(value))
-                self.table.setItem(row_index, col_index, item)
-        self.table.resizeColumnsToContents()
-
-
-class RoundPage(QtWidgets.QWidget):
-    def __init__(self, ctx: ProjectContext) -> None:
-        super().__init__()
-        self.ctx = ctx
-        self._setup_ui()
-        self.ctx.project_changed.connect(self.refresh)
-
-    def _setup_ui(self) -> None:
-        layout = QtWidgets.QVBoxLayout(self)
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
-        layout.addWidget(splitter)
-
-        self.round_list = QtWidgets.QListWidget()
-        self.round_list.itemSelectionChanged.connect(self._load_round_config)
-        splitter.addWidget(self.round_list)
-
-        right = QtWidgets.QWidget()
-        splitter.addWidget(right)
-        right_layout = QtWidgets.QVBoxLayout(right)
-
-        round_group = QtWidgets.QGroupBox("Round setup")
-        round_form = QtWidgets.QFormLayout(round_group)
-
-        self.pheno_combo = QtWidgets.QComboBox()
+        setup_group = QtWidgets.QGroupBox("Round setup")
+        setup_form = QtWidgets.QFormLayout(setup_group)
         self.labelset_edit = QtWidgets.QLineEdit()
         self.seed_spin = QtWidgets.QSpinBox()
         self.seed_spin.setMaximum(2**31 - 1)
@@ -320,17 +310,12 @@ class RoundPage(QtWidgets.QWidget):
         self.sample_spin.setRange(1, 10000)
         self.status_combo = QtWidgets.QComboBox()
         self.status_combo.addItems(["draft", "active", "closed", "adjudicating", "finalized"])
-        self.create_btn = QtWidgets.QPushButton("Generate round")
-        self.create_btn.clicked.connect(self._create_round)
-
-        round_form.addRow("Phenotype", self.pheno_combo)
-        round_form.addRow("Label set ID", self.labelset_edit)
-        round_form.addRow("Seed", self.seed_spin)
-        round_form.addRow("Overlap N", self.overlap_spin)
-        round_form.addRow("Sample per reviewer", self.sample_spin)
-        round_form.addRow("Status", self.status_combo)
-        round_form.addRow(self.create_btn)
-        right_layout.addWidget(round_group)
+        setup_form.addRow("Label set ID", self.labelset_edit)
+        setup_form.addRow("Seed", self.seed_spin)
+        setup_form.addRow("Overlap N", self.overlap_spin)
+        setup_form.addRow("Sample per reviewer", self.sample_spin)
+        setup_form.addRow("Status", self.status_combo)
+        scroll_layout.addWidget(setup_group)
 
         filter_group = QtWidgets.QGroupBox("Sampling filters")
         filter_form = QtWidgets.QFormLayout(filter_group)
@@ -369,14 +354,13 @@ class RoundPage(QtWidgets.QWidget):
         note_years_layout.addWidget(self.note_year_end)
         self.note_regex_edit = QtWidgets.QLineEdit()
         self.note_regex_edit.setPlaceholderText("Python regex applied to note text")
-
         filter_form.addRow("Patient STA3N", self.patient_sta3n_edit)
         filter_form.addRow("Patient year range", patient_years_layout)
         filter_form.addRow("Patient softlabel ≥", self.patient_softlabel_spin)
         filter_form.addRow("Note types", self.note_type_edit)
         filter_form.addRow("Note year range", note_years_layout)
         filter_form.addRow("Note regex", self.note_regex_edit)
-        right_layout.addWidget(filter_group)
+        scroll_layout.addWidget(filter_group)
 
         strat_group = QtWidgets.QGroupBox("Stratification")
         strat_form = QtWidgets.QFormLayout(strat_group)
@@ -388,50 +372,169 @@ class RoundPage(QtWidgets.QWidget):
         self.strat_sample_spin.setValue(0)
         strat_form.addRow("Stratify by", self.strat_keys_edit)
         strat_form.addRow("Sample per stratum", self.strat_sample_spin)
-        right_layout.addWidget(strat_group)
+        scroll_layout.addWidget(strat_group)
 
-        right_layout.addWidget(QtWidgets.QLabel("Selected round configuration"))
-        self.round_config_view = QtWidgets.QTextEdit()
-        self.round_config_view.setReadOnly(True)
-        self.round_config_view.setPlaceholderText("Select an existing round to inspect its configuration")
-        right_layout.addWidget(self.round_config_view)
-        right_layout.addStretch()
+        scroll_layout.addStretch()
+        scroll.setWidget(container)
+        layout.addWidget(scroll)
 
-    def refresh(self) -> None:
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+    def _collect_filters(self) -> SamplingFilters:
+        patient_filters: Dict[str, object] = {}
+        note_filters: Dict[str, object] = {}
+        sta_text = self.patient_sta3n_edit.text().strip()
+        if sta_text:
+            values = [value.strip() for value in sta_text.split(",") if value.strip()]
+            if values:
+                patient_filters["sta3n_in"] = values
+        start = self.patient_year_start.value()
+        end = self.patient_year_end.value()
+        if start and end:
+            if end < start:
+                start, end = end, start
+            patient_filters["year_range"] = [start, end]
+        softlabel = self.patient_softlabel_spin.value()
+        if softlabel >= 0:
+            patient_filters["softlabel_gte"] = softlabel
+        note_types = [value.strip() for value in self.note_type_edit.text().split(",") if value.strip()]
+        if note_types:
+            note_filters["notetype_in"] = note_types
+        note_start = self.note_year_start.value()
+        note_end = self.note_year_end.value()
+        if note_start and note_end:
+            if note_end < note_start:
+                note_start, note_end = note_end, note_start
+            note_filters["note_year_range"] = [note_start, note_end]
+        regex = self.note_regex_edit.text().strip()
+        if regex:
+            note_filters["regex"] = regex
+        return SamplingFilters(patient_filters=patient_filters, note_filters=note_filters)
+
+    def _prompt_reviewers(self) -> Optional[List[Dict[str, str]]]:
+        dialog = QtWidgets.QDialog(self)
+        dialog.setWindowTitle("Reviewers")
+        layout = QtWidgets.QVBoxLayout(dialog)
+        table = QtWidgets.QTableWidget(0, 1)
+        table.setHorizontalHeaderLabels(["Reviewer name"])
+        table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(table)
+
+        def add_row() -> None:
+            row = table.rowCount()
+            table.insertRow(row)
+            table.setItem(row, 0, QtWidgets.QTableWidgetItem(""))
+
+        add_row()
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        add_btn = QtWidgets.QPushButton("Add reviewer")
+        add_btn.clicked.connect(add_row)
+        layout.addWidget(add_btn)
+        layout.addWidget(buttons)
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return None
+        names: List[str] = []
+        for row in range(table.rowCount()):
+            item = table.item(row, 0)
+            name = item.text().strip() if item else ""
+            if name:
+                names.append(name)
+        if not names:
+            QtWidgets.QMessageBox.warning(self, "Reviewers", "Add at least one reviewer name.")
+            return []
+        seen: Set[str] = set()
+        reviewers: List[Dict[str, str]] = []
+        for name in names:
+            slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "reviewer"
+            candidate = slug
+            counter = 2
+            while candidate in seen:
+                candidate = f"{slug}_{counter}"
+                counter += 1
+            seen.add(candidate)
+            reviewers.append({"id": candidate, "name": name})
+        return reviewers
+
+    def _next_round_number(self) -> int:
+        pheno_id = self.pheno_row["pheno_id"]
         db = self.ctx.require_db()
         with db.connect() as conn:
-            phenos = conn.execute("SELECT pheno_id, name FROM phenotypes ORDER BY name").fetchall()
-            rounds = conn.execute("SELECT * FROM rounds ORDER BY created_at DESC").fetchall()
-        self.pheno_combo.clear()
-        for pheno in phenos:
-            self.pheno_combo.addItem(pheno["name"], pheno["pheno_id"])
-        self.round_list.clear()
-        for row in rounds:
-            item = QtWidgets.QListWidgetItem(f"{row['round_number']} - {row['round_id']}")
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, row)
-            self.round_list.addItem(item)
-        if self.round_list.count():
-            self.round_list.setCurrentRow(0)
-        else:
-            self.round_config_view.clear()
+            row = conn.execute(
+                "SELECT MAX(round_number) FROM rounds WHERE pheno_id=?",
+                (pheno_id,),
+            ).fetchone()
+        return (row[0] or 0) + 1
 
-    def _create_round(self) -> None:
-        if self.pheno_combo.currentIndex() < 0:
-            QtWidgets.QMessageBox.warning(self, "Phenotype missing", "Select a phenotype")
+    def _build_label_schema(self, labelset_id: str, db: Database) -> Dict[str, object]:
+        with db.connect() as conn:
+            labels = conn.execute(
+                "SELECT * FROM labels WHERE labelset_id=? ORDER BY order_index",
+                (labelset_id,),
+            ).fetchall()
+            options = conn.execute(
+                "SELECT * FROM label_options WHERE label_id IN (SELECT label_id FROM labels WHERE labelset_id=?)",
+                (labelset_id,),
+            ).fetchall()
+        option_map: Dict[str, List[Dict[str, object]]] = {}
+        for opt in options:
+            option_map.setdefault(opt["label_id"], []).append(
+                {
+                    "value": opt["value"],
+                    "display": opt["display"],
+                    "order_index": opt["order_index"],
+                    "weight": opt["weight"],
+                }
+            )
+        schema_labels = []
+        for label in labels:
+            schema_labels.append(
+                {
+                    "label_id": label["label_id"],
+                    "name": label["name"],
+                    "type": label["type"],
+                    "required": bool(label["required"]),
+                    "na_allowed": bool(label["na_allowed"]),
+                    "rules": label["rules"],
+                    "unit": label["unit"],
+                    "range": {"min": label["min"], "max": label["max"]},
+                    "gating_expr": label["gating_expr"],
+                    "options": sorted(option_map.get(label["label_id"], []), key=lambda o: o["order_index"]),
+                }
+            )
+        return {"labelset_id": labelset_id, "labels": schema_labels}
+
+    def accept(self) -> None:  # noqa: D401 - Qt override
+        if not self._create_round():
             return
+        super().accept()
+
+    def _create_round(self) -> bool:
+        pheno_id = self.pheno_row["pheno_id"]
+        pheno_level = self.pheno_row["level"]
         ctx = self.ctx
         db = ctx.require_db()
-        pheno_id = self.pheno_combo.currentData()
         seed = self.seed_spin.value()
         overlap = self.overlap_spin.value()
         reviewers = self._prompt_reviewers()
         if not reviewers:
-            return
+            return False
         labelset_id = self.labelset_edit.text().strip() or f"auto_{pheno_id}"
         created_at = QtCore.QDateTime.currentDateTimeUtc().toString(QtCore.Qt.ISODate)
         default_labels: List[Dict[str, object]] = []
         with db.connect() as conn:
-            exists = conn.execute("SELECT 1 FROM label_sets WHERE labelset_id=?", (labelset_id,)).fetchone()
+            exists = conn.execute(
+                "SELECT 1 FROM label_sets WHERE labelset_id=?",
+                (labelset_id,),
+            ).fetchone()
         if not exists:
             default_labels.append(
                 {
@@ -447,10 +550,14 @@ class RoundPage(QtWidgets.QWidget):
                 }
             )
         filters = self._collect_filters()
-        corpus_rows = candidate_documents(ctx.require_corpus_db(), "single_doc", filters)
+        try:
+            corpus_rows = candidate_documents(ctx.get_corpus_db(pheno_id), pheno_level, filters)
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(self, "Round", f"Failed to query corpus: {exc}")
+            return False
         if not corpus_rows:
-            QtWidgets.QMessageBox.warning(self, "No corpus", "The corpus database has no documents to sample")
-            return
+            QtWidgets.QMessageBox.warning(self, "Round", "The selected corpus returned no candidate documents.")
+            return False
         strat_keys = [key.strip() for key in self.strat_keys_edit.text().split(",") if key.strip()]
         strat_sample = self.strat_sample_spin.value()
         if strat_sample <= 0:
@@ -476,12 +583,12 @@ class RoundPage(QtWidgets.QWidget):
         if missing:
             QtWidgets.QMessageBox.warning(
                 self,
-                "Sample size",
-                "Not enough candidate documents were found to satisfy the desired sample size for:"
-                f" {', '.join(missing)}",
+                "Round",
+                "Not enough candidate documents were found to satisfy the desired sample size for: "
+                + ", ".join(missing),
             )
         round_id = str(uuid.uuid4())
-        round_number = self._next_round_number(pheno_id)
+        round_number = self._next_round_number()
         round_record = models.Round(
             round_id=round_id,
             pheno_id=pheno_id,
@@ -492,9 +599,9 @@ class RoundPage(QtWidgets.QWidget):
             status=self.status_combo.currentText(),
             created_at=created_at,
         )
-        manifest_dir = ctx.require_project() / "phenotypes" / pheno_id / f"rounds/{round_number}"
-        manifest_dir.mkdir(parents=True, exist_ok=True)
-        write_manifest(manifest_dir / "manifest.csv", assignments)
+        project_root = ctx.require_project()
+        round_dir = ensure_dir(project_root / "phenotypes" / pheno_id / "rounds" / f"round_{round_number}")
+        write_manifest(round_dir / "manifest.csv", assignments)
         with db.transaction() as conn:
             if default_labels:
                 labelset = models.LabelSet(
@@ -580,171 +687,412 @@ class RoundPage(QtWidgets.QWidget):
                 )
                 assignment.save(conn)
         for reviewer in reviewers:
-            assignment_dir = manifest_dir / "assignments" / reviewer["id"]
-            assignment_dir.mkdir(parents=True, exist_ok=True)
+            assignment_dir = ensure_dir(round_dir / "assignments" / reviewer["id"])
             db_path = assignment_dir / "assignment.db"
             assignment_db = initialize_assignment_db(db_path)
             populate_assignment_db(assignment_db, reviewer["id"], assignments[reviewer["id"]].units)
             label_schema = self._build_label_schema(labelset_id, db)
             schema_path = assignment_dir / "label_schema.json"
             schema_path.write_text(json.dumps(label_schema, indent=2), encoding="utf-8")
+        self.created_round_id = round_id
+        self.created_round_number = round_number
+        return True
+
+
+class ProjectTreeWidget(QtWidgets.QTreeWidget):
+    node_selected = QtCore.Signal(dict)
+
+    def __init__(self, ctx: ProjectContext, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.ctx = ctx
+        self.setHeaderHidden(True)
+        self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._show_context_menu)
+        self.currentItemChanged.connect(self._on_current_item_changed)
+        self.ctx.project_changed.connect(self.refresh)
         self.refresh()
 
-    def _collect_filters(self) -> SamplingFilters:
-        patient_filters: Dict[str, object] = {}
-        note_filters: Dict[str, object] = {}
-        sta_text = self.patient_sta3n_edit.text().strip()
-        if sta_text:
-            values = [value.strip() for value in sta_text.split(",") if value.strip()]
-            if values:
-                patient_filters["sta3n_in"] = values
-        start = self.patient_year_start.value()
-        end = self.patient_year_end.value()
-        if start and end:
-            if end < start:
-                start, end = end, start
-            patient_filters["year_range"] = [start, end]
-        softlabel = self.patient_softlabel_spin.value()
-        if softlabel >= 0:
-            patient_filters["softlabel_gte"] = softlabel
-        note_types = [value.strip() for value in self.note_type_edit.text().split(",") if value.strip()]
-        if note_types:
-            note_filters["notetype_in"] = note_types
-        note_start = self.note_year_start.value()
-        note_end = self.note_year_end.value()
-        if note_start and note_end:
-            if note_end < note_start:
-                note_start, note_end = note_end, note_start
-            note_filters["note_year_range"] = [note_start, note_end]
-        regex = self.note_regex_edit.text().strip()
-        if regex:
-            note_filters["regex"] = regex
-        return SamplingFilters(patient_filters=patient_filters, note_filters=note_filters)
-
-    def _load_round_config(self) -> None:
-        current = self.round_list.currentItem()
-        if not current:
-            self.round_config_view.clear()
+    def refresh(self) -> None:
+        self.clear()
+        project = self.ctx.project_row or self.ctx._load_project_row()
+        if not project:
+            placeholder = QtWidgets.QTreeWidgetItem(["No project loaded"])
+            placeholder.setFlags(QtCore.Qt.ItemFlag.NoItemFlags)
+            self.addTopLevelItem(placeholder)
             return
-        data = current.data(QtCore.Qt.ItemDataRole.UserRole)
-        if not data:
-            self.round_config_view.clear()
+        display_name = project.get("name") or project.get("project_id") or "Project"
+        project_item = QtWidgets.QTreeWidgetItem([str(display_name)])
+        project_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, {"type": "project", "project": dict(project)})
+        self.addTopLevelItem(project_item)
+        project_item.setExpanded(True)
+        for pheno in self.ctx.list_phenotypes():
+            pheno_item = self._build_phenotype_item(pheno)
+            project_item.addChild(pheno_item)
+            pheno_item.setExpanded(True)
+        self.expandItem(project_item)
+        if project_item.childCount():
+            self.setCurrentItem(project_item.child(0))
+        else:
+            self.setCurrentItem(project_item)
+
+    def _build_phenotype_item(self, pheno: sqlite3.Row) -> QtWidgets.QTreeWidgetItem:
+        pheno_item = QtWidgets.QTreeWidgetItem([f"{pheno['name']} ({pheno['level']})"])
+        pheno_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, {"type": "phenotype", "pheno": dict(pheno)})
+        rounds = self.ctx.list_rounds(pheno["pheno_id"])
+        for round_row in rounds:
+            label = f"Round {round_row['round_number']} ({round_row['status']})"
+            child = QtWidgets.QTreeWidgetItem([label])
+            child.setData(0, QtCore.Qt.ItemDataRole.UserRole, {"type": "round", "round": dict(round_row)})
+            pheno_item.addChild(child)
+        corpus_item = QtWidgets.QTreeWidgetItem(["Corpus"])
+        corpus_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, {"type": "corpus", "pheno": dict(pheno)})
+        pheno_item.addChild(corpus_item)
+        iaa_item = QtWidgets.QTreeWidgetItem(["IAA"])
+        iaa_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, {"type": "iaa", "pheno": dict(pheno)})
+        pheno_item.addChild(iaa_item)
+        return pheno_item
+
+    def _on_current_item_changed(
+        self,
+        current: Optional[QtWidgets.QTreeWidgetItem],
+        previous: Optional[QtWidgets.QTreeWidgetItem],
+    ) -> None:
+        del previous
+        if not current:
+            self.node_selected.emit({})
+            return
+        data = current.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        if isinstance(data, dict):
+            self.node_selected.emit(data)
+
+    def _show_context_menu(self, point: QtCore.QPoint) -> None:
+        item = self.itemAt(point)
+        if not item:
+            return
+        data = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        if not isinstance(data, dict):
+            return
+        menu = QtWidgets.QMenu(self)
+        node_type = data.get("type")
+        if node_type == "project":
+            action = menu.addAction("Add phenotype…")
+            action.triggered.connect(lambda: self._add_phenotype(item))
+        elif node_type == "phenotype":
+            action = menu.addAction("Add round…")
+            action.triggered.connect(lambda: self._add_round(item))
+        if not menu.isEmpty():
+            menu.exec(self.viewport().mapToGlobal(point))
+
+    def _add_phenotype(self, item: QtWidgets.QTreeWidgetItem) -> None:
+        del item
+        dialog = PhenotypeDialog(self.ctx, self)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        values = dialog.values()
+        corpus_path = values.get("corpus_path")
+        if not isinstance(corpus_path, Path):
+            QtWidgets.QMessageBox.warning(self, "Phenotype", "Invalid corpus selection.")
             return
         try:
-            db = self.ctx.require_db()
-        except RuntimeError:
-            self.round_config_view.setPlainText("No project loaded.")
+            record = self.ctx.create_phenotype(
+                name=str(values.get("name", "")),
+                level=str(values.get("level", "single_doc")),
+                description=str(values.get("description", "")),
+                corpus_source=corpus_path,
+            )
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(self, "Phenotype", f"Failed to create phenotype: {exc}")
             return
-        config_text = ""
-        with db.connect() as conn:
-            row = conn.execute(
-                "SELECT config_json FROM round_configs WHERE round_id=?",
-                (data["round_id"],),
-            ).fetchone()
-            if row and row["config_json"]:
-                config_text = row["config_json"]
-        if not config_text:
-            try:
-                project_root = self.ctx.require_project()
-            except RuntimeError:
-                self.round_config_view.setPlainText("Configuration not available.")
-                return
-            round_number = data["round_number"]
-            round_dir = project_root / "phenotypes" / data["pheno_id"] / "rounds" / f"round_{round_number}"
-            config_path = round_dir / "round_config.json"
-            if config_path.exists():
-                config_text = config_path.read_text(encoding="utf-8")
-        if config_text:
-            try:
-                parsed = json.loads(config_text)
-                pretty = json.dumps(parsed, indent=2)
-                self.round_config_view.setPlainText(pretty)
-            except json.JSONDecodeError:
-                self.round_config_view.setPlainText(config_text)
-        else:
-            self.round_config_view.setPlainText("Configuration not found for the selected round.")
+        QtCore.QTimer.singleShot(0, lambda: self._select_phenotype(record.pheno_id))
 
-    def _prompt_reviewers(self) -> Optional[List[Dict[str, str]]]:
-        dialog = QtWidgets.QDialog(self)
-        dialog.setWindowTitle("Reviewers")
-        layout = QtWidgets.QVBoxLayout(dialog)
-        table = QtWidgets.QTableWidget(0, 3)
-        table.setHorizontalHeaderLabels(["Reviewer ID", "Name", "Email"])
-        layout.addWidget(table)
-
-        def add_row() -> None:
-            row = table.rowCount()
-            table.insertRow(row)
-            for col in range(3):
-                table.setItem(row, col, QtWidgets.QTableWidgetItem(""))
-
-        add_row()
-        buttons = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel
-        )
-        add_btn = QtWidgets.QPushButton("Add reviewer")
-        add_btn.clicked.connect(add_row)
-        layout.addWidget(add_btn)
-        layout.addWidget(buttons)
-        buttons.accepted.connect(dialog.accept)
-        buttons.rejected.connect(dialog.reject)
+    def _add_round(self, item: QtWidgets.QTreeWidgetItem) -> None:
+        data = item.data(0, QtCore.Qt.ItemDataRole.UserRole) or {}
+        pheno = data.get("pheno")
+        if not isinstance(pheno, dict):
+            return
+        pheno_row = self.ctx.get_phenotype(pheno["pheno_id"])
+        if not pheno_row:
+            QtWidgets.QMessageBox.warning(self, "Round", "Phenotype record not found.")
+            return
+        dialog = RoundBuilderDialog(self.ctx, pheno_row, self)
         if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
-            return None
-        reviewers: List[Dict[str, str]] = []
-        for row in range(table.rowCount()):
-            reviewer_id = table.item(row, 0).text().strip()
-            name = table.item(row, 1).text().strip()
-            email = table.item(row, 2).text().strip()
-            if reviewer_id:
-                reviewers.append({"id": reviewer_id, "name": name, "email": email})
-        return reviewers
+            return
+        round_id = dialog.created_round_id
+        if round_id:
+            self.ctx.project_changed.emit()
+            QtCore.QTimer.singleShot(0, lambda: self._select_round(pheno_row["pheno_id"], round_id))
 
-    def _next_round_number(self, pheno_id: str) -> int:
-        db = self.ctx.require_db()
-        with db.connect() as conn:
-            row = conn.execute("SELECT MAX(round_number) FROM rounds WHERE pheno_id=?", (pheno_id,)).fetchone()
-        return (row[0] or 0) + 1
+    def _iter_items(self, root: Optional[QtWidgets.QTreeWidgetItem]) -> Iterable[QtWidgets.QTreeWidgetItem]:
+        if not root:
+            return
+        yield root
+        for index in range(root.childCount()):
+            yield from self._iter_items(root.child(index))
 
-    def _build_label_schema(self, labelset_id: str, db: Database) -> Dict[str, object]:
-        with db.connect() as conn:
-            labels = conn.execute("SELECT * FROM labels WHERE labelset_id=? ORDER BY order_index", (labelset_id,)).fetchall()
-            options = conn.execute("SELECT * FROM label_options WHERE label_id IN (SELECT label_id FROM labels WHERE labelset_id=?)", (labelset_id,)).fetchall()
-        option_map: Dict[str, List[Dict[str, object]]] = {}
-        for opt in options:
-            option_map.setdefault(opt["label_id"], []).append(
-                {
-                    "value": opt["value"],
-                    "display": opt["display"],
-                    "order_index": opt["order_index"],
-                    "weight": opt["weight"],
-                }
-            )
-        schema_labels = []
-        for label in labels:
-            schema_labels.append(
-                {
-                    "label_id": label["label_id"],
-                    "name": label["name"],
-                    "type": label["type"],
-                    "required": bool(label["required"]),
-                    "na_allowed": bool(label["na_allowed"]),
-                    "rules": label["rules"],
-                    "unit": label["unit"],
-                    "range": {"min": label["min"], "max": label["max"]},
-                    "gating_expr": label["gating_expr"],
-                    "options": sorted(option_map.get(label["label_id"], []), key=lambda o: o["order_index"]),
-                }
-            )
-        return {
-            "labelset_id": labelset_id,
-            "labels": schema_labels,
-        }
+    def _select_phenotype(self, pheno_id: str) -> None:
+        for item in self._iter_items(self.topLevelItem(0)):
+            data = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+            if isinstance(data, dict) and data.get("type") == "phenotype" and data.get("pheno", {}).get("pheno_id") == pheno_id:
+                self.setCurrentItem(item)
+                self.expandItem(item)
+                return
+        self.refresh()
+
+    def _select_round(self, pheno_id: str, round_id: str) -> None:
+        self.refresh()
+        project_item = self.topLevelItem(0)
+        target_round: Optional[QtWidgets.QTreeWidgetItem] = None
+        for pheno_item in self._iter_items(project_item):
+            data = pheno_item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+            if isinstance(data, dict) and data.get("type") == "round" and data.get("round", {}).get("round_id") == round_id:
+                target_round = pheno_item
+                break
+        if target_round:
+            self.setCurrentItem(target_round)
+            parent = target_round.parent()
+            if parent:
+                self.expandItem(parent)
 
 
-class IaaPage(QtWidgets.QWidget):
-    def __init__(self, ctx: ProjectContext) -> None:
-        super().__init__()
+
+class ProjectOverviewWidget(QtWidgets.QWidget):
+    def __init__(self, ctx: ProjectContext, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
         self.ctx = ctx
+        layout = QtWidgets.QVBoxLayout(self)
+        self.text = QtWidgets.QTextBrowser()
+        layout.addWidget(self.text)
+        layout.addStretch()
+
+    def set_project(self, project: Optional[Dict[str, object]]) -> None:
+        if not project:
+            self.text.setPlainText("Select a project to view metadata.")
+            return
+        lines = [
+            f"Project: {project.get('name') or '—'}",
+            f"Project ID: {project.get('project_id') or '—'}",
+            f"Created by: {project.get('created_by') or '—'}",
+            f"Created at: {project.get('created_at') or '—'}",
+        ]
+        phenotypes = self.ctx.list_phenotypes()
+        if phenotypes:
+            lines.append("")
+            lines.append("Phenotypes:")
+            for pheno in phenotypes:
+                lines.append(f"  • {pheno['name']} ({pheno['level']})")
+        else:
+            lines.append("")
+            lines.append("No phenotypes defined. Right-click the project to add one.")
+        self.text.setPlainText("\n".join(lines))
+
+
+class PhenotypeDetailWidget(QtWidgets.QWidget):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QFormLayout(self)
+        self.name_label = QtWidgets.QLabel()
+        self.level_label = QtWidgets.QLabel()
+        self.description_label = QtWidgets.QTextEdit()
+        self.description_label.setReadOnly(True)
+        self.corpus_label = QtWidgets.QLabel()
+        self.description_label.setFixedHeight(120)
+        layout.addRow("Name", self.name_label)
+        layout.addRow("Level", self.level_label)
+        layout.addRow("Corpus", self.corpus_label)
+        layout.addRow("Description", self.description_label)
+
+    def set_phenotype(self, pheno: Optional[Dict[str, object]]) -> None:
+        if not pheno:
+            self.name_label.clear()
+            self.level_label.clear()
+            self.description_label.clear()
+            self.corpus_label.clear()
+            return
+        self.name_label.setText(str(pheno.get("name", "")))
+        self.level_label.setText(str(pheno.get("level", "")))
+        self.corpus_label.setText(str(pheno.get("corpus_path", "")))
+        self.description_label.setPlainText(str(pheno.get("description", "")))
+
+
+class RoundDetailWidget(QtWidgets.QWidget):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+        self.meta_form = QtWidgets.QFormLayout()
+        self.round_label = QtWidgets.QLabel()
+        self.status_label = QtWidgets.QLabel()
+        self.labelset_label = QtWidgets.QLabel()
+        self.seed_label = QtWidgets.QLabel()
+        self.overlap_label = QtWidgets.QLabel()
+        self.meta_form.addRow("Round", self.round_label)
+        self.meta_form.addRow("Status", self.status_label)
+        self.meta_form.addRow("Label set", self.labelset_label)
+        self.meta_form.addRow("Seed", self.seed_label)
+        self.meta_form.addRow("Overlap", self.overlap_label)
+        layout.addLayout(self.meta_form)
+        self.config_view = QtWidgets.QTextEdit()
+        self.config_view.setReadOnly(True)
+        self.config_view.setPlaceholderText("Select a round to view configuration")
+        layout.addWidget(self.config_view)
+
+    def set_round(self, round_row: Optional[Dict[str, object]], config: Optional[Dict[str, object]]) -> None:
+        if not round_row:
+            self.round_label.clear()
+            self.status_label.clear()
+            self.labelset_label.clear()
+            self.seed_label.clear()
+            self.overlap_label.clear()
+            self.config_view.clear()
+            return
+        self.round_label.setText(f"Round {round_row.get('round_number')} ({round_row.get('round_id')})")
+        self.status_label.setText(str(round_row.get("status", "")))
+        self.labelset_label.setText(str(round_row.get("labelset_id", "")))
+        self.seed_label.setText(str(round_row.get("rng_seed", "")))
+        self.overlap_label.setText(str(round_row.get("overlap_n", "")))
+        if config:
+            self.config_view.setPlainText(self._summarize_config(config))
+        else:
+            self.config_view.setPlainText("Configuration not available.")
+        self.config_view.moveCursor(QtGui.QTextCursor.MoveOperation.Start)
+
+    def _summarize_config(self, config: Dict[str, object]) -> str:
+        sections: List[str] = []
+        setup_items: List[str] = []
+        setup_items.append(f"Round ID: {config.get('round_id', '—')}")
+        if config.get("round_number") is not None:
+            setup_items.append(f"Round number: {config['round_number']}")
+        setup_items.append(f"Label set: {config.get('labelset_id', '—')}")
+        setup_items.append(f"Status: {config.get('status', 'draft')}")
+        if config.get("sample_per_reviewer"):
+            setup_items.append(f"Sample per reviewer: {config['sample_per_reviewer']}")
+        setup_items.append(f"Overlap units: {config.get('overlap_n', 0)}")
+        setup_items.append(f"RNG seed: {config.get('rng_seed', 0)}")
+        reviewers = config.get("reviewers") or []
+        if reviewers:
+            reviewer_names = [str(reviewer.get("name") or reviewer.get("id")) for reviewer in reviewers]
+            setup_items.append(f"Reviewers: {', '.join(reviewer_names)}")
+        sections.append(self._format_section("Round setup", setup_items))
+
+        filters = config.get("filters") or {}
+        filter_items: List[str] = []
+        patient_filters = filters.get("patient") or {}
+        for key, value in patient_filters.items():
+            label = {
+                "sta3n_in": "Patient STA3N",
+                "year_range": "Patient year range",
+                "softlabel_gte": "Softlabel ≥",
+            }.get(key, key)
+            filter_items.append(f"Patient – {label}: {self._format_filter_value(key, value)}")
+        note_filters = filters.get("note") or {}
+        for key, value in note_filters.items():
+            label = {
+                "notetype_in": "Note types",
+                "note_year_range": "Note year range",
+                "regex": "Regex",
+            }.get(key, key)
+            filter_items.append(f"Note – {label}: {self._format_filter_value(key, value)}")
+        if filter_items:
+            sections.append(self._format_section("Sampling filters", filter_items))
+
+        stratification = config.get("stratification") or {}
+        strat_items: List[str] = []
+        keys = stratification.get("keys")
+        if keys:
+            if isinstance(keys, list):
+                strat_items.append(f"Stratify by: {', '.join(keys)}")
+            else:
+                strat_items.append(f"Stratify by: {keys}")
+        if stratification.get("sample_per_stratum"):
+            strat_items.append(f"Sample per stratum: {stratification['sample_per_stratum']}")
+        if strat_items:
+            sections.append(self._format_section("Stratification", strat_items))
+
+        summary = "\n\n".join(section for section in sections if section)
+        return summary or "Configuration not available."
+
+    @staticmethod
+    def _format_section(title: str, entries: List[str]) -> str:
+        filtered = [entry for entry in entries if entry]
+        if not filtered:
+            return ""
+        lines = [title]
+        lines.extend(f"  • {entry}" for entry in filtered)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_filter_value(key: str, value: object) -> str:
+        if isinstance(value, list):
+            if len(value) == 2 and all(isinstance(v, (int, float, str)) for v in value):
+                return f"{value[0]} – {value[1]}"
+            return ", ".join(str(v) for v in value)
+        if key == "softlabel_gte":
+            return str(value)
+        return str(value)
+
+
+class CorpusWidget(QtWidgets.QWidget):
+    def __init__(self, ctx: ProjectContext, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.ctx = ctx
+        layout = QtWidgets.QVBoxLayout(self)
+        self.summary_label = QtWidgets.QLabel("Select a phenotype to view corpus contents.")
+        layout.addWidget(self.summary_label)
+        self.table = QtWidgets.QTableWidget(0, 5)
+        self.table.setHorizontalHeaderLabels(["Doc ID", "Patient", "Note type", "Date", "Preview"])
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+    def set_phenotype(self, pheno: Optional[Dict[str, object]]) -> None:
+        if not pheno:
+            self.summary_label.setText("Select a phenotype to view corpus contents.")
+            self.table.setRowCount(0)
+            return
+        pheno_id = pheno.get("pheno_id")
+        if not pheno_id:
+            self.summary_label.setText("Phenotype metadata incomplete.")
+            self.table.setRowCount(0)
+            return
+        try:
+            db = self.ctx.get_corpus_db(pheno_id)
+        except Exception as exc:  # noqa: BLE001
+            self.summary_label.setText(f"Corpus unavailable: {exc}")
+            self.table.setRowCount(0)
+            return
+        with db.connect() as conn:
+            patient_count = conn.execute("SELECT COUNT(*) FROM patients").fetchone()[0]
+            document_count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+            rows = conn.execute(
+                "SELECT doc_id, patient_icn, notetype, date_note, substr(text, 1, 200) AS preview "
+                "FROM documents ORDER BY date_note DESC LIMIT 50"
+            ).fetchall()
+        self.summary_label.setText(
+            f"Patients: {patient_count:,} • Documents: {document_count:,} • Showing {len(rows)} most recent notes"
+        )
+        self.table.setRowCount(len(rows))
+        for row_index, row in enumerate(rows):
+            values = [
+                row["doc_id"],
+                row["patient_icn"],
+                row["notetype"],
+                row["date_note"],
+                (row["preview"] or "").replace("\n", " ")
+                + ("…" if row["preview"] and len(row["preview"]) == 200 else ""),
+            ]
+            for col_index, value in enumerate(values):
+                item = QtWidgets.QTableWidgetItem(str(value))
+                self.table.setItem(row_index, col_index, item)
+        self.table.resizeColumnsToContents()
+
+
+
+class IaaWidget(QtWidgets.QWidget):
+    def __init__(self, ctx: ProjectContext, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.ctx = ctx
+        self.current_pheno: Optional[Dict[str, object]] = None
         self.current_round: Optional[Dict[str, object]] = None
         self.current_reviewer_names: Dict[str, str] = {}
         self.assignment_paths: Dict[str, Path] = {}
@@ -754,24 +1102,11 @@ class IaaPage(QtWidgets.QWidget):
         self.label_order: List[str] = []
         self.reviewer_column_order: List[str] = []
         self._setup_ui()
-        self.ctx.project_changed.connect(self.refresh)
+        self.ctx.project_changed.connect(self.reset)
 
     def _setup_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(6, 6, 6, 6)
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
-        layout.addWidget(splitter)
-
-        left_panel = QtWidgets.QWidget()
-        left_layout = QtWidgets.QVBoxLayout(left_panel)
-        left_layout.addWidget(QtWidgets.QLabel("Phenotypes"))
-        self.pheno_list = QtWidgets.QListWidget()
-        self.pheno_list.itemSelectionChanged.connect(self._on_pheno_selected)
-        left_layout.addWidget(self.pheno_list)
-        splitter.addWidget(left_panel)
-
-        right_panel = QtWidgets.QWidget()
-        right_layout = QtWidgets.QVBoxLayout(right_panel)
 
         self.round_table = QtWidgets.QTableWidget()
         self.round_table.setColumnCount(3)
@@ -781,7 +1116,7 @@ class IaaPage(QtWidgets.QWidget):
         self.round_table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
         self.round_table.itemSelectionChanged.connect(self._on_round_selected)
         self.round_table.horizontalHeader().setStretchLastSection(True)
-        right_layout.addWidget(self.round_table)
+        layout.addWidget(self.round_table)
 
         controls = QtWidgets.QHBoxLayout()
         self.metric_selector = QtWidgets.QComboBox()
@@ -795,7 +1130,7 @@ class IaaPage(QtWidgets.QWidget):
         controls.addWidget(QtWidgets.QLabel("Metric:"))
         controls.addWidget(self.metric_selector)
         controls.addWidget(self.compute_btn)
-        right_layout.addLayout(controls)
+        layout.addLayout(controls)
 
         import_layout = QtWidgets.QHBoxLayout()
         self.auto_import_btn = QtWidgets.QPushButton("Import submitted assignments")
@@ -811,19 +1146,19 @@ class IaaPage(QtWidgets.QWidget):
         import_layout.addWidget(QtWidgets.QLabel("Reviewer:"))
         import_layout.addWidget(self.manual_reviewer_combo)
         import_layout.addWidget(self.manual_import_btn)
-        right_layout.addLayout(import_layout)
+        layout.addLayout(import_layout)
 
         self.import_status_label = QtWidgets.QLabel()
         self.import_status_label.setWordWrap(True)
-        right_layout.addWidget(self.import_status_label)
+        layout.addWidget(self.import_status_label)
 
         self.round_summary = QtWidgets.QLabel("Select a round to review agreement metrics")
         self.round_summary.setWordWrap(True)
-        right_layout.addWidget(self.round_summary)
+        layout.addWidget(self.round_summary)
 
         units_label = QtWidgets.QLabel("Imported units (overlapping assignments shown first)")
         units_label.setWordWrap(True)
-        right_layout.addWidget(units_label)
+        layout.addWidget(units_label)
 
         self.unit_table = QtWidgets.QTableWidget()
         self._update_unit_table_headers()
@@ -832,10 +1167,9 @@ class IaaPage(QtWidgets.QWidget):
         self.unit_table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
         self.unit_table.itemSelectionChanged.connect(self._on_unit_selected)
         self.unit_table.horizontalHeader().setStretchLastSection(True)
-        right_layout.addWidget(self.unit_table)
+        layout.addWidget(self.unit_table)
 
         doc_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
-
         doc_panel = QtWidgets.QWidget()
         doc_layout = QtWidgets.QVBoxLayout(doc_panel)
         doc_layout.setContentsMargins(0, 0, 0, 0)
@@ -857,50 +1191,10 @@ class IaaPage(QtWidgets.QWidget):
         doc_splitter.addWidget(self.document_preview)
         doc_splitter.setStretchFactor(0, 1)
         doc_splitter.setStretchFactor(1, 2)
+        layout.addWidget(doc_splitter)
 
-        right_layout.addWidget(doc_splitter)
-        splitter.addWidget(right_panel)
-        splitter.setStretchFactor(1, 3)
-
-    def refresh(self) -> None:
-        self.pheno_list.clear()
-        self.round_table.setRowCount(0)
-        self.label_selector.clear()
-        self.unit_table.setRowCount(0)
-        self.document_table.setRowCount(0)
-        self.document_preview.clear()
-        self.manual_reviewer_combo.clear()
-        self.manual_import_btn.setEnabled(False)
-        self.auto_import_btn.setEnabled(False)
-        self.import_status_label.clear()
-        self.current_round = None
-        self.current_reviewer_names = {}
-        self.assignment_paths = {}
-        self.unit_rows = []
-        self.round_manifest = {}
-        self.round_summary.setText("Select a round to review agreement metrics")
-        try:
-            db = self.ctx.require_db()
-        except RuntimeError:
-            return
-        with db.connect() as conn:
-            rows = conn.execute("SELECT pheno_id, name FROM phenotypes ORDER BY name").fetchall()
-        for row in rows:
-            item = QtWidgets.QListWidgetItem(f"{row['name']} ({row['pheno_id']})")
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, dict(row))
-            self.pheno_list.addItem(item)
-
-    def _on_pheno_selected(self) -> None:
-        items = self.pheno_list.selectedItems()
-        self.round_table.setRowCount(0)
-        self.label_selector.clear()
-        self.unit_table.setRowCount(0)
-        self.document_table.setRowCount(0)
-        self.document_preview.clear()
-        self.manual_reviewer_combo.clear()
-        self.manual_import_btn.setEnabled(False)
-        self.auto_import_btn.setEnabled(False)
-        self.import_status_label.clear()
+    def reset(self) -> None:
+        self.current_pheno = None
         self.current_round = None
         self.current_reviewer_names = {}
         self.assignment_paths = {}
@@ -909,10 +1203,28 @@ class IaaPage(QtWidgets.QWidget):
         self.label_lookup = {}
         self.label_order = []
         self.reviewer_column_order = []
-        if not items:
+        self.round_table.setRowCount(0)
+        self.label_selector.clear()
+        self.unit_table.setRowCount(0)
+        self.document_table.setRowCount(0)
+        self.document_preview.clear()
+        self.manual_reviewer_combo.clear()
+        self.manual_import_btn.setEnabled(False)
+        self.auto_import_btn.setEnabled(False)
+        self.import_status_label.clear()
+        self.round_summary.setText("Select a round to review agreement metrics")
+
+    def set_phenotype(self, pheno: Optional[Dict[str, object]]) -> None:
+        self.reset()
+        if not pheno:
             return
-        pheno = items[0].data(QtCore.Qt.ItemDataRole.UserRole) or {}
-        pheno_id = pheno.get("pheno_id")
+        self.current_pheno = pheno
+        self._load_rounds()
+
+    def _load_rounds(self) -> None:
+        if not self.current_pheno:
+            return
+        pheno_id = self.current_pheno.get("pheno_id")
         if not pheno_id:
             return
         db = self.ctx.require_db()
@@ -922,158 +1234,110 @@ class IaaPage(QtWidgets.QWidget):
                 (pheno_id,),
             ).fetchall()
         self.round_table.setRowCount(len(rounds))
-        for row_index, round_row in enumerate(rounds):
-            with db.connect() as conn:
-                reviewers = conn.execute(
-                    """
-                    SELECT reviewers.reviewer_id, reviewers.name
-                    FROM assignments
-                    JOIN reviewers ON reviewers.reviewer_id = assignments.reviewer_id
-                    WHERE assignments.round_id=?
-                    ORDER BY reviewers.name
-                    """,
-                    (round_row["round_id"],),
-                ).fetchall()
-            reviewer_names = ", ".join(r["name"] for r in reviewers) or "No reviewers"
-            round_item = QtWidgets.QTableWidgetItem(f"Round {round_row['round_number']}")
-            round_item.setData(
-                QtCore.Qt.ItemDataRole.UserRole,
-                {
-                    "pheno_id": pheno_id,
-                    "round_id": round_row["round_id"],
-                    "round_number": round_row["round_number"],
-                    "status": round_row["status"],
-                    "labelset_id": round_row["labelset_id"],
-                    "reviewers": [dict(r) for r in reviewers],
-                },
-            )
-            status_item = QtWidgets.QTableWidgetItem(round_row["status"])
-            reviewers_item = QtWidgets.QTableWidgetItem(reviewer_names)
-            self.round_table.setItem(row_index, 0, round_item)
-            self.round_table.setItem(row_index, 1, status_item)
-            self.round_table.setItem(row_index, 2, reviewers_item)
-        self.round_table.resizeColumnsToContents()
-        if self.round_table.rowCount():
-            self.round_table.setCurrentCell(0, 0)
+        for row_idx, round_row in enumerate(rounds):
+            item = QtWidgets.QTableWidgetItem(f"Round {round_row['round_number']}")
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, dict(round_row))
+            self.round_table.setItem(row_idx, 0, item)
+            self.round_table.setItem(row_idx, 1, QtWidgets.QTableWidgetItem(round_row["status"]))
+            self.round_table.setItem(row_idx, 2, QtWidgets.QTableWidgetItem(round_row["labelset_id"]))
+        if rounds:
+            self.round_table.selectRow(0)
+        else:
+            self._on_round_selected()
 
     def _on_round_selected(self) -> None:
         items = self.round_table.selectedItems()
+        if not items:
+            self.current_round = None
+            self.label_selector.clear()
+            self.unit_table.setRowCount(0)
+            self.document_table.setRowCount(0)
+            self.document_preview.clear()
+            self.manual_reviewer_combo.clear()
+            self.manual_import_btn.setEnabled(False)
+            self.auto_import_btn.setEnabled(False)
+            self.import_status_label.clear()
+            self.round_summary.setText("Select a round to review agreement metrics")
+            return
+        round_meta = items[0].data(QtCore.Qt.ItemDataRole.UserRole) or {}
+        self.current_round = round_meta
+        pheno_id = round_meta.get("pheno_id") or (self.current_pheno or {}).get("pheno_id")
+        if pheno_id:
+            self.current_round["pheno_id"] = pheno_id
+        self._load_round_details()
+
+    def _load_round_details(self) -> None:
+        if not self.current_round:
+            return
+        round_id = self.current_round.get("round_id")
+        if not round_id:
+            return
+        db = self.ctx.require_db()
+        with db.connect() as conn:
+            reviewers = conn.execute(
+                "SELECT reviewer_id, name FROM reviewers WHERE reviewer_id IN (SELECT reviewer_id FROM assignments WHERE round_id=?)",
+                (round_id,),
+            ).fetchall()
+            labels = conn.execute(
+                "SELECT labels.label_id, labels.name FROM labels JOIN label_sets ON label_sets.labelset_id = labels.labelset_id "
+                "WHERE label_sets.labelset_id=? ORDER BY labels.order_index",
+                (self.current_round.get("labelset_id"),),
+            ).fetchall()
+        self.current_reviewer_names = {row["reviewer_id"]: row["name"] for row in reviewers}
+        self.current_round["reviewers"] = [
+            {"reviewer_id": row["reviewer_id"], "name": row["name"]} for row in reviewers
+        ]
+        self.manual_reviewer_combo.clear()
+        for reviewer in reviewers:
+            self.manual_reviewer_combo.addItem(reviewer["name"], reviewer["reviewer_id"])
+        self.manual_import_btn.setEnabled(bool(reviewers))
+        self.auto_import_btn.setEnabled(True)
         self.label_selector.clear()
-        self.unit_table.setRowCount(0)
-        self.document_table.setRowCount(0)
-        self.document_preview.clear()
+        self.label_lookup = {row["label_id"]: row["name"] for row in labels}
+        self.label_order = [row["label_id"] for row in labels]
+        for row in labels:
+            self.label_selector.addItem(row["name"], row["label_id"])
         self.assignment_paths = {}
         self.unit_rows = []
         self.round_manifest = {}
-        self.label_lookup = {}
-        self.label_order = []
-        if not items:
-            self.current_round = None
-            self.round_summary.setText("Select a round to review agreement metrics")
-            return
-        round_data = items[0].data(QtCore.Qt.ItemDataRole.UserRole)
-        if not round_data:
-            self.current_round = None
-            self.round_summary.setText("Select a round to review agreement metrics")
-            return
-        self.current_round = round_data
-        reviewers = round_data.get("reviewers", [])
-        self.current_reviewer_names = {rev["reviewer_id"]: rev["name"] for rev in reviewers if "reviewer_id" in rev}
-        self.reviewer_column_order = sorted(
-            self.current_reviewer_names.keys(), key=lambda rid: self.current_reviewer_names[rid].lower()
-        )
-        self.manual_reviewer_combo.clear()
-        for reviewer in reviewers:
-            reviewer_id = reviewer.get("reviewer_id")
-            if not reviewer_id:
-                continue
-            display = reviewer.get("name") or reviewer_id
-            self.manual_reviewer_combo.addItem(display, reviewer_id)
-        has_reviewers = self.manual_reviewer_combo.count() > 0
-        self.manual_import_btn.setEnabled(has_reviewers)
-        self.auto_import_btn.setEnabled(has_reviewers)
-        summary_parts = [
-            f"Round {round_data.get('round_number')}",
-            round_data.get("status", ""),
-            ", ".join(self.current_reviewer_names.values()) or "No reviewers",
-        ]
-        self.round_summary.setText(" • ".join(part for part in summary_parts if part))
-        db = self.ctx.require_db()
-        with db.connect() as conn:
-            labels = conn.execute(
-                "SELECT label_id, name FROM labels WHERE labelset_id=? ORDER BY order_index",
-                (round_data.get("labelset_id"),),
-            ).fetchall()
-        for label in labels:
-            display = label["name"]
-            self.label_selector.addItem(display, label["label_id"])
-        self.label_lookup = {label["label_id"]: label["name"] for label in labels}
-        self.label_order = [label["label_id"] for label in labels]
-        if self.label_selector.count():
-            self.label_selector.setCurrentIndex(0)
-        round_dir = self._resolve_round_dir()
-        if round_dir:
-            self.round_manifest = self._load_manifest(round_dir)
-            self._discover_existing_imports(round_dir)
+        self.reviewer_column_order = []
+        self.import_status_label.clear()
+        self.round_summary.setText("Assignments not yet imported for this round.")
+        self._auto_discover_imports()
         self._refresh_units_table()
-        if has_reviewers:
-            self._auto_import_submissions(silent=True)
+
+    def _auto_discover_imports(self) -> None:
+        round_dir = self._resolve_round_dir()
+        if not round_dir:
+            return
+        self._discover_existing_imports(round_dir)
+        if self.assignment_paths:
+            self.import_status_label.setText("Detected existing assignment imports.")
 
     def _on_auto_import_clicked(self) -> None:
         if not self.current_round:
-            QtWidgets.QMessageBox.information(
-                self, "Assignment import", "Select a round to import submissions."
-            )
+            QtWidgets.QMessageBox.information(self, "Assignment import", "Select a round before importing.")
             return
-        self._auto_import_submissions(silent=False)
+        round_dir = self._resolve_round_dir()
+        if not round_dir:
+            QtWidgets.QMessageBox.warning(self, "Assignment import", "Round directory unavailable.")
+            return
+        self._import_round_assignments(round_dir, silent=False)
 
-    def _auto_import_submissions(self, silent: bool) -> None:
-        if not self.current_round:
-            if not silent:
-                QtWidgets.QMessageBox.information(
-                    self, "Assignment import", "Select a round to import submissions."
-                )
-            return
-        try:
-            project_root = self.ctx.require_project()
-        except RuntimeError:
-            message = "Project directory is not available."
-            self.import_status_label.setText(message)
-            if not silent:
-                QtWidgets.QMessageBox.warning(self, "Assignment import", message)
-            return
-        pheno_id = self.current_round.get("pheno_id")
-        round_number = self.current_round.get("round_number")
-        if not pheno_id or round_number is None:
-            message = "Round metadata is incomplete."
-            self.import_status_label.setText(message)
-            if not silent:
-                QtWidgets.QMessageBox.warning(self, "Assignment import", message)
-            return
-        round_dir = project_root / "phenotypes" / pheno_id / "rounds" / f"round_{round_number}"
+    def _import_round_assignments(self, round_dir: Path, silent: bool = False) -> None:
         statuses: List[str] = []
         errors = 0
         for reviewer in self.current_round.get("reviewers", []):
             reviewer_id = reviewer.get("reviewer_id")
-            display_name = reviewer.get("name") or reviewer_id or "Unknown reviewer"
             if not reviewer_id:
                 continue
-            assignment_dir = round_dir / "assignments" / reviewer_id
-            submitted_path = assignment_dir / "submitted.json"
-            assignment_db = assignment_dir / "assignment.db"
-            if not assignment_dir.exists():
-                statuses.append(f"{display_name}: assignment folder missing")
-                errors += 1
-                continue
-            if not submitted_path.exists():
-                statuses.append(f"{display_name}: awaiting submission")
-                continue
-            if not assignment_db.exists():
-                statuses.append(f"{display_name}: assignment.db missing")
-                errors += 1
+            display_name = reviewer.get("name", reviewer_id)
+            src = round_dir / "imports" / f"{reviewer_id}_assignment.db"
+            if not src.exists():
+                statuses.append(f"{display_name}: no submission found")
                 continue
             try:
-                target_path = self._copy_assignment_to_imports(reviewer_id, assignment_db)
+                target_path = self._copy_assignment_to_imports(reviewer_id, src)
             except Exception as exc:  # noqa: BLE001
                 statuses.append(f"{display_name}: import failed ({exc})")
                 errors += 1
@@ -1091,15 +1355,11 @@ class IaaPage(QtWidgets.QWidget):
 
     def _manual_import_assignment(self) -> None:
         if not self.current_round:
-            QtWidgets.QMessageBox.information(
-                self, "Assignment import", "Select a round before importing."
-            )
+            QtWidgets.QMessageBox.information(self, "Assignment import", "Select a round before importing.")
             return
         reviewer_id = self.manual_reviewer_combo.currentData()
         if not reviewer_id:
-            QtWidgets.QMessageBox.information(
-                self, "Assignment import", "Select a reviewer to import."
-            )
+            QtWidgets.QMessageBox.information(self, "Assignment import", "Select a reviewer to import.")
             return
         start_dir = str(self.ctx.project_root or Path.home())
         path_str, _ = QtWidgets.QFileDialog.getOpenFileName(
@@ -1396,83 +1656,86 @@ class IaaPage(QtWidgets.QWidget):
         if not doc_rows:
             return
         metadata: Dict[str, sqlite3.Row] = {}
-        try:
-            corpus_db = self.ctx.require_corpus_db()
-        except RuntimeError:
-            corpus_db = None
+        corpus_db: Optional[Database] = None
+        pheno_id = (self.current_pheno or {}).get("pheno_id")
+        if pheno_id:
+            try:
+                corpus_db = self.ctx.get_corpus_db(pheno_id)
+            except Exception:
+                corpus_db = None
         if corpus_db:
             with corpus_db.connect() as conn:
-                for doc_row in doc_rows:
-                    doc_id = doc_row["doc_id"]
-                    if not doc_id or doc_id in metadata:
-                        continue
-                    metadata[doc_id] = conn.execute(
-                        "SELECT doc_id, notetype, date_note, sta3n FROM documents WHERE doc_id=?",
-                        (doc_id,),
-                    ).fetchone()
+                placeholders = ",".join(["?"] * len(doc_rows))
+                rows = conn.execute(
+                    f"SELECT doc_id, notetype, date_note, sta3n FROM documents WHERE doc_id IN ({placeholders})",
+                    [row["doc_id"] for row in doc_rows],
+                ).fetchall()
+            metadata = {row["doc_id"]: row for row in rows}
         self.document_table.setRowCount(len(doc_rows))
-        for row_index, doc_row in enumerate(doc_rows):
-            doc_id = doc_row["doc_id"] or ""
-            meta = metadata.get(doc_row["doc_id"])
-            payload = {
-                "doc_id": doc_id,
-                "text": doc_row["text"] or "",
-            }
-            if meta:
-                payload.update(
-                    {
-                        "notetype": meta["notetype"],
-                        "date_note": meta["date_note"],
-                        "sta3n": meta["sta3n"],
-                    }
-                )
-            doc_item = QtWidgets.QTableWidgetItem(doc_id or "—")
-            doc_item.setData(QtCore.Qt.ItemDataRole.UserRole, payload)
-            type_item = QtWidgets.QTableWidgetItem(meta["notetype"] if meta else "")
-            date_item = QtWidgets.QTableWidgetItem(meta["date_note"] if meta else "")
-            facility_item = QtWidgets.QTableWidgetItem(meta["sta3n"] if meta else "")
-            self.document_table.setItem(row_index, 0, doc_item)
-            self.document_table.setItem(row_index, 1, type_item)
-            self.document_table.setItem(row_index, 2, date_item)
-            self.document_table.setItem(row_index, 3, facility_item)
+        for idx, doc_row in enumerate(doc_rows):
+            doc_id = doc_row["doc_id"]
+            meta = metadata.get(doc_id)
+            values = [
+                doc_id,
+                meta["notetype"] if meta else "—",
+                meta["date_note"] if meta else "—",
+                meta["sta3n"] if meta else "—",
+            ]
+            for col, value in enumerate(values):
+                self.document_table.setItem(idx, col, QtWidgets.QTableWidgetItem(str(value)))
         self.document_table.resizeColumnsToContents()
-        if self.document_table.rowCount():
+        if doc_rows:
             self.document_table.selectRow(0)
-            self._on_document_selected()
+            self.document_preview.setPlainText(doc_rows[0]["text"] or "")
 
     def _on_document_selected(self) -> None:
-        row = self.document_table.currentRow()
-        if row < 0:
+        current_row = self.document_table.currentRow()
+        if current_row < 0:
             self.document_preview.clear()
             return
-        item = self.document_table.item(row, 0)
-        if not item:
+        unit_index = self._selected_unit_index()
+        if unit_index is None or unit_index >= len(self.unit_rows):
             self.document_preview.clear()
             return
-        payload = item.data(QtCore.Qt.ItemDataRole.UserRole) or {}
-        text = payload.get("text") or ""
-        self.document_preview.setPlainText(text if text else "Document text not found.")
+        reviewer_ids = self.unit_rows[unit_index].get("reviewer_ids") or []
+        assignment_path: Optional[Path] = None
+        for reviewer_id in reviewer_ids:
+            candidate = self.assignment_paths.get(reviewer_id)
+            if candidate and candidate.exists():
+                assignment_path = candidate
+                break
+        if not assignment_path:
+            self.document_preview.clear()
+            return
+        unit_id = self.unit_rows[unit_index].get("unit_id")
+        if not unit_id:
+            self.document_preview.clear()
+            return
+        with sqlite3.connect(assignment_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT documents.text FROM unit_notes JOIN documents ON documents.doc_id = unit_notes.doc_id "
+                "WHERE unit_notes.unit_id=? ORDER BY unit_notes.order_index LIMIT 1 OFFSET ?",
+                (unit_id, current_row),
+            ).fetchone()
+        if row:
+            self.document_preview.setPlainText(row["text"] or "")
+        else:
+            self.document_preview.clear()
 
-    def _is_overlap_unit(self, unit_id: str, reviewer_ids: List[str]) -> bool:
-        manifest_entry = self.round_manifest.get(unit_id)
-        if not manifest_entry:
-            return False
-        return all(manifest_entry.get(reviewer_id) for reviewer_id in reviewer_ids)
+    def _is_overlap_unit(self, unit_id: str, reviewer_ids: Iterable[str]) -> bool:
+        if self.round_manifest.get(unit_id):
+            return any(self.round_manifest[unit_id].get(rid) for rid in reviewer_ids)
+        return len(set(reviewer_ids)) > 1
 
-    def _apply_discord_flags(self, discordant_units: Set[str]) -> None:
-        selected_unit = self._selected_unit_id()
-        updated = False
+    def _apply_discord_flags(self, discordant_ids: Set[str]) -> None:
         for row in self.unit_rows:
-            flag = row["unit_id"] in discordant_units
-            if row.get("discord") != flag:
-                row["discord"] = flag
-                updated = True
-        if updated or selected_unit:
-            self._display_unit_rows(selected_unit)
+            row["discord"] = row["unit_id"] in discordant_ids
+        self._display_unit_rows()
 
     def _compute_agreement(self) -> None:
         if not self.current_round:
-            QtWidgets.QMessageBox.information(self, "IAA", "Select a round before calculating agreement")
+            QtWidgets.QMessageBox.warning(self, "IAA", "Select a round first.")
             return
         label_id = self.label_selector.currentData()
         if not label_id:
@@ -1587,12 +1850,13 @@ class IaaPage(QtWidgets.QWidget):
         return ""
 
 
+
 class AdminMainWindow(QtWidgets.QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.ctx = ProjectContext()
         self.setWindowTitle("VAAnnotate Admin")
-        self.resize(1200, 800)
+        self.resize(1280, 860)
         self._setup_menu()
         self._setup_central()
 
@@ -1606,37 +1870,74 @@ class AdminMainWindow(QtWidgets.QMainWindow):
 
     def _setup_central(self) -> None:
         splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
-        nav_widget = QtWidgets.QListWidget()
-        nav_widget.addItems(["Projects", "Phenotypes", "Rounds", "Corpus", "IAA"])
-        nav_widget.currentRowChanged.connect(self._switch_page)
-        splitter.addWidget(nav_widget)
+        self.tree = ProjectTreeWidget(self.ctx)
+        splitter.addWidget(self.tree)
 
         self.stack = QtWidgets.QStackedWidget()
-        self.pages = [
-            ProjectsPage(self.ctx),
-            PhenotypePage(self.ctx),
-            RoundPage(self.ctx),
-            CorpusOverviewPage(self.ctx),
-            IaaPage(self.ctx),
-        ]
-        for page in self.pages:
-            self.stack.addWidget(page)
+        self.project_view = ProjectOverviewWidget(self.ctx)
+        self.pheno_view = PhenotypeDetailWidget()
+        self.round_view = RoundDetailWidget()
+        self.corpus_view = CorpusWidget(self.ctx)
+        self.iaa_view = IaaWidget(self.ctx)
+        self.stack.addWidget(self.project_view)
+        self.stack.addWidget(self.pheno_view)
+        self.stack.addWidget(self.round_view)
+        self.stack.addWidget(self.corpus_view)
+        self.stack.addWidget(self.iaa_view)
         splitter.addWidget(self.stack)
-        splitter.setStretchFactor(1, 5)
-        nav_widget.setCurrentRow(0)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 3)
         self.setCentralWidget(splitter)
 
-    def _switch_page(self, index: int) -> None:
+        self.view_index = {
+            "project": self.stack.indexOf(self.project_view),
+            "phenotype": self.stack.indexOf(self.pheno_view),
+            "round": self.stack.indexOf(self.round_view),
+            "corpus": self.stack.indexOf(self.corpus_view),
+            "iaa": self.stack.indexOf(self.iaa_view),
+        }
+        self.tree.node_selected.connect(self._on_node_selected)
+
+    def _show_view(self, key: str) -> None:
+        index = self.view_index.get(key, self.view_index["project"])
         self.stack.setCurrentIndex(index)
-        self.pages[index].refresh()
+
+    def _on_node_selected(self, data: Dict[str, object]) -> None:
+        node_type = data.get("type")
+        if node_type == "project":
+            self.project_view.set_project(data.get("project"))
+            self._show_view("project")
+        elif node_type == "phenotype":
+            pheno = data.get("pheno")
+            self.pheno_view.set_phenotype(pheno if isinstance(pheno, dict) else None)
+            self._show_view("phenotype")
+        elif node_type == "round":
+            round_row = data.get("round")
+            if isinstance(round_row, dict):
+                config = self.ctx.get_round_config(round_row.get("round_id", ""))
+                self.round_view.set_round(round_row, config)
+            else:
+                self.round_view.set_round(None, None)
+            self._show_view("round")
+        elif node_type == "corpus":
+            pheno = data.get("pheno")
+            self.corpus_view.set_phenotype(pheno if isinstance(pheno, dict) else None)
+            self._show_view("corpus")
+        elif node_type == "iaa":
+            pheno = data.get("pheno")
+            self.iaa_view.set_phenotype(pheno if isinstance(pheno, dict) else None)
+            self._show_view("iaa")
+        else:
+            self.project_view.set_project(self.ctx.project_row)
+            self._show_view("project")
 
     def _open_project(self) -> None:
         directory = QtWidgets.QFileDialog.getExistingDirectory(self, "Select project folder")
         if not directory:
             return
         self.ctx.open_project(Path(directory))
-        for page in self.pages:
-            page.refresh()
+        self.project_view.set_project(self.ctx.project_row)
+        self.tree.refresh()
 
 
 def run() -> None:

--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -23,6 +23,7 @@ PROJECT_SCHEMA = [
         name TEXT NOT NULL,
         level TEXT NOT NULL CHECK(level IN ('single_doc','multi_doc')),
         description TEXT,
+        corpus_path TEXT NOT NULL,
         UNIQUE(project_id, name)
     );
     """,

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -97,6 +97,7 @@ class Phenotype(Record):
     name: str
     level: str
     description: str
+    corpus_path: str
 
     __tablename__ = "phenotypes"
     __schema__ = (
@@ -107,6 +108,7 @@ class Phenotype(Record):
             name TEXT NOT NULL,
             level TEXT CHECK(level IN ('single_doc','multi_doc')) NOT NULL,
             description TEXT NOT NULL,
+            corpus_path TEXT NOT NULL,
             UNIQUE(project_id, name),
             FOREIGN KEY(project_id) REFERENCES projects(project_id)
         )


### PR DESCRIPTION
## Summary
- refactor the Admin application around a project tree with context menus and streamlined detail panels
- require a corpus selection when creating phenotypes and persist the corpus path per phenotype throughout the backend
- update round generation, IAA tooling, CLI helpers, seed data, and documentation to reflect the new per-phenotype corpus model

## Testing
- python -m compileall vaannotate

------
https://chatgpt.com/codex/tasks/task_e_68ddf5e8f44c8327ab08302ba413d981