### PR TITLE
Ensure AI backend returns final selection DataFrame

### DIFF
--- a/vaannotate/vaannotate_ai_backend/engine.py
+++ b/vaannotate/vaannotate_ai_backend/engine.py
@@ -3892,8 +3892,10 @@ class ActiveLearningLLMFirst:
             ).drop_duplicates(subset=["unit_id"], keep="first")
     
         final.to_parquet(os.path.join(self.paths.outdir, "final_selection.parquet"), index=False)
+        result_df = final
 
         # (Optional) run family labeling on the final units for transparency/audit
+        final_out = None
         if self.cfg.final_llm_labeling:
             fam_rows = []
             fam = FamilyLabeler(self.llm, self.rag, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst)
@@ -3944,6 +3946,8 @@ class ActiveLearningLLMFirst:
                 final_units = final[["unit_id", "label_id", "label_type", "selection_reason"]].drop_duplicates()
                 final_out = final_units.merge(fam_wide, on="unit_id", how="left")
                 final_out.to_parquet(os.path.join(self.paths.outdir, "final_selection_with_llm.parquet"), index=False)
+        if final_out is not None:
+            result_df = final_out
         
         diagnostics = {
             "total_selected": int(len(final)),
@@ -3967,6 +3971,8 @@ class ActiveLearningLLMFirst:
         hours, remainder = divmod(total_seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
         print(f"Done. Total elapsed: {int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}")
+
+        return result_df
         
         
 # ------------------------------


### PR DESCRIPTION
## Summary
- have the AI engine return the final selection dataframe so downstream callers can safely copy it
- preserve final-LLM labeling enrichment when present by returning the merged dataframe

## Testing
- pytest tests/test_ai_engine_label_overlays.py

------
https://chatgpt.com/codex/tasks/task_e_690bd6174d708327bf7c0aa55716540c