### PR TITLE
Centralize label config storage and update labelset constraints

### DIFF
--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -53,7 +53,7 @@ PROJECT_SCHEMA = [
     """,
     """
     CREATE TABLE IF NOT EXISTS labels(
-        label_id TEXT PRIMARY KEY,
+        label_id TEXT NOT NULL,
         labelset_id TEXT NOT NULL,
         name TEXT NOT NULL,
         type TEXT NOT NULL,
@@ -64,17 +64,21 @@ PROJECT_SCHEMA = [
         na_allowed INTEGER DEFAULT 0,
         unit TEXT,
         min REAL,
-        max REAL
+        max REAL,
+        PRIMARY KEY(labelset_id, label_id)
     );
     """,
     """
     CREATE TABLE IF NOT EXISTS label_options(
         option_id TEXT PRIMARY KEY,
+        labelset_id TEXT NOT NULL,
         label_id TEXT NOT NULL,
         value TEXT NOT NULL,
         display TEXT NOT NULL,
         order_index INTEGER NOT NULL,
-        weight REAL
+        weight REAL,
+        FOREIGN KEY(labelset_id) REFERENCES label_sets(labelset_id),
+        FOREIGN KEY(labelset_id, label_id) REFERENCES labels(labelset_id, label_id)
     );
     """,
     """

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -175,7 +175,7 @@ class Label(Record):
     __schema__ = (
         """
         CREATE TABLE IF NOT EXISTS labels (
-            label_id TEXT PRIMARY KEY,
+            label_id TEXT NOT NULL,
             labelset_id TEXT NOT NULL,
             name TEXT NOT NULL,
             type TEXT NOT NULL,
@@ -187,6 +187,7 @@ class Label(Record):
             unit TEXT NULL,
             min REAL NULL,
             max REAL NULL,
+            PRIMARY KEY(labelset_id, label_id),
             FOREIGN KEY(labelset_id) REFERENCES label_sets(labelset_id)
         )
         """
@@ -196,6 +197,7 @@ class Label(Record):
 @dataclass
 class LabelOption(Record):
     option_id: str
+    labelset_id: str
     label_id: str
     value: str
     display: str
@@ -207,12 +209,14 @@ class LabelOption(Record):
         """
         CREATE TABLE IF NOT EXISTS label_options (
             option_id TEXT PRIMARY KEY,
+            labelset_id TEXT NOT NULL,
             label_id TEXT NOT NULL,
             value TEXT NOT NULL,
             display TEXT NOT NULL,
             order_index INTEGER NOT NULL,
             weight REAL NULL,
-            FOREIGN KEY(label_id) REFERENCES labels(label_id)
+            FOREIGN KEY(labelset_id) REFERENCES label_sets(labelset_id),
+            FOREIGN KEY(labelset_id, label_id) REFERENCES labels(labelset_id, label_id)
         )
         """
     )


### PR DESCRIPTION
## Summary
- move generated label_config.json files into a centralized label_sets/<labelset_id> folder and update the admin UI and AI backend to read from this location while still honoring existing legacy files
- allow label identifiers to be reused across label sets by adjusting the schema, ORM models, and admin queries to key options by both labelset_id and label_id
- add project-level tests that exercise the new label config path helper and the relaxed label id uniqueness rules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690bc805f8c483278d567d27bd88ed86