### PR TITLE
Add metadata-driven document tables and dark theme

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -14,6 +14,7 @@ from typing import Iterator
 
 from .project import fetch_labelset
 from .schema import initialize_assignment_db, initialize_round_aggregate_db
+from .shared.metadata import extract_document_metadata
 from .utils import (
     canonical_json,
     copy_sqlite_database,
@@ -193,9 +194,16 @@ class RoundBuilder:
                             doc_id = doc.get("doc_id")
                             if not doc_id:
                                 continue
+                            metadata = extract_document_metadata(doc)
+                            metadata_json = json.dumps(metadata, sort_keys=True) if metadata else None
                             assign_conn.execute(
-                                "INSERT OR REPLACE INTO documents(doc_id, hash, text) VALUES (?,?,?)",
-                                (doc_id, doc.get("hash", ""), doc.get("text", "")),
+                                "INSERT OR REPLACE INTO documents(doc_id, hash, text, metadata_json) VALUES (?,?,?,?)",
+                                (
+                                    doc_id,
+                                    doc.get("hash", ""),
+                                    doc.get("text", ""),
+                                    metadata_json,
+                                ),
                             )
                             assign_conn.execute(
                                 "INSERT OR REPLACE INTO unit_notes(unit_id, doc_id, order_index) VALUES (?,?,?)",

--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -189,8 +189,12 @@ ASSIGNMENT_SCHEMA = [
     CREATE TABLE IF NOT EXISTS documents(
         doc_id TEXT PRIMARY KEY,
         hash TEXT NOT NULL,
-        text TEXT NOT NULL
+        text TEXT NOT NULL,
+        metadata_json TEXT
     );
+    """,
+    """
+    ALTER TABLE documents ADD COLUMN metadata_json TEXT;
     """,
     """
     CREATE TABLE IF NOT EXISTS annotations(

--- a/vaannotate/shared/metadata.py
+++ b/vaannotate/shared/metadata.py
@@ -1,0 +1,53 @@
+"""Helpers for working with document metadata."""
+from __future__ import annotations
+
+from typing import Dict, Mapping, Any
+
+
+_METADATA_EXCLUDE_KEYS = {
+    "doc_id",
+    "hash",
+    "text",
+    "order_index",
+    "documents",
+    "metadata",
+    "metadata_json",
+}
+
+
+def _is_meaningful(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    return True
+
+
+def extract_document_metadata(source: Mapping[str, object] | None) -> Dict[str, object]:
+    """Return a normalized metadata dictionary for a document payload.
+
+    The helper merges explicit ``metadata`` dictionaries with any scalar
+    attributes present on the document payload while skipping core fields like
+    the note text and document identifier. Empty strings and ``None`` values
+    are omitted so the caller receives only meaningful metadata entries.
+    """
+
+    metadata: Dict[str, object] = {}
+    if not source:
+        return metadata
+    raw_metadata = source.get("metadata") if isinstance(source, Mapping) else None
+    if isinstance(raw_metadata, Mapping):
+        for key, value in raw_metadata.items():
+            if _is_meaningful(value):
+                metadata[key] = value
+    for key, value in source.items():
+        if key in _METADATA_EXCLUDE_KEYS:
+            continue
+        if isinstance(value, Mapping):
+            continue
+        if isinstance(value, (list, tuple, set)):
+            continue
+        if not _is_meaningful(value):
+            continue
+        metadata.setdefault(key, value)
+    return metadata

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -380,6 +380,7 @@ class AssignmentDocument(Record):
     doc_id: str
     hash: str
     text: str
+    metadata_json: Optional[str] = None
 
     __tablename__ = "documents"
     __schema__ = (
@@ -387,7 +388,8 @@ class AssignmentDocument(Record):
         CREATE TABLE IF NOT EXISTS documents (
             doc_id TEXT PRIMARY KEY,
             hash TEXT NOT NULL,
-            text TEXT NOT NULL
+            text TEXT NOT NULL,
+            metadata_json TEXT NULL
         )
         """
     )

--- a/vaannotate/shared/theme.py
+++ b/vaannotate/shared/theme.py
@@ -1,0 +1,28 @@
+"""Shared helpers for applying application-wide themes."""
+from __future__ import annotations
+
+from PySide6 import QtGui, QtWidgets
+
+
+def apply_dark_palette(app: QtWidgets.QApplication) -> None:
+    """Configure the application with a high-contrast dark palette."""
+
+    app.setStyle("Fusion")
+    palette = QtGui.QPalette()
+    palette.setColor(QtGui.QPalette.ColorRole.Window, QtGui.QColor(53, 53, 53))
+    palette.setColor(QtGui.QPalette.ColorRole.WindowText, QtGui.QColor(220, 220, 220))
+    palette.setColor(QtGui.QPalette.ColorRole.Base, QtGui.QColor(42, 42, 42))
+    palette.setColor(QtGui.QPalette.ColorRole.AlternateBase, QtGui.QColor(60, 60, 60))
+    palette.setColor(QtGui.QPalette.ColorRole.ToolTipBase, QtGui.QColor(53, 53, 53))
+    palette.setColor(QtGui.QPalette.ColorRole.ToolTipText, QtGui.QColor(220, 220, 220))
+    palette.setColor(QtGui.QPalette.ColorRole.Text, QtGui.QColor(220, 220, 220))
+    palette.setColor(QtGui.QPalette.ColorRole.Button, QtGui.QColor(53, 53, 53))
+    palette.setColor(QtGui.QPalette.ColorRole.ButtonText, QtGui.QColor(220, 220, 220))
+    palette.setColor(QtGui.QPalette.ColorRole.BrightText, QtGui.QColor(255, 85, 85))
+    palette.setColor(QtGui.QPalette.ColorRole.Highlight, QtGui.QColor(100, 100, 150))
+    palette.setColor(QtGui.QPalette.ColorRole.HighlightedText, QtGui.QColor(255, 255, 255))
+    palette.setColor(QtGui.QPalette.ColorRole.Link, QtGui.QColor(130, 160, 255))
+    app.setPalette(palette)
+    app.setStyleSheet(
+        "QToolTip { color: #f0f0f0; background-color: #353535; border: 1px solid #767676; }"
+    )


### PR DESCRIPTION
## Summary
- persist full note metadata in assignments and surface it in the Client preview table with sortable columns
- expand the Admin IAA document viewer to show sortable metadata columns with corpus and assignment fallbacks
- introduce a shared dark Fusion theme applied to both desktop applications

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1a69a3e5083278b4cdb647b206749