### PR TITLE
Capture custom corpus metadata for sampling

### DIFF
--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -152,9 +152,11 @@ CORPUS_SCHEMA = [
         sta3n TEXT,
         hash TEXT NOT NULL,
         text TEXT NOT NULL,
+        metadata_json TEXT,
         FOREIGN KEY(patient_icn) REFERENCES patients(patient_icn)
     );
     """,
+    """ALTER TABLE documents ADD COLUMN metadata_json TEXT;""",
     """CREATE INDEX IF NOT EXISTS idx_documents_patient ON documents(patient_icn);""",
     """CREATE INDEX IF NOT EXISTS idx_documents_year ON documents(note_year);""",
     """CREATE INDEX IF NOT EXISTS idx_documents_sta ON documents(sta3n);""",

--- a/vaannotate/shared/metadata.py
+++ b/vaannotate/shared/metadata.py
@@ -82,6 +82,7 @@ _METADATA_EXCLUDE_KEYS = {
     "documents",
     "metadata",
     "metadata_json",
+    "patient_icn",
 }
 
 
@@ -110,6 +111,17 @@ def extract_document_metadata(source: Mapping[str, object] | None) -> Dict[str, 
         for key, value in raw_metadata.items():
             if _is_meaningful(value):
                 metadata[key] = value
+    if isinstance(source, Mapping):
+        metadata_json = source.get("metadata_json")
+        if isinstance(metadata_json, str) and metadata_json.strip():
+            try:
+                parsed = json.loads(metadata_json)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, Mapping):
+                for key, value in parsed.items():
+                    if _is_meaningful(value):
+                        metadata.setdefault(key, value)
     for key, value in source.items():
         if key in _METADATA_EXCLUDE_KEYS:
             continue
@@ -133,10 +145,7 @@ def _sanitize_alias(value: str) -> str:
 
 
 def _human_label(name: str) -> str:
-    name = name.replace("_", " ").strip()
-    if not name:
-        return "Metadata"
-    return name[:1].upper() + name[1:]
+    return name
 
 
 _DATE_FORMATS = (

--- a/vaannotate/shared/sampling.py
+++ b/vaannotate/shared/sampling.py
@@ -116,6 +116,7 @@ def _candidate_documents_from_connection(
         "documents.cptname AS cptname",
         "documents.sta3n AS sta3n",
         "documents.hash AS hash",
+        "documents.metadata_json AS metadata_json",
         "documents.text AS text",
     ]
     seen_aliases = {
@@ -127,6 +128,7 @@ def _candidate_documents_from_connection(
         "cptname",
         "sta3n",
         "hash",
+        "metadata_json",
         "text",
     }
     for field in active_fields:
@@ -239,6 +241,7 @@ def _candidate_documents_from_connection(
                 "note_count": len(ordered_docs),
                 "documents": doc_payloads,
                 "metadata": primary_metadata,
+                "metadata_json": primary_dict.get("metadata_json"),
             }
             for field in active_fields:
                 entry[field.alias] = primary_dict.get(field.alias)


### PR DESCRIPTION
## Summary
- store non-required corpus columns in `metadata_json` during import so they remain available for filtering and stratification
- surface metadata values throughout discovery and round building while presenting the actual column names from the corpus
- cover the behavior with a regression test that ensures custom columns are preserved and discoverable

## Testing
- pytest tests/test_metadata.py tests/test_round_import.py

------
https://chatgpt.com/codex/tasks/task_e_68e56db2020c8327b672413ea137846b