### PR TITLE
Filter metadata entries from AI label configs

### DIFF
--- a/tests/test_ai_adapters.py
+++ b/tests/test_ai_adapters.py
@@ -117,8 +117,9 @@ def test_export_inputs_uses_storage_path(tmp_path: Path) -> None:
     assert isinstance(ann_df, pd.DataFrame)
     assert {"doc_id", "patient_icn", "text"}.issubset(notes_df.columns)
     assert notes_df.loc[0, "doc_id"] == "doc_1"
-    assert {"round_id", "label_value", "patient_icn"}.issubset(ann_df.columns)
+    assert {"round_id", "label_value", "patient_icn", "labelset_id"}.issubset(ann_df.columns)
     assert ann_df.loc[0, "round_id"] == "ph_test_r1"
     assert ann_df.loc[0, "reviewer_id"] == "rev1"
     assert ann_df.loc[0, "document_text"] == "Sample text"
+    assert ann_df.loc[0, "labelset_id"] == "ls_test"
 

--- a/vaannotate/vaannotate_ai_backend/cli.py
+++ b/vaannotate/vaannotate_ai_backend/cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse, json
 from pathlib import Path
 import pandas as pd
+
+from .label_configs import LabelConfigBundle
 from .orchestrator import build_next_batch
 
 def main():
@@ -25,7 +27,14 @@ def main():
     label_config = json.loads(Path(args.label_config).read_text()) if args.label_config else None
     cfg_overrides = json.loads(Path(args.cfg).read_text()) if args.cfg else None
 
-    final_df, artifacts = build_next_batch(notes_df, ann_df, outdir=Path(args.outdir), label_config=label_config, cfg_overrides=cfg_overrides)
+    bundle = LabelConfigBundle(current=label_config) if label_config else None
+    final_df, artifacts = build_next_batch(
+        notes_df,
+        ann_df,
+        outdir=Path(args.outdir),
+        label_config_bundle=bundle,
+        cfg_overrides=cfg_overrides,
+    )
     print(str(artifacts["ai_next_batch_csv"]))
 
 if __name__ == "__main__":

--- a/vaannotate/vaannotate_ai_backend/label_configs.py
+++ b/vaannotate/vaannotate_ai_backend/label_configs.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Mapping, Optional
+
+
+def sanitize_label_config(config: Mapping[str, Any] | None) -> Dict[str, Any]:
+    """Return a shallow copy of ``config`` without metadata entries."""
+
+    if not isinstance(config, Mapping):
+        return {}
+    return {key: value for key, value in dict(config).items() if str(key) != "_meta"}
+
+
+@dataclass(frozen=True)
+class LabelConfigBundle:
+    """Collection of label configurations for the AI backend.
+
+    Attributes
+    ----------
+    current:
+        The label configuration for the round currently being built.
+    current_labelset_id:
+        Identifier of the current round's label set.
+    legacy:
+        Mapping of legacy ``labelset_id`` values to their materialised label
+        configurations.  The current label set may also be present here for
+        convenience when code paths expect legacy lookups by identifier.
+    round_labelsets:
+        Mapping of known ``round_id`` values (and/or round numbers encoded as
+        strings) to their associated ``labelset_id``.
+    """
+
+    current: Optional[Dict[str, object]] = None
+    current_labelset_id: Optional[str] = None
+    legacy: Dict[str, Dict[str, object]] = field(default_factory=dict)
+    round_labelsets: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.current is not None:
+            object.__setattr__(self, "current", sanitize_label_config(self.current))
+        sanitized_legacy = {
+            str(labelset_id): sanitize_label_config(config)
+            for labelset_id, config in (self.legacy or {}).items()
+        }
+        object.__setattr__(self, "legacy", sanitized_legacy)
+
+    def with_current_fallback(self, label_config: Mapping[str, object] | None) -> "LabelConfigBundle":
+        """Return a bundle where ``current`` is populated from ``label_config``.
+
+        This is primarily used to maintain compatibility with existing call
+        sites that still supply a single ``label_config`` dictionary.
+        """
+
+        if label_config is None:
+            return self
+        sanitized = sanitize_label_config(label_config)
+        if self.current == sanitized:
+            return self
+        return replace(self, current=sanitized)
+
+    def config_for_labelset(self, labelset_id: Optional[str]) -> Dict[str, object]:
+        """Return the materialised label configuration for ``labelset_id``."""
+
+        if not labelset_id:
+            return self.current or {}
+        normalized = str(labelset_id)
+        if self.current_labelset_id and normalized == str(self.current_labelset_id):
+            if self.current is not None:
+                return self.current
+        return self.legacy.get(normalized, self.current or {})
+
+    def config_for_round(self, round_identifier: Optional[str]) -> Dict[str, object]:
+        """Return the configuration associated with ``round_identifier``."""
+
+        if not round_identifier:
+            return self.current or {}
+        labelset_id = self.round_labelsets.get(str(round_identifier))
+        return self.config_for_labelset(labelset_id)
+
+
+EMPTY_BUNDLE = LabelConfigBundle()


### PR DESCRIPTION
## Summary
- sanitize bundled label configurations so _meta blocks are not treated as label definitions
- ignore _meta entries when building label dependency graphs in the engine
- add regression coverage to ensure the bundle surfaces only real labels

## Testing
- pytest tests/test_ai_adapters.py tests/test_ai_engine_label_overlays.py

------
https://chatgpt.com/codex/tasks/task_e_690cbec5c5b0832788b0aaaab0f4bbfa