### PR TITLE
Fix pending deletion overrides and stratified overlap allocation

### DIFF
--- a/tests/test_project_context.py
+++ b/tests/test_project_context.py
@@ -28,3 +28,22 @@ def test_project_context_defers_file_deletion(tmp_path: Path) -> None:
 
     assert not file_path.exists()
     assert not ctx._pending_deletions
+
+
+def test_registering_artifact_clears_pending_deletion(tmp_path: Path) -> None:
+    ctx = ProjectContext()
+    round_dir = tmp_path / "rounds" / "round_1"
+    manifest_path = round_dir / "manifest.csv"
+
+    ctx._schedule_deletion(round_dir, mode="tree")
+    assert ctx._pending_deletions
+
+    ctx.register_manifest(manifest_path, {})
+    assert not ctx._pending_deletions
+
+    text_path = round_dir / "notes.txt"
+    ctx._schedule_deletion(text_path, mode="file")
+    assert ctx._pending_deletions
+
+    ctx.register_text_file(text_path, "sample")
+    assert not ctx._pending_deletions


### PR DESCRIPTION
## Summary
- clear pending deletion tasks when new manifests or text files are registered to prevent stale deletions
- rebalance overlap unit allocation across strata for both the admin RoundBuilder and shared sampling utilities
- add regression tests covering deletion cancellation and overlap distribution behavior

## Testing
- pytest tests/test_project_context.py tests/test_round_import.py::test_allocate_units_respects_total_n tests/test_round_import.py::test_allocate_units_stratified_overlap_matches_target tests/test_round_import.py::test_round_builder_overlap_respects_target_total

------
https://chatgpt.com/codex/tasks/task_e_68e1c86fa9308327a4b46393fb512b58