### PR TITLE
Fix phenotype selection carryover and improve IAA agreement tools

### DIFF
--- a/tests/test_admin_agreement.py
+++ b/tests/test_admin_agreement.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    from PySide6 import QtWidgets
+except ImportError:  # pragma: no cover - handled via skip
+    pytest.skip("PySide6 is not available", allow_module_level=True)
+
+from vaannotate.AdminApp.main import AgreementSample, IaaWidget, ProjectContext
+
+
+@pytest.fixture(scope="module")
+def qt_app() -> QtWidgets.QApplication:
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def test_prepare_agreement_samples_detects_discord(qt_app: QtWidgets.QApplication) -> None:
+    widget = IaaWidget(ProjectContext())
+    widget.round_manifest = {
+        "unit-1": {"r1": True, "r2": True},
+        "unit-2": {"r1": True, "r2": True},
+        "unit-3": {"r1": False, "r2": False},
+    }
+    values_by_unit = {
+        "unit-1": {"r1": "Yes", "r2": "No"},
+        "unit-2": {"r1": "No", "r2": "No"},
+        "unit-3": {"r1": "Yes"},
+    }
+
+    samples, discordant, reviewers = widget._prepare_agreement_samples(values_by_unit)
+
+    assert {sample.unit_id for sample in samples} == {"unit-1", "unit-2"}
+    assert discordant == {"unit-1"}
+    assert reviewers == ["r1", "r2"]
+
+    # Samples preserve reviewer ordering for downstream metrics
+    assert all(isinstance(sample, AgreementSample) for sample in samples)
+    assert all(sample.reviewer_ids == ("r1", "r2") for sample in samples)
+
+    widget.deleteLater()
+

--- a/tests/test_client_annotation_form.py
+++ b/tests/test_client_annotation_form.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    from PySide6 import QtGui, QtWidgets
+except ImportError:  # pragma: no cover - handled via skip
+    pytest.skip("PySide6 is not available", allow_module_level=True)
+
+from vaannotate.ClientApp.main import AnnotationForm, AssignmentContext, LabelDefinition
+
+
+@pytest.fixture(scope="module")
+def qt_app() -> QtWidgets.QApplication:
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def _dummy_cursor() -> QtGui.QTextCursor:
+    document = QtGui.QTextDocument()
+    return QtGui.QTextCursor(document)
+
+
+def test_boolean_selection_clears_between_units(qt_app: QtWidgets.QApplication) -> None:
+    ctx = AssignmentContext()
+    form = AnnotationForm(ctx, _dummy_cursor, lambda: None)
+
+    label = LabelDefinition(
+        label_id="has_pheno",
+        name="Has phenotype",
+        type="boolean",
+        required=False,
+        na_allowed=False,
+        rules="",
+        unit=None,
+        value_range=None,
+        gating_expr=None,
+        options=[
+            {"value": "yes", "display": "Yes"},
+            {"value": "no", "display": "No"},
+        ],
+    )
+
+    form.set_schema([label])
+    form.load_unit("unit-1", {label.label_id: {"value": "yes"}})
+    widgets = form.label_widgets[label.label_id]
+    group: QtWidgets.QButtonGroup = widgets["button_group"]  # type: ignore[index]
+    checked_buttons = [button for button in group.buttons() if button.isChecked()]
+    assert len(checked_buttons) == 1
+    assert checked_buttons[0].property("option_value") == "yes"
+
+    form.load_unit("unit-2", {})
+    assert all(not button.isChecked() for button in group.buttons())
+

--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -403,10 +403,11 @@ class AnnotationForm(QtWidgets.QScrollArea):
     def _reset_widgets(self, widgets: Dict[str, object]) -> None:
         if "button_group" in widgets:
             group: QtWidgets.QButtonGroup = widgets["button_group"]  # type: ignore[assignment]
+            was_exclusive = group.exclusive()
+            group.setExclusive(False)
             for button in group.buttons():
-                button.setAutoExclusive(False)
                 button.setChecked(False)
-                button.setAutoExclusive(True)
+            group.setExclusive(was_exclusive)
         if "checkboxes" in widgets:
             for cb in widgets["checkboxes"]:  # type: ignore[index]
                 cb.setChecked(False)


### PR DESCRIPTION
## Summary
- ensure boolean radio groups in the annotator client fully clear when loading a new unit
- refactor the IAA agreement workflow to derive overlap samples correctly, improve discordant detection, and reposition the document preview to a right-hand pane
- add regression tests covering the annotation form reset logic and the agreement sample preparation (skipped when PySide6 is unavailable)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de7b794c648327a2dc0299e1be8b4f