### PR TITLE
Adjust AI adapter corpus discovery for central corpora

### DIFF
--- a/tests/test_ai_adapters.py
+++ b/tests/test_ai_adapters.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+class _Unavailable:  # pragma: no cover - helper for import stubbing
+    def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401
+        raise RuntimeError("Optional dependency is not available in tests")
+
+
+if "sentence_transformers" not in sys.modules:
+    stub = types.ModuleType("sentence_transformers")
+    stub.SentenceTransformer = _Unavailable
+    stub.CrossEncoder = _Unavailable
+    sys.modules["sentence_transformers"] = stub
+
+if "langchain_text_splitters" not in sys.modules:
+    stub = types.ModuleType("langchain_text_splitters")
+    stub.RecursiveCharacterTextSplitter = _Unavailable
+    sys.modules["langchain_text_splitters"] = stub
+
+if "langchain" not in sys.modules:
+    langchain_stub = types.ModuleType("langchain")
+    text_splitter_stub = types.ModuleType("langchain.text_splitter")
+    text_splitter_stub.RecursiveCharacterTextSplitter = _Unavailable
+    sys.modules["langchain"] = langchain_stub
+    sys.modules["langchain.text_splitter"] = text_splitter_stub
+
+from vaannotate.project import add_phenotype, get_connection, init_project
+from vaannotate.schema import initialize_corpus_db
+from vaannotate.vaannotate_ai_backend.adapters import export_inputs_from_repo
+
+
+def test_export_inputs_uses_storage_path(tmp_path: Path) -> None:
+    project_root = tmp_path / "Project"
+    paths = init_project(project_root, "proj", "Project", "tester")
+
+    pheno_id = "ph_test"
+    storage_relative = Path("phenotypes") / "custom_slug"
+    phenotype_dir = project_root / storage_relative
+    (phenotype_dir / "rounds").mkdir(parents=True, exist_ok=True)
+
+    with get_connection(paths.project_db) as conn:
+        add_phenotype(
+            conn,
+            pheno_id=pheno_id,
+            project_id="proj",
+            name="Test phenotype",
+            level="single_doc",
+            storage_path=str(storage_relative.as_posix()),
+        )
+        conn.commit()
+
+    corpus_dir = project_root / "Corpora" / pheno_id
+    corpus_dir.mkdir(parents=True, exist_ok=True)
+    corpus_db = corpus_dir / "corpus.db"
+    with initialize_corpus_db(corpus_db) as conn:
+        conn.execute("INSERT INTO patients(patient_icn) VALUES (?)", ("p1",))
+        conn.execute(
+            """
+            INSERT INTO documents(doc_id, patient_icn, date_note, hash, text, metadata_json)
+            VALUES (?,?,?,?,?,?)
+            """,
+            ("doc_1", "p1", "2020-01-01", "hash1", "Sample text", "{}"),
+        )
+        conn.execute("ALTER TABLE documents ADD COLUMN patienticn TEXT")
+        conn.execute("UPDATE documents SET patienticn = patient_icn")
+        conn.execute("ALTER TABLE documents ADD COLUMN notetype TEXT")
+        conn.execute("UPDATE documents SET notetype = ''")
+        conn.commit()
+
+    with get_connection(paths.project_db) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO rounds(round_id, pheno_id, round_number, labelset_id, config_hash, rng_seed, status, created_at) VALUES (?,?,?,?,?,?,?,?)",
+            ("ph_test_r1", pheno_id, 1, "ls_test", "hash", 0, "finalized", "2020-01-01T00:00:00"),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO round_configs(round_id, config_json) VALUES (?, ?)",
+            ("ph_test_r1", json.dumps({"corpus_id": "cor_ph_test", "corpus_path": "Corpora/ph_test/corpus.db"})),
+        )
+        conn.commit()
+
+    round_dir = phenotype_dir / "rounds" / "round_1"
+    round_dir.mkdir(parents=True, exist_ok=True)
+    round_db = round_dir / "round_aggregate.db"
+    with sqlite3.connect(round_db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE annotations(
+                round_id TEXT,
+                unit_id TEXT,
+                doc_id TEXT,
+                label_id TEXT,
+                reviewer_id TEXT,
+                label_value TEXT,
+                reviewer_notes TEXT,
+                rationales_json TEXT,
+                document_text TEXT,
+                document_metadata_json TEXT,
+                label_rules TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO annotations(round_id, unit_id, doc_id, label_id, reviewer_id, label_value,
+                                     reviewer_notes, rationales_json, document_text, document_metadata_json, label_rules)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "ph_test_r1",
+                "unit_1",
+                "doc_1",
+                "LabelA",
+                "rev1",
+                "yes",
+                "note",
+                "[]",
+                "Sample text",
+                "{}",
+                "",
+            ),
+        )
+        conn.commit()
+
+    notes_df, ann_df = export_inputs_from_repo(project_root, pheno_id, [1])
+
+    assert isinstance(notes_df, pd.DataFrame)
+    assert isinstance(ann_df, pd.DataFrame)
+    assert {"doc_id", "patienticn", "text"}.issubset(notes_df.columns)
+    assert notes_df.loc[0, "doc_id"] == "doc_1"
+    assert ann_df.loc[0, "round_id"] == "ph_test_r1"
+

--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -20,6 +20,137 @@ class BackendResult:
     artifacts: Dict[str, Any]
     params_path: Path
 
+def _resolve_phenotype_dir(project_root: Path, pheno_id: str) -> Path:
+    project_db = Path(project_root) / "project.db"
+    if not project_db.exists():
+        raise FileNotFoundError(f"Project database missing at {project_db}")
+
+    con = sqlite3.connect(str(project_db))
+    try:
+        con.row_factory = sqlite3.Row
+        row = con.execute(
+            "SELECT storage_path FROM phenotypes WHERE pheno_id=?",
+            (pheno_id,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    if not row:
+        raise ValueError(f"Phenotype {pheno_id} not found in project database")
+
+    storage_path = row["storage_path"]
+    if not storage_path:
+        raise ValueError(f"Phenotype {pheno_id} is missing a storage_path")
+
+    storage = Path(storage_path)
+    if not storage.is_absolute():
+        storage = (Path(project_root) / storage).resolve()
+    return storage
+
+
+def _candidate_corpus_paths(
+    project_root: Path,
+    phenotype_dir: Path,
+    pheno_id: str,
+    hints: Optional[List[str]] = None,
+) -> List[Path]:
+    candidates: List[Path] = [
+        phenotype_dir / "corpus" / "corpus.db",
+        phenotype_dir / "corpus.db",
+        phenotype_dir / "corpus.sqlite",
+        phenotype_dir / f"{pheno_id}.db",
+    ]
+
+    for corpora_folder in (project_root / "corpora", project_root / "Corpora"):
+        candidates.extend(
+            [
+                corpora_folder / pheno_id / "corpus.db",
+                corpora_folder / pheno_id / "corpus.sqlite",
+                corpora_folder / pheno_id / f"{pheno_id}.db",
+                corpora_folder / f"{pheno_id}.db",
+                corpora_folder / f"{pheno_id}.sqlite",
+            ]
+        )
+
+    for hint in hints or []:
+        path = Path(hint)
+        if not path.is_absolute():
+            path = (project_root / path).resolve()
+        candidates.append(path)
+
+    seen: set[Path] = set()
+    unique: List[Path] = []
+    for candidate in candidates:
+        resolved = candidate if candidate.is_absolute() else (project_root / candidate).resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(resolved)
+    return unique
+
+
+def _find_corpus_db(project_root: Path, pheno_id: str, prior_rounds: List[int]) -> Path:
+    phenotype_dir = _resolve_phenotype_dir(project_root, pheno_id)
+    project_db = Path(project_root) / "project.db"
+    hints: List[str] = []
+
+    if project_db.exists():
+        con = sqlite3.connect(str(project_db))
+        try:
+            con.row_factory = sqlite3.Row
+            round_ids: List[str] = []
+            if prior_rounds:
+                round_ids.extend(f"{pheno_id}_r{number}" for number in sorted(prior_rounds, reverse=True))
+            rows = con.execute(
+                "SELECT round_id FROM rounds WHERE pheno_id=? ORDER BY round_number DESC",
+                (pheno_id,),
+            ).fetchall()
+            round_ids.extend(row["round_id"] for row in rows)
+
+            seen_rounds: set[str] = set()
+            for round_id in round_ids:
+                if round_id in seen_rounds:
+                    continue
+                seen_rounds.add(round_id)
+                cfg_row = con.execute(
+                    "SELECT config_json FROM round_configs WHERE round_id=?",
+                    (round_id,),
+                ).fetchone()
+                if not cfg_row:
+                    continue
+                try:
+                    config = json.loads(cfg_row["config_json"])
+                except Exception:  # noqa: BLE001
+                    continue
+                corpus_id = config.get("corpus_id")
+                if corpus_id:
+                    corpus_row = con.execute(
+                        "SELECT relative_path FROM project_corpora WHERE corpus_id=?",
+                        (corpus_id,),
+                    ).fetchone()
+                    if corpus_row and corpus_row["relative_path"]:
+                        hints.append(corpus_row["relative_path"])
+                corpus_path = config.get("corpus_path")
+                if corpus_path:
+                    hints.append(corpus_path)
+        finally:
+            con.close()
+
+    for candidate in _candidate_corpus_paths(project_root, phenotype_dir, pheno_id, hints=hints):
+        if candidate.exists():
+            return candidate
+
+    legacy = Path(project_root) / "phenotypes" / pheno_id / "corpus" / "corpus.db"
+    if legacy.exists():
+        return legacy
+
+    checked = [str(p) for p in _candidate_corpus_paths(project_root, phenotype_dir, pheno_id, hints=hints)]
+    checked.append(str(legacy))
+    raise FileNotFoundError(
+        f"Could not locate corpus.db for phenotype {pheno_id}; checked {checked}"
+    )
+
+
 def _read_corpus_db(corpus_db: Path) -> pd.DataFrame:
     con = sqlite3.connect(str(corpus_db))
     try:
@@ -55,14 +186,14 @@ def _read_round_aggregate(round_db: Path) -> pd.DataFrame:
 
 def export_inputs_from_repo(project_root: Path, pheno_id: str, prior_rounds: List[int]) -> Tuple[pd.DataFrame, pd.DataFrame]:
     root = Path(project_root)
-    # Corpus DB at: phenotypes/<pheno_id>/corpus/corpus.db
-    corpus_db = root / "phenotypes" / pheno_id / "corpus" / "corpus.db"
+    phenotype_dir = _resolve_phenotype_dir(root, pheno_id)
+    corpus_db = _find_corpus_db(root, pheno_id, prior_rounds)
     notes_df = _read_corpus_db(corpus_db)
 
-    # Aggregate from selected rounds: phenotypes/<pheno_id>/rounds/round_<n>/round_aggregate.db
+    # Aggregate from selected rounds: <storage_path>/rounds/round_<n>/round_aggregate.db
     ann_frames = []
     for r in prior_rounds:
-        round_db = root / "phenotypes" / pheno_id / "rounds" / f"round_{r}" / "round_aggregate.db"
+        round_db = phenotype_dir / "rounds" / f"round_{r}" / "round_aggregate.db"
         if round_db.exists():
             ann_frames.append(_read_round_aggregate(round_db))
     ann_df = pd.concat(ann_frames, ignore_index=True) if ann_frames else pd.DataFrame(columns=[


### PR DESCRIPTION
## Summary
- Resolve phenotype storage directories via project metadata before reading corpora for the AI backend
- Add corpus database discovery fallbacks including central project corpora resolved from metadata and round configs, while using phenotype storage paths for prior round aggregation lookups
- Add a regression test ensuring `export_inputs_from_repo` works with custom phenotype storage paths and corpora stored in the project-level `Corpora` directory

## Testing
- pytest tests/test_ai_adapters.py

------
https://chatgpt.com/codex/tasks/task_e_68f64d16c3988327880eabe508d8446a