### PR TITLE
Ensure label config gating metadata matches backend format

### DIFF
--- a/tests/test_project_label_config.py
+++ b/tests/test_project_label_config.py
@@ -62,8 +62,20 @@ def test_build_label_config_dependency_tree() -> None:
     assert isinstance(child_entry, dict)
     assert child_entry.get("parents")[0]["label_id"] == "Root"
     assert child_entry.get("children")[0]["label_id"] == "ChildB"
+    assert child_entry.get("gated_by") == "Root"
+    rules = child_entry.get("gating_rules")
+    assert isinstance(rules, list) and rules
+    assert rules[0]["parent"] == "Root"
+    assert rules[0]["type"] == "categorical"
+    assert rules[0]["op"] == "in"
+    assert rules[0]["values"] == ["yes"]
 
     grandchild_entry = config.get("ChildB")
     assert isinstance(grandchild_entry, dict)
     assert grandchild_entry.get("parents")[0]["label_id"] == "ChildA"
     assert grandchild_entry.get("gating_expr") == "Child A == 'positive'"
+    assert grandchild_entry.get("gated_by") == "ChildA"
+    grules = grandchild_entry.get("gating_rules")
+    assert isinstance(grules, list) and grules
+    assert grules[0]["parent"] == "ChildA"
+    assert grules[0]["values"] == ["positive"]


### PR DESCRIPTION
## Summary
- generate gated_by and gating_rules metadata when building label_config payloads
- resolve phenotype directories from stored storage_path when writing AdminApp label_config files
- extend label config tests to cover new gating metadata structure expected by the AI backend

## Testing
- pytest tests/test_project_label_config.py
- pytest tests/test_client_annotation_form.py


------
https://chatgpt.com/codex/tasks/task_e_690bc265a0b883279bc717e62b220084