### PR TITLE
Fix label config handling and enrich AI output metadata

### DIFF
--- a/vaannotate/vaannotate_ai_backend/orchestrator.py
+++ b/vaannotate/vaannotate_ai_backend/orchestrator.py
@@ -24,9 +24,6 @@ def _default_paths(outdir: Path, cache_dir: Path | None = None) -> engine.Paths:
 
 def _apply_overrides(target: object, overrides: Mapping[str, Any]) -> None:
     for key, value in overrides.items():
-        if key == "phenotype_level":
-            # Not currently consumed directly by the engine config.
-            continue
         if isinstance(value, Mapping):
             current = getattr(target, key, None)
             if current is not None and not isinstance(current, (str, bytes, int, float, bool)):


### PR DESCRIPTION
## Summary
- sanitize the AI backend label config before use and propagate the phenotype level into the orchestrator
- ensure the AI backend derives patient/doc mappings per unit and injects patient identifiers into the final selection output
- expand engine unit tests to cover label-config sanitization and dependency handling

## Testing
- pytest tests/test_ai_engine_label_overlays.py
- pytest tests/test_round_import.py::test_generate_round_with_preselected_csv tests/test_round_import.py::test_generate_round_with_preselected_multi_doc

------
https://chatgpt.com/codex/tasks/task_e_690be05549f88327874ae2030c1f6ccd