### PR TITLE
Fix annotation reset and enhance IAA agreement display

### DIFF
--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -406,7 +406,13 @@ class AnnotationForm(QtWidgets.QScrollArea):
             was_exclusive = group.exclusive()
             group.setExclusive(False)
             for button in group.buttons():
-                button.setChecked(False)
+                if hasattr(button, "autoExclusive"):
+                    was_auto = button.autoExclusive()
+                    button.setAutoExclusive(False)
+                    button.setChecked(False)
+                    button.setAutoExclusive(was_auto)
+                else:
+                    button.setChecked(False)
             group.setExclusive(was_exclusive)
         if "checkboxes" in widgets:
             for cb in widgets["checkboxes"]:  # type: ignore[index]


### PR DESCRIPTION
## Summary
- ensure radio button resets in the client form fully clear selections when switching units
- reorganize the IAA view so the document pane spans the full height and agreement results highlight discordant units per label

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de811bc2f883279b36af0f359736e6