### PR TITLE
Handle sqlite row level lookup

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -932,7 +932,18 @@ class RoundBuilderDialog(QtWidgets.QDialog):
 
     def _load_reviewed_unit_ids(self) -> Set[str]:
         pheno_id = self.pheno_row["pheno_id"]
-        level = str(self.pheno_row.get("level", "single_doc"))
+        if isinstance(self.pheno_row, sqlite3.Row):
+            level_value: Optional[object] = None
+            try:
+                if "level" in self.pheno_row.keys():
+                    level_value = self.pheno_row["level"]
+            except Exception:
+                level_value = None
+        else:
+            level_value = self.pheno_row.get("level")
+        if not level_value:
+            level_value = "single_doc"
+        level = str(level_value)
         reviewed: Set[str] = set()
         try:
             rounds = self.ctx.list_rounds(pheno_id)


### PR DESCRIPTION
## Summary
- handle phenotype rows that arrive as sqlite3.Row objects when determining the round level
- fall back to the default single document level when the level column is missing or empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded4ab276c8327a10ad33693bad046