### PR TITLE
Enable metadata-driven sampling filters

### DIFF
--- a/vaannotate/shared/metadata.py
+++ b/vaannotate/shared/metadata.py
@@ -1,7 +1,76 @@
-"""Helpers for working with document metadata."""
 from __future__ import annotations
 
-from typing import Dict, Mapping, Any
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from .database import Database
+
+MetadataScope = str
+MetadataType = str
+
+
+@dataclass(frozen=True)
+class MetadataField:
+    key: str
+    label: str
+    scope: MetadataScope
+    data_type: MetadataType
+    expression: str
+    alias: str
+    constant_for_unit: bool
+
+
+@dataclass
+class MetadataFilterCondition:
+    field: str
+    label: str
+    scope: MetadataScope
+    data_type: MetadataType
+    min_value: Optional[str] = None
+    max_value: Optional[str] = None
+    values: Optional[List[str]] = None
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "field": self.field,
+            "label": self.label,
+            "scope": self.scope,
+            "type": self.data_type,
+        }
+        if self.min_value is not None:
+            payload["min"] = self.min_value
+        if self.max_value is not None:
+            payload["max"] = self.max_value
+        if self.values:
+            payload["values"] = list(self.values)
+        return payload
+
+    @classmethod
+    def from_payload(cls, data: Mapping[str, Any]) -> "MetadataFilterCondition":
+        field = str(data.get("field") or "")
+        label = str(data.get("label") or field)
+        scope = str(data.get("scope") or "document")
+        data_type = str(data.get("type") or "text")
+        min_value = data.get("min")
+        max_value = data.get("max")
+        raw_values = data.get("values")
+        values: Optional[List[str]]
+        if isinstance(raw_values, (list, tuple, set)):
+            values = [str(value) for value in raw_values]
+        else:
+            values = None
+        return cls(
+            field=field,
+            label=label,
+            scope=scope,
+            data_type=data_type,
+            min_value=str(min_value) if min_value is not None else None,
+            max_value=str(max_value) if max_value is not None else None,
+            values=values,
+        )
 
 
 _METADATA_EXCLUDE_KEYS = {
@@ -51,3 +120,226 @@ def extract_document_metadata(source: Mapping[str, object] | None) -> Dict[str, 
             continue
         metadata.setdefault(key, value)
     return metadata
+
+
+def _sanitize_alias(value: str) -> str:
+    cleaned = re.sub(r"[^0-9A-Za-z_]+", "_", value.strip())
+    if not cleaned:
+        cleaned = "field"
+    if cleaned[0].isdigit():
+        cleaned = f"f_{cleaned}"
+    return cleaned
+
+
+def _human_label(name: str) -> str:
+    name = name.replace("_", " ").strip()
+    if not name:
+        return "Metadata"
+    return name[:1].upper() + name[1:]
+
+
+def _looks_like_date(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    value = value.strip()
+    if not value:
+        return False
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+        return True
+    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}", value):
+        return True
+    if re.match(r"^\d{4}/\d{2}/\d{2}$", value):
+        return True
+    return False
+
+
+def _all_numeric(values: Sequence[Any]) -> bool:
+    numbers_found = False
+    for value in values:
+        if value in (None, ""):
+            continue
+        try:
+            float(value)
+        except (TypeError, ValueError):
+            return False
+        numbers_found = True
+    return numbers_found
+
+
+def _all_dates(values: Sequence[Any]) -> bool:
+    dates_found = False
+    for value in values:
+        if value in (None, ""):
+            continue
+        if not _looks_like_date(value):
+            return False
+        dates_found = True
+    return dates_found
+
+
+def _infer_data_type(declared_type: str, samples: Sequence[Any]) -> MetadataType:
+    declared = (declared_type or "").upper()
+    if any(token in declared for token in ("INT", "REAL", "NUM", "DEC", "DOUBLE", "FLOAT")):
+        return "number"
+    if "BOOL" in declared:
+        return "number"
+    if "DATE" in declared or "TIME" in declared:
+        return "date"
+    if _all_numeric(samples):
+        return "number"
+    if _all_dates(samples):
+        return "date"
+    return "text"
+
+
+def _column_samples(conn: sqlite3.Connection, table: str, column: str, limit: int) -> List[Any]:
+    sql = f'SELECT "{column}" FROM {table} WHERE "{column}" IS NOT NULL LIMIT ?'
+    rows = conn.execute(sql, (limit,)).fetchall()
+    return [row[0] for row in rows]
+
+
+def _json_samples(conn: sqlite3.Connection, limit: int) -> Dict[str, List[Any]]:
+    samples: Dict[str, List[Any]] = {}
+    try:
+        rows = conn.execute(
+            "SELECT metadata_json FROM documents WHERE metadata_json IS NOT NULL LIMIT ?",
+            (limit,),
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        return samples
+    for row in rows:
+        payload = row[0]
+        if not payload:
+            continue
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        for key, value in parsed.items():
+            if isinstance(value, (list, dict)):
+                continue
+            samples.setdefault(key, []).append(value)
+    return samples
+
+
+def _is_constant_per_patient(conn: sqlite3.Connection, expression: str) -> bool:
+    try:
+        row = conn.execute(
+            f"""
+            SELECT 1
+            FROM (
+                SELECT patient_icn,
+                       MIN({expression}) AS min_value,
+                       MAX({expression}) AS max_value
+                FROM documents
+                GROUP BY patient_icn
+                HAVING (min_value IS NOT max_value)
+                LIMIT 1
+            )
+            """
+        ).fetchone()
+    except sqlite3.DatabaseError:
+        return False
+    return row is None
+
+
+def _supports_json(conn: sqlite3.Connection) -> bool:
+    try:
+        conn.execute("SELECT json_extract('{\"a\": 1}', '$.a')").fetchone()
+    except sqlite3.DatabaseError:
+        return False
+    return True
+
+
+def _discover_from_connection(conn: sqlite3.Connection, sample_limit: int) -> List[MetadataField]:
+    fields: List[MetadataField] = []
+
+    patient_info = conn.execute("PRAGMA table_info(patients)").fetchall()
+    for row in patient_info:
+        name = row["name"]
+        if name == "patient_icn":
+            continue
+        declared = row["type"]
+        samples = _column_samples(conn, "patients", name, sample_limit)
+        data_type = _infer_data_type(declared, samples)
+        key = f"patient.{name}"
+        alias = _sanitize_alias(f"patient__{name}")
+        label = f"{_human_label(name)} (patient)"
+        expression = f'patients."{name}"'
+        fields.append(
+            MetadataField(
+                key=key,
+                label=label,
+                scope="patient",
+                data_type=data_type,
+                expression=expression,
+                alias=alias,
+                constant_for_unit=True,
+            )
+        )
+
+    document_info = conn.execute("PRAGMA table_info(documents)").fetchall()
+    excluded = {"doc_id", "patient_icn", "hash", "text"}
+    for row in document_info:
+        name = row["name"]
+        if name in excluded:
+            continue
+        declared = row["type"]
+        samples = _column_samples(conn, "documents", name, sample_limit)
+        data_type = _infer_data_type(declared, samples)
+        key = f"document.{name}"
+        alias = _sanitize_alias(f"document__{name}")
+        label = _human_label(name)
+        expression = f'documents."{name}"'
+        constant = _is_constant_per_patient(conn, expression)
+        fields.append(
+            MetadataField(
+                key=key,
+                label=label,
+                scope="document",
+                data_type=data_type,
+                expression=expression,
+                alias=alias,
+                constant_for_unit=constant,
+            )
+        )
+
+    if _supports_json(conn):
+        json_samples = _json_samples(conn, sample_limit)
+        for name, values in json_samples.items():
+            if not values:
+                continue
+            data_type = _infer_data_type("", values)
+            key = f"metadata.{name}"
+            alias = _sanitize_alias(f"metadata__{name}")
+            label = _human_label(name)
+            escaped = name.replace('"', '""')
+            expression = f"json_extract(documents.metadata_json, '$.\"{escaped}\"')"
+            constant = _is_constant_per_patient(conn, expression)
+            fields.append(
+                MetadataField(
+                    key=key,
+                    label=label,
+                    scope="document",
+                    data_type=data_type,
+                    expression=expression,
+                    alias=alias,
+                    constant_for_unit=constant,
+                )
+            )
+
+    fields.sort(key=lambda field: (field.label.lower(), field.key))
+    return fields
+
+
+def discover_corpus_metadata(
+    source: Database | sqlite3.Connection,
+    *,
+    sample_limit: int = 500,
+) -> List[MetadataField]:
+    if isinstance(source, Database):
+        with source.connect() as conn:
+            return _discover_from_connection(conn, sample_limit)
+    return _discover_from_connection(source, sample_limit)


### PR DESCRIPTION
## Summary
- discover corpus metadata fields dynamically, capturing JSON fields when available and handling missing metadata columns
- support metadata-based filtering and stratification in sampling, round building, and admin UI with validation for multi-document phenotypes
- extend round import tests to cover metadata filters, stratification, and guardrails against variable per-document fields

## Testing
- pytest tests/test_round_import.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b1ad24408327b43e9bcddc824338