### PR TITLE
Enhance round creation workflows

### DIFF
--- a/vaannotate/shared/sampling.py
+++ b/vaannotate/shared/sampling.py
@@ -148,7 +148,7 @@ def write_manifest(path: Path, assignments: Dict[str, ReviewerAssignment]) -> No
         writer.writeheader()
         for reviewer_id, assignment in assignments.items():
             for unit in assignment.units:
-                row = dict(unit)
+                row = {key: unit.get(key, "") for key in fieldnames}
                 row["assigned_to"] = reviewer_id
                 writer.writerow(row)
 


### PR DESCRIPTION
## Summary
- integrate reviewer management directly into the round builder with support for existing and new reviewers
- convert the label set field to a dropdown, embed label schema metadata in saved configs, and surface label details in the round summary
- extend the toy project seed data with reusable label set definitions and fix manifest writing when extra fields are present

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de85baa9988327bac0c9d064a55af3