### PR TITLE
Fix Admin preload handling of sqlite rows

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -262,15 +262,24 @@ class ProjectContext(QtCore.QObject):
         except Exception:  # noqa: BLE001
             return
         for pheno in phenotypes:
-            pheno_id = pheno.get("pheno_id")
+            pheno_id: Optional[object]
+            if isinstance(pheno, sqlite3.Row):
+                pheno_id = pheno["pheno_id"] if "pheno_id" in pheno.keys() else None
+            elif isinstance(pheno, Mapping):
+                pheno_id = pheno.get("pheno_id")
+            else:
+                try:
+                    pheno_id = pheno["pheno_id"]  # type: ignore[index]
+                except Exception:  # noqa: BLE001
+                    pheno_id = None
             if not pheno_id:
                 continue
             try:
-                self.get_corpus_db(pheno_id)
+                self.get_corpus_db(str(pheno_id))
             except Exception:  # noqa: BLE001
                 continue
             try:
-                pheno_dir = self.resolve_phenotype_dir(pheno_id)
+                pheno_dir = self.resolve_phenotype_dir(str(pheno_id))
             except Exception:  # noqa: BLE001
                 continue
             rounds_dir = pheno_dir / "rounds"


### PR DESCRIPTION
## Summary
- update Admin project's round preloading to handle sqlite3.Row objects returned from the database
- normalize phenotype identifiers before accessing corpus and round assets

## Testing
- pytest tests/test_round_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e067f1fb9c83279935893b8e817e81