### PR TITLE
Fix multi-doc round sampling and client note view refresh

### DIFF
--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -172,6 +172,13 @@ ASSIGNMENT_SCHEMA = [
     );
     """,
     """
+    CREATE TABLE IF NOT EXISTS documents(
+        doc_id TEXT PRIMARY KEY,
+        hash TEXT NOT NULL,
+        text TEXT NOT NULL
+    );
+    """,
+    """
     CREATE TABLE IF NOT EXISTS annotations(
         unit_id TEXT NOT NULL,
         label_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- ensure the round builder populates assignment units with the correct display unit data and persisted documents
- fix the client UI to show patient-based units for multi-doc phenotypes and refresh the note preview when rows change
- add coverage verifying multi-document rounds write patient-level assignments

## Testing
- pytest tests/test_round_import.py

------
https://chatgpt.com/codex/tasks/task_e_68de8fea24a4832799f4f69e78da51c4