### PR TITLE
Add label set wizard and fix phenotype directory naming

### DIFF
--- a/tests/test_round_import.py
+++ b/tests/test_round_import.py
@@ -51,6 +51,7 @@ def seeded_project(tmp_path: Path) -> tuple[RoundBuilder, Path]:
         add_labelset(
             conn,
             labelset_id="ls_test",
+            project_id="proj",
             pheno_id="ph_test",
             version=1,
             created_by="tester",
@@ -148,6 +149,7 @@ def test_multi_doc_round_uses_patient_display_unit(tmp_path: Path) -> None:
         add_labelset(
             conn,
             labelset_id="ls_multi",
+            project_id="proj",
             pheno_id="ph_multi",
             version=1,
             created_by="tester",

--- a/tools/seed_toy_project.py
+++ b/tools/seed_toy_project.py
@@ -425,6 +425,7 @@ def seed_metadata(project_db: Path, corpus_paths: Dict[str, str]) -> None:
         add_labelset(
             conn,
             labelset_id="ls_diabetes_v1",
+            project_id="Project_Toy",
             pheno_id="ph_diabetes",
             version=1,
             created_by="toy_seed",
@@ -443,6 +444,7 @@ def seed_metadata(project_db: Path, corpus_paths: Dict[str, str]) -> None:
         add_labelset(
             conn,
             labelset_id="ls_htn_v1",
+            project_id="Project_Toy",
             pheno_id="ph_hypertension",
             version=1,
             created_by="toy_seed",

--- a/vaannotate/project.py
+++ b/vaannotate/project.py
@@ -82,7 +82,8 @@ def add_labelset(
     conn: sqlite3.Connection,
     *,
     labelset_id: str,
-    pheno_id: str,
+    project_id: str,
+    pheno_id: str | None,
     version: int,
     created_by: str,
     notes: str | None,
@@ -90,8 +91,12 @@ def add_labelset(
 ) -> None:
     created_at = datetime.utcnow().isoformat()
     conn.execute(
-        "INSERT OR REPLACE INTO label_sets(labelset_id, pheno_id, version, created_at, created_by, notes) VALUES (?,?,?,?,?,?)",
-        (labelset_id, pheno_id, version, created_at, created_by, notes),
+        """
+        INSERT OR REPLACE INTO label_sets(
+            labelset_id, project_id, pheno_id, version, created_at, created_by, notes
+        ) VALUES (?,?,?,?,?,?,?)
+        """,
+        (labelset_id, project_id, pheno_id, version, created_at, created_by, notes),
     )
     for idx, label in enumerate(labels):
         label_id = label["label_id"]

--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -30,11 +30,14 @@ PROJECT_SCHEMA = [
     """
     CREATE TABLE IF NOT EXISTS label_sets(
         labelset_id TEXT PRIMARY KEY,
-        pheno_id TEXT NOT NULL,
+        project_id TEXT NOT NULL,
+        pheno_id TEXT,
         version INTEGER NOT NULL,
         created_at TEXT NOT NULL,
         created_by TEXT NOT NULL,
-        notes TEXT
+        notes TEXT,
+        FOREIGN KEY(project_id) REFERENCES projects(project_id),
+        FOREIGN KEY(pheno_id) REFERENCES phenotypes(pheno_id)
     );
     """,
     """

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -119,7 +119,8 @@ class Phenotype(Record):
 @dataclass
 class LabelSet(Record):
     labelset_id: str
-    pheno_id: str
+    project_id: str
+    pheno_id: Optional[str]
     version: int
     created_at: str
     created_by: str
@@ -130,12 +131,14 @@ class LabelSet(Record):
         """
         CREATE TABLE IF NOT EXISTS label_sets (
             labelset_id TEXT PRIMARY KEY,
-            pheno_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            pheno_id TEXT NULL,
             version INTEGER NOT NULL,
             created_at TEXT NOT NULL,
             created_by TEXT NOT NULL,
             notes TEXT NOT NULL,
-            FOREIGN KEY(pheno_id) REFERENCES phenotypes(pheno_id)
+            FOREIGN KEY(pheno_id) REFERENCES phenotypes(pheno_id),
+            FOREIGN KEY(project_id) REFERENCES projects(project_id)
         )
         """
     )


### PR DESCRIPTION
## Summary
- add a project-level label set wizard to the admin UI with reusable label schemas
- scope label sets to the project in the database and refresh round configuration options accordingly
- create phenotype directories using readable names and update path resolution helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dea6315a208327bb8450b85b7c91a1