### PR TITLE
Ensure AI round builder syncs project cache

### DIFF
--- a/vaannotate/shared/database.py
+++ b/vaannotate/shared/database.py
@@ -108,6 +108,20 @@ class Database:
     def is_dirty(self) -> bool:
         return self._dirty
 
+    def refresh_from_disk(self) -> None:
+        """Reload the cached database contents from disk."""
+
+        if not self._cache_enabled:
+            return
+
+        if self._memory_keeper is not None:
+            self._memory_keeper.close()
+            self._memory_keeper = None
+
+        self._memory_uri = None
+        self._cache_enabled = False
+        self.enable_memory_cache()
+
 
 class Record:
     """Base class for ORM style records."""


### PR DESCRIPTION
## Summary
- flush the cached project database before generating AI-assisted rounds
- refresh the cached database after the round builder writes new metadata
- add a database helper to reload cached SQLite files from disk

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690cdaae6750832782adf0c4185d6436