### PR TITLE
Fix AI backend corpus and round aggregate readers

### DIFF
--- a/tests/test_ai_adapters.py
+++ b/tests/test_ai_adapters.py
@@ -136,7 +136,8 @@ def test_export_inputs_uses_storage_path(tmp_path: Path) -> None:
 
     assert isinstance(notes_df, pd.DataFrame)
     assert isinstance(ann_df, pd.DataFrame)
-    assert {"doc_id", "patienticn", "text"}.issubset(notes_df.columns)
+    assert {"doc_id", "patient_icn", "text"}.issubset(notes_df.columns)
     assert notes_df.loc[0, "doc_id"] == "doc_1"
+    assert {"round_id", "label_value", "patient_icn"}.issubset(ann_df.columns)
     assert ann_df.loc[0, "round_id"] == "ph_test_r1"
 


### PR DESCRIPTION
## Summary
- ensure the AI backend corpus reader prefers `patient_icn` while remaining compatible with legacy column names
- normalize round aggregate imports into the long format used by the AdminApp export, filling defaults for missing columns
- update the AI adapter test to reflect the normalized column names

## Testing
- pytest tests/test_ai_adapters.py

------
https://chatgpt.com/codex/tasks/task_e_68f65a6d9f488327ab9edb3c61c1c290