### PR TITLE
Ensure AI next-batch includes patient/doc identifiers

### DIFF
--- a/vaannotate/vaannotate_ai_backend/orchestrator.py
+++ b/vaannotate/vaannotate_ai_backend/orchestrator.py
@@ -25,9 +25,6 @@ def _default_paths(outdir: Path, cache_dir: Path | None = None) -> engine.Paths:
 
 def _apply_overrides(target: object, overrides: Mapping[str, Any]) -> None:
     for key, value in overrides.items():
-        if key == "phenotype_level":
-            # Not currently consumed directly by the engine config.
-            continue
         if isinstance(value, Mapping):
             current = getattr(target, key, None)
             if current is not None and not isinstance(current, (str, bytes, int, float, bool)):
@@ -207,8 +204,10 @@ def build_next_batch(
 
     # Build config
     cfg = engine.OrchestratorConfig()
-    if cfg_overrides:
-        _apply_overrides(cfg, cfg_overrides)
+    overrides = dict(cfg_overrides or {})
+    phenotype_level = overrides.pop("phenotype_level", None)
+    if overrides:
+        _apply_overrides(cfg, overrides)
 
     bundle = (label_config_bundle or EMPTY_BUNDLE).with_current_fallback(label_config)
 
@@ -218,6 +217,7 @@ def build_next_batch(
                 paths=paths,
                 cfg=cfg,
                 label_config_bundle=bundle,
+                phenotype_level=phenotype_level,
             )
             final_df = orch.run()  # engine returns DataFrame
 


### PR DESCRIPTION
## Summary
- propagate the phenotype level through the AI backend so repositories and orchestrator know when units are single- vs multi-document
- attach patient and, when applicable, document identifiers to the engine output so `ai_next_batch.csv` contains the metadata RoundBuilder needs
- add regression coverage for multi- and single-document metadata attachment

## Testing
- pytest tests/test_ai_engine_label_overlays.py

------
https://chatgpt.com/codex/tasks/task_e_690ccd4464e083278d67f356680037a3