### PR TITLE
Add AI-assisted round creation path

### DIFF
--- a/vaannotate/vaannotate_ai_backend/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/__init__.py
@@ -1,2 +1,14 @@
+"""Lightweight facade for the AI backend integration."""
+
+__version__ = "0.1.0"
+
 from .orchestrator import build_next_batch
-from .adapters import export_inputs_from_repo, run_ai_backend_and_collect
+from .adapters import BackendResult, export_inputs_from_repo, run_ai_backend_and_collect
+
+__all__ = [
+    "__version__",
+    "BackendResult",
+    "build_next_batch",
+    "export_inputs_from_repo",
+    "run_ai_backend_and_collect",
+]


### PR DESCRIPTION
## Summary
- allow RoundBuilder to build rounds from preselected CSVs while preserving unit order and recording status
- expose a lightweight AI backend facade that normalizes outputs, logs parameters, and returns reusable results
- add Admin dialog controls that run the AI backend in the background with logging, preview, and error handling
- cover the new workflows with single- and multi-document tests for AI-driven selections

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f44a4a60e483278a89d3c9c7803184