### PR TITLE
Improve AI backend progress log updates and cancellation

### DIFF
--- a/vaannotate/vaannotate_ai_backend/orchestrator.py
+++ b/vaannotate/vaannotate_ai_backend/orchestrator.py
@@ -129,8 +129,23 @@ class _CallbackHandler(logging.Handler):
         except Exception:  # noqa: BLE001
             message = record.getMessage()
         message = message.strip()
-        if message:
-            self._callback(message)
+        if not message:
+            return
+
+        step = getattr(record, "step", None)
+        done = getattr(record, "done", None)
+        total = getattr(record, "total", None)
+
+        if step is not None and done is not None:
+            self._callback("\r" + message)
+            if total is not None and done == total:
+                # Emit a trailing message without the carriage return so the
+                # UI can finalize the in-place progress line without adding a
+                # duplicate entry.
+                self._callback(message)
+            return
+
+        self._callback(message)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary
- ensure the admin UI exposes the worker cancel event so cancelling sets the flag immediately
- avoid duplicate cancel requests while still invoking the worker slot for logging
- render progress log records with carriage returns so the UI updates a single line in place

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69065bfd52848327876077197b6e6624