### PR TITLE
Fix RoundBuilder AI log progress updates

### DIFF
--- a/tests/test_ai_log_progress.py
+++ b/tests/test_ai_log_progress.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip(
+    "PySide6.QtWidgets",
+    reason="PySide6 QtWidgets bindings unavailable (missing libGL)",
+    exc_type=ImportError,
+)
+from PySide6 import QtWidgets
+
+from vaannotate.AdminApp.main import RoundBuilderDialog
+
+
+@pytest.fixture(scope="module")
+def qt_app() -> QtWidgets.QApplication:
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+class _LogCollector:
+    _append_ai_log = RoundBuilderDialog._append_ai_log
+    _write_ai_log_line = RoundBuilderDialog._write_ai_log_line
+    _replace_last_ai_log_line = RoundBuilderDialog._replace_last_ai_log_line
+
+    def __init__(self) -> None:
+        self.ai_log_output = QtWidgets.QTextEdit()
+        self._ai_progress_active = False
+        self._ai_progress_stamp = ""
+        self._ai_progress_text = ""
+        self._ai_progress_block_number = None
+
+
+def _datetime_generator(*stamps: str):
+    iterator = iter(stamps)
+
+    def _utcnow() -> SimpleNamespace:
+        stamp = next(iterator)
+
+        class _DateTime:
+            def __init__(self, value: str) -> None:
+                self._value = value
+
+            def strftime(self, fmt: str) -> str:
+                return self._value
+
+        return _DateTime(stamp)
+
+    return SimpleNamespace(utcnow=_utcnow)
+
+
+def test_progress_updates_preserve_prior_logs(monkeypatch, qt_app):
+    collector = _LogCollector()
+
+    fake_datetime = _datetime_generator("12:00:00", "12:00:01", "12:00:02")
+    monkeypatch.setattr("vaannotate.AdminApp.main.datetime", fake_datetime)
+
+    collector._append_ai_log("Initial message")
+    collector._append_ai_log("\rProgress update 1/3")
+    collector._append_ai_log("\rProgress update 2/3")
+
+    lines = collector.ai_log_output.toPlainText().splitlines()
+
+    assert len(lines) == 2
+    assert lines[0].endswith("Initial message")
+    assert lines[1].endswith("Progress update 2/3")

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -2669,13 +2669,13 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             target_block = doc.findBlockByNumber(block_number)
             if not target_block.isValid():
                 target_block = doc.lastBlock()
+        target_block_number = target_block.blockNumber()
         cursor = QtGui.QTextCursor(target_block)
         cursor.select(QtGui.QTextCursor.BlockUnderCursor)
-        cursor.removeSelectedText()
         cursor.insertText(f"[{stamp}] {text}")
         self.ai_log_output.setTextCursor(cursor)
         self.ai_log_output.ensureCursorVisible()
-        return cursor.blockNumber()
+        return target_block_number
 
     def reject(self) -> None:  # type: ignore[override]
         if self._ai_job_running:


### PR DESCRIPTION
## Summary
- ensure the RoundBuilder dialog preserves existing log entries when progress lines update in place
- add a regression test covering iter_with_bar log updates (skipped automatically when Qt is unavailable)

## Testing
- pytest tests/test_ai_log_progress.py

------
https://chatgpt.com/codex/tasks/task_e_69066308b6448327bdd310bff9cf7506