### PR TITLE
Parse metadata JSON into table columns

### DIFF
--- a/vaannotate/shared/metadata.py
+++ b/vaannotate/shared/metadata.py
@@ -347,7 +347,7 @@ def _discover_from_connection(conn: sqlite3.Connection, sample_limit: int) -> Li
         )
 
     document_info = conn.execute("PRAGMA table_info(documents)").fetchall()
-    excluded = {"doc_id", "patient_icn", "hash", "text"}
+    excluded = {"doc_id", "patient_icn", "hash", "text", "metadata_json"}
     for row in document_info:
         name = row["name"]
         if name in excluded:


### PR DESCRIPTION
## Summary
- expand the corpus viewer to surface metadata_json keys as individual columns
- hide the raw metadata_json field from metadata discovery so round builder pickers show real metadata fields

## Testing
- pytest tests/test_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68eef7a162048327a6b2b3266db3618c