### PR TITLE
Implement in-memory caching and explicit save flow for Admin app

### DIFF
--- a/vaannotate/shared/database.py
+++ b/vaannotate/shared/database.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import sqlite3
+import uuid
 from dataclasses import fields, asdict
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Type, TypeVar
@@ -14,23 +15,55 @@ T = TypeVar("T", bound="Record")
 class Database:
     """A thin wrapper around sqlite3 with sane defaults for network shares.
 
-    The helper applies WAL journaling and NORMAL synchronous writes which are the
-    recommended settings for SQLite files that live on SMB shares.  Connections
-    are short lived; call :meth:`transaction` or :meth:`connect` to work with
-    them.
+    The helper applies WAL journaling and NORMAL synchronous writes which are
+    recommended settings for SQLite files that live on SMB shares.  The class
+    also supports loading the database into an in-memory cache so that callers
+    can operate on slow network files with minimal disk I/O; call
+    :meth:`enable_memory_cache` to opt in and :meth:`flush_to_disk` to persist
+    pending changes.
     """
 
     def __init__(self, path: Path | str) -> None:
         self.path = Path(path)
         if not self.path.parent.exists():
             self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._memory_uri: Optional[str] = None
+        self._memory_keeper: Optional[sqlite3.Connection] = None
+        self._cache_enabled = False
+        self._dirty = False
 
-    def connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.path)
+    def _apply_pragmas(self, conn: sqlite3.Connection) -> None:
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("PRAGMA foreign_keys=ON")
+
+    def enable_memory_cache(self) -> None:
+        """Load the SQLite file into a shared in-memory database."""
+
+        if self._cache_enabled:
+            return
+        cache_id = uuid.uuid4().hex
+        uri = f"file:vaannotate-cache-{cache_id}?mode=memory&cache=shared"
+        keeper = sqlite3.connect(uri, uri=True)
+        self._apply_pragmas(keeper)
+        if self.path.exists():
+            disk_conn = sqlite3.connect(self.path)
+            disk_conn.row_factory = sqlite3.Row
+            disk_conn.backup(keeper)
+            disk_conn.close()
+        self._memory_uri = uri
+        self._memory_keeper = keeper
+        self._cache_enabled = True
+        self._dirty = False
+
+    def connect(self) -> sqlite3.Connection:
+        if self._cache_enabled and self._memory_uri:
+            conn = sqlite3.connect(self._memory_uri, uri=True)
+            self._apply_pragmas(conn)
+            return conn
+        conn = sqlite3.connect(self.path)
+        self._apply_pragmas(conn)
         return conn
 
     @contextlib.contextmanager
@@ -39,11 +72,41 @@ class Database:
         try:
             yield conn
             conn.commit()
+            if self._cache_enabled and conn.total_changes:
+                self._dirty = True
         except Exception:
             conn.rollback()
             raise
         finally:
             conn.close()
+
+    def flush_to_disk(self) -> None:
+        """Persist pending changes from the in-memory cache to disk."""
+
+        if not self._cache_enabled or not self._memory_uri:
+            return
+        if not self._dirty and self.path.exists():
+            return
+        mem_conn = sqlite3.connect(self._memory_uri, uri=True)
+        self._apply_pragmas(mem_conn)
+        disk_conn = sqlite3.connect(self.path)
+        self._apply_pragmas(disk_conn)
+        mem_conn.backup(disk_conn)
+        disk_conn.close()
+        mem_conn.close()
+        self._dirty = False
+
+    def close(self) -> None:
+        if self._memory_keeper is not None:
+            self._memory_keeper.close()
+            self._memory_keeper = None
+        self._memory_uri = None
+        self._cache_enabled = False
+        self._dirty = False
+
+    @property
+    def is_dirty(self) -> bool:
+        return self._dirty
 
 
 class Record:


### PR DESCRIPTION
## Summary
- add optional in-memory caching and flush support to the shared Database helper to minimise repeated file I/O
- update the AdminApp project context to cache project, corpus, assignment, and aggregate data in memory while deferring writes until an explicit Save
- expose a Save action/unsaved indicator in the UI and reuse cached assignment data in IAA features to avoid redundant reads

## Testing
- pytest tests/test_admin_agreement.py

------
https://chatgpt.com/codex/tasks/task_e_68e062c46d04832786a526bf976ef8c6