### PR TITLE
Improve metadata date filtering and defer deletions

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,105 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vaannotate.schema import initialize_corpus_db
+from vaannotate.shared.database import Database
+from vaannotate.shared.metadata import (
+    MetadataFilterCondition,
+    discover_corpus_metadata,
+    normalize_date_value,
+)
+from vaannotate.shared.sampling import SamplingFilters, candidate_documents
+
+
+def test_discover_metadata_identifies_dates(tmp_path: Path) -> None:
+    corpus_path = tmp_path / "corpus.db"
+    with initialize_corpus_db(corpus_path) as conn:
+        conn.execute("ALTER TABLE documents ADD COLUMN custom_date TEXT")
+        conn.execute(
+            "INSERT INTO patients(patient_icn, sta3n, date_index, softlabel) VALUES (?,?,?,?)",
+            ("p1", "506", None, None),
+        )
+        conn.execute(
+            """
+            INSERT INTO documents(
+                doc_id, patient_icn, notetype, note_year, date_note,
+                cptname, sta3n, hash, text, custom_date
+            ) VALUES (?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "doc1",
+                "p1",
+                "NOTE",
+                2024,
+                "2024-02-15",
+                "",
+                "506",
+                "hash1",
+                "Example text",
+                "02/15/2024",
+            ),
+        )
+        conn.commit()
+
+    with initialize_corpus_db(corpus_path) as conn:
+        conn.row_factory = sqlite3.Row
+        fields = discover_corpus_metadata(conn)
+
+    assert any(field.key == "document.date_note" and field.data_type == "date" for field in fields)
+    assert any(field.key == "document.custom_date" and field.data_type == "date" for field in fields)
+
+
+def test_candidate_documents_supports_date_range_filters(tmp_path: Path) -> None:
+    corpus_path = tmp_path / "corpus.db"
+    with initialize_corpus_db(corpus_path) as conn:
+        conn.execute(
+            "INSERT INTO patients(patient_icn, sta3n, date_index, softlabel) VALUES (?,?,?,?)",
+            ("p2", "506", None, None),
+        )
+        conn.execute(
+            """
+            INSERT INTO documents(
+                doc_id, patient_icn, notetype, note_year, date_note,
+                cptname, sta3n, hash, text
+            ) VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "doc_range",
+                "p2",
+                "NOTE",
+                2024,
+                "2024-02-15",
+                "",
+                "506",
+                "hash_range",
+                "Range test",
+            ),
+        )
+        conn.commit()
+
+    filters = SamplingFilters(
+        metadata_filters=[
+            MetadataFilterCondition(
+                field="document.date_note",
+                label="Date note",
+                scope="document",
+                data_type="date",
+                min_value="02/01/2024",
+                max_value="02/20/2024",
+            )
+        ]
+    )
+
+    rows = candidate_documents(Database(corpus_path), "single_doc", filters)
+    assert [row["doc_id"] for row in rows] == ["doc_range"]
+
+
+def test_normalize_date_value_formats() -> None:
+    assert normalize_date_value("02/01/2024") == "2024-02-01"
+    assert normalize_date_value("2024-02-01") == "2024-02-01"
+    assert normalize_date_value("  ") is None

--- a/tests/test_project_context.py
+++ b/tests/test_project_context.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    from PySide6 import QtWidgets  # noqa: F401
+except ImportError:  # pragma: no cover - skip if Qt not available
+    pytest.skip("PySide6 is not available", allow_module_level=True)
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vaannotate.AdminApp.main import ProjectContext
+
+
+def test_project_context_defers_file_deletion(tmp_path: Path) -> None:
+    ctx = ProjectContext()
+    file_path = tmp_path / "rounds" / "round_1" / "manifest.csv"
+    ctx.register_manifest(file_path, {})
+
+    # Scheduling deletion should remove pending artifacts immediately.
+    ctx._schedule_deletion(file_path, mode="file")
+    assert file_path.resolve() not in ctx._pending_manifests
+
+    ctx.save_all()
+
+    assert not file_path.exists()
+    assert not ctx._pending_deletions

--- a/tests/test_round_import.py
+++ b/tests/test_round_import.py
@@ -448,7 +448,7 @@ def test_admin_sampling_creates_multi_doc_units(tmp_path: Path) -> None:
                 assert doc_row["text"] == text_map[doc_id]
 
 
-def test_round_builder_blocks_variable_metadata_for_multi_doc(tmp_path: Path) -> None:
+def test_round_builder_allows_document_stratification_for_multi_doc(tmp_path: Path) -> None:
     project_root = tmp_path / "Project"
     paths = init_project(project_root, "proj", "Project", "tester")
 
@@ -539,8 +539,20 @@ def test_round_builder_blocks_variable_metadata_for_multi_doc(tmp_path: Path) ->
     }
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Cannot stratify multi-document units"):
-        builder.generate_round("ph_multi", config_path, created_by="tester")
+    builder.generate_round("ph_multi", config_path, created_by="tester")
+
+    manifest_path = (
+        project_root
+        / "phenotypes"
+        / "ph_multi"
+        / "rounds"
+        / "round_1"
+        / "manifest.csv"
+    )
+    assert manifest_path.exists()
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert [row["strata_key"] for row in rows] == ["2020"]
 
 
 def test_allocate_units_respects_total_n() -> None:

--- a/vaannotate/shared/sampling.py
+++ b/vaannotate/shared/sampling.py
@@ -18,6 +18,7 @@ from .metadata import (
     MetadataFilterCondition,
     discover_corpus_metadata,
     extract_document_metadata,
+    normalize_date_value,
 )
 from . import models
 
@@ -167,15 +168,20 @@ def _candidate_documents_from_connection(
                     params.extend(numeric_values)
         elif field.data_type == "date":
             if condition.min_value:
+                normalized = normalize_date_value(condition.min_value)
+                value = normalized or condition.min_value
                 local_clauses.append(f"{field.expression} >= ?")
-                params.append(condition.min_value)
+                params.append(value)
             if condition.max_value:
+                normalized = normalize_date_value(condition.max_value)
+                value = normalized or condition.max_value
                 local_clauses.append(f"{field.expression} <= ?")
-                params.append(condition.max_value)
+                params.append(value)
             if condition.values:
-                placeholders = ",".join(["?"] * len(condition.values))
+                normalized_values = [normalize_date_value(value) or value for value in condition.values]
+                placeholders = ",".join(["?"] * len(normalized_values))
                 local_clauses.append(f"{field.expression} IN ({placeholders})")
-                params.extend(condition.values)
+                params.extend(normalized_values)
         else:
             if condition.values:
                 placeholders = ",".join(["?"] * len(condition.values))


### PR DESCRIPTION
## Summary
- enhance metadata date detection and normalize filter values for consistent date range queries
- allow metadata-driven filtering/stratification for multi-document phenotypes and defer project file deletions until save
- cover the new behaviours with metadata, project context, and round builder tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1c2bfff0c8327a9ced415dbf06d1f