### PR TITLE
Add RoundBuilder final LLM labeling integration

### DIFF
--- a/vaannotate/vaannotate_ai_backend/engine.py
+++ b/vaannotate/vaannotate_ai_backend/engine.py
@@ -4201,6 +4201,29 @@ class ActiveLearningLLMFirst:
                 final_units = final[["unit_id", "label_id", "label_type", "selection_reason"]].drop_duplicates()
                 final_out = final_units.merge(fam_wide, on="unit_id", how="left")
                 final_out.to_parquet(os.path.join(self.paths.outdir, "final_selection_with_llm.parquet"), index=False)
+
+                labels_path = Path(self.paths.outdir) / "final_llm_labels.parquet"
+                try:
+                    fam_wide.to_parquet(labels_path, index=False)
+                except Exception:
+                    pass
+                else:
+                    try:
+                        labels_path.with_suffix(".json").write_text(
+                            fam_wide.to_json(orient="records", indent=2, force_ascii=False),
+                            encoding="utf-8",
+                        )
+                    except TypeError:
+                        labels_path.with_suffix(".json").write_text(
+                            fam_wide.to_json(orient="records"),
+                            encoding="utf-8",
+                        )
+
+            try:
+                probe_json_path = Path(self.paths.outdir) / "final_llm_family_probe.json"
+                fam_df.to_json(probe_json_path, orient="records", indent=2, force_ascii=False)
+            except TypeError:
+                fam_df.to_json(probe_json_path, orient="records")
         if final_out is not None:
             result_df = final_out
         

--- a/vaannotate/vaannotate_ai_backend/orchestrator.py
+++ b/vaannotate/vaannotate_ai_backend/orchestrator.py
@@ -246,16 +246,26 @@ def build_next_batch(
     else:
         normalized.to_csv(csv_path, index=False)
 
+    outdir_path = Path(outdir)
     artifacts = {
         "ai_next_batch_csv": str(csv_path),
         "buckets": {
-            "disagreement": str(Path(outdir) / "bucket_disagreement.parquet"),
-            "llm_uncertain": str(Path(outdir) / "bucket_llm_uncertain.parquet"),
-            "llm_certain": str(Path(outdir) / "bucket_llm_certain.parquet"),
-            "diversity": str(Path(outdir) / "bucket_diversity.parquet"),
+            "disagreement": str(outdir_path / "bucket_disagreement.parquet"),
+            "llm_uncertain": str(outdir_path / "bucket_llm_uncertain.parquet"),
+            "llm_certain": str(outdir_path / "bucket_llm_certain.parquet"),
+            "diversity": str(outdir_path / "bucket_diversity.parquet"),
         },
-        "final_labels": str(Path(outdir) / "final_llm_labels.parquet")
-        if (Path(outdir) / "final_llm_labels.parquet").exists()
+        "final_labels": str(outdir_path / "final_llm_labels.parquet")
+        if (outdir_path / "final_llm_labels.parquet").exists()
+        else None,
+        "final_labels_json": str(outdir_path / "final_llm_labels.json")
+        if (outdir_path / "final_llm_labels.json").exists()
+        else None,
+        "final_family_probe": str(outdir_path / "final_llm_family_probe.parquet")
+        if (outdir_path / "final_llm_family_probe.parquet").exists()
+        else None,
+        "final_family_probe_json": str(outdir_path / "final_llm_family_probe.json")
+        if (outdir_path / "final_llm_family_probe.json").exists()
         else None,
     }
     return normalized, artifacts


### PR DESCRIPTION
## Summary
- add an optional final LLM labeling step to RoundBuilder that reuses AI backend artifacts or runs the family labeler directly when needed
- persist final LLM outputs (Parquet/JSON) from the AI backend engine and expose their locations through the orchestrator and round config
- store the generated LLM outputs alongside round artifacts for both AI backend and random sample workflows

## Testing
- pytest tests/test_round_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_690d08cae1a48327bddfd43016b8b8b9