### PR TITLE
Allow project-level corpus selection

### DIFF
--- a/tools/seed_toy_project.py
+++ b/tools/seed_toy_project.py
@@ -26,6 +26,7 @@ from vaannotate.corpus import normalize_text as corpus_normalize_text
 from vaannotate.project import (
     add_labelset,
     add_phenotype,
+    add_project_corpus,
     fetch_labelset,
     get_connection,
     init_project,
@@ -304,6 +305,7 @@ ROUND_CONFIGS = [
     {
         "pheno_id": "ph_diabetes",
         "labelset_id": "ls_diabetes_v1",
+        "corpus_id": "cor_ph_diabetes",
         "round_number": 1,
         "round_id": "ph_diabetes_r1",
         "created_by": "toy_seed",
@@ -331,6 +333,7 @@ ROUND_CONFIGS = [
     {
         "pheno_id": "ph_diabetes",
         "labelset_id": "ls_diabetes_v1",
+        "corpus_id": "cor_ph_diabetes",
         "round_number": 2,
         "round_id": "ph_diabetes_r2",
         "created_by": "toy_seed",
@@ -354,6 +357,7 @@ ROUND_CONFIGS = [
     {
         "pheno_id": "ph_diabetes",
         "labelset_id": "ls_diabetes_v1",
+        "corpus_id": "cor_ph_diabetes",
         "round_number": 3,
         "round_id": "ph_diabetes_r3",
         "created_by": "toy_seed",
@@ -378,6 +382,7 @@ ROUND_CONFIGS = [
     {
         "pheno_id": "ph_hypertension",
         "labelset_id": "ls_htn_v1",
+        "corpus_id": "cor_ph_hypertension",
         "round_number": 1,
         "round_id": "ph_hypertension_r1",
         "created_by": "toy_seed",
@@ -463,11 +468,21 @@ def seed_metadata(project_db: Path, corpus_paths: Dict[str, str]) -> None:
     with get_connection(project_db) as conn:
         for reviewer in REVIEWERS:
             register_reviewer(conn, **reviewer)
+
         def corpus_for(pheno_id: str) -> str:
             path = corpus_paths.get(pheno_id)
             if not path:
                 raise RuntimeError(f"Missing corpus path for {pheno_id}")
             return path
+
+        for pheno_id, path in corpus_paths.items():
+            add_project_corpus(
+                conn,
+                corpus_id=f"cor_{pheno_id}",
+                project_id="Project_Toy",
+                name=f"Corpus for {pheno_id}",
+                relative_path=path,
+            )
         add_phenotype(
             conn,
             pheno_id="ph_diabetes",
@@ -475,7 +490,7 @@ def seed_metadata(project_db: Path, corpus_paths: Dict[str, str]) -> None:
             name="Diabetes Phenotyping",
             level="multi_doc",
             description="Toy diabetes phenotype for demonstrations",
-            corpus_path=corpus_for("ph_diabetes"),
+            storage_path=str(Path(corpus_for("ph_diabetes")).parent.parent),
         )
         add_labelset(
             conn,
@@ -494,7 +509,7 @@ def seed_metadata(project_db: Path, corpus_paths: Dict[str, str]) -> None:
             name="Hypertension Phenotyping",
             level="single_doc",
             description="Toy hypertension phenotype for demonstrations",
-            corpus_path=corpus_for("ph_hypertension"),
+            storage_path=str(Path(corpus_for("ph_hypertension")).parent.parent),
         )
         add_labelset(
             conn,

--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -85,7 +85,7 @@ class ProjectBrowser:
         with get_connection(self.project_db) as conn:
             rows = conn.execute(
                 """
-                SELECT a.round_id, r.pheno_id, r.round_number, p.name AS phenotype_name, p.corpus_path
+                SELECT a.round_id, r.pheno_id, r.round_number, p.name AS phenotype_name, p.storage_path
                 FROM assignments AS a
                 JOIN rounds AS r ON a.round_id = r.round_id
                 JOIN phenotypes AS p ON r.pheno_id = p.pheno_id
@@ -107,7 +107,7 @@ class ProjectBrowser:
                 pheno_id,
                 round_number,
                 round_id,
-                str(row["corpus_path"] or ""),
+                str(row["storage_path"] or ""),
             )
             if not round_dir:
                 warnings.append(
@@ -139,9 +139,9 @@ class ProjectBrowser:
         pheno_id: str,
         round_number: Optional[int],
         round_id: str,
-        corpus_path: str,
+        storage_path: str,
     ) -> Optional[Path]:
-        rounds_root = self._resolve_rounds_root(pheno_id, corpus_path)
+        rounds_root = self._resolve_rounds_root(pheno_id, storage_path)
         if rounds_root is None:
             return None
         if round_number is not None:
@@ -165,14 +165,13 @@ class ProjectBrowser:
                 return candidate
         return None
 
-    def _resolve_rounds_root(self, pheno_id: str, corpus_path: str) -> Optional[Path]:
-        rounds_root: Optional[Path] = None
-        if corpus_path:
-            corpus = Path(corpus_path)
-            if not corpus.is_absolute():
-                corpus = (self.project_root / corpus).resolve()
-            phenotype_dir = corpus.parent.parent
-            rounds_root = phenotype_dir / "rounds"
+    def _resolve_rounds_root(self, pheno_id: str, storage_path: str) -> Optional[Path]:
+        rounds_root: Optional[Path]
+        if storage_path:
+            storage = Path(storage_path)
+            if not storage.is_absolute():
+                storage = (self.project_root / storage).resolve()
+            rounds_root = storage / "rounds"
         else:
             rounds_root = None
         # Fallback for legacy directory structures where the phenotype ID was used

--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -23,8 +23,19 @@ PROJECT_SCHEMA = [
         name TEXT NOT NULL,
         level TEXT NOT NULL CHECK(level IN ('single_doc','multi_doc')),
         description TEXT,
-        corpus_path TEXT NOT NULL,
+        storage_path TEXT NOT NULL,
         UNIQUE(project_id, name)
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS project_corpora(
+        corpus_id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        relative_path TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE(project_id, name),
+        FOREIGN KEY(project_id) REFERENCES projects(project_id)
     );
     """,
     """

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -97,7 +97,7 @@ class Phenotype(Record):
     name: str
     level: str
     description: str
-    corpus_path: str
+    storage_path: str
 
     __tablename__ = "phenotypes"
     __schema__ = (
@@ -108,7 +108,31 @@ class Phenotype(Record):
             name TEXT NOT NULL,
             level TEXT CHECK(level IN ('single_doc','multi_doc')) NOT NULL,
             description TEXT NOT NULL,
-            corpus_path TEXT NOT NULL,
+            storage_path TEXT NOT NULL,
+            UNIQUE(project_id, name),
+            FOREIGN KEY(project_id) REFERENCES projects(project_id)
+        )
+        """
+    )
+
+
+@dataclass
+class ProjectCorpus(Record):
+    corpus_id: str
+    project_id: str
+    name: str
+    relative_path: str
+    created_at: str
+
+    __tablename__ = "project_corpora"
+    __schema__ = (
+        """
+        CREATE TABLE IF NOT EXISTS project_corpora (
+            corpus_id TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            relative_path TEXT NOT NULL,
+            created_at TEXT NOT NULL,
             UNIQUE(project_id, name),
             FOREIGN KEY(project_id) REFERENCES projects(project_id)
         )


### PR DESCRIPTION
## Summary
- add project corpus registry and update the admin app to select or import corpora when creating rounds
- migrate phenotype storage to track directories instead of corpus paths and surface corpus details in round views
- adjust client, CLI, tooling, and tests to use project-level corpora and the new schema

## Testing
- pytest tests/test_round_import.py

------
https://chatgpt.com/codex/tasks/task_e_68e18d4379688327a1e9555f3c4d67e6