### PR TITLE
Ensure random final LLM labeling builds corpus embeddings

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -562,6 +562,17 @@ class RoundBuilder:
             phenotype_level=phenotype_level,
         )
 
+        # Ensure the RAG retriever has access to corpus embeddings. The AI backend
+        # pathway builds the chunk index prior to any LLM labeling so that each
+        # call has patient-level context with reranking. The random sampling
+        # pathway skips the orchestrator run loop, so we need to explicitly build
+        # the embeddings/index here as well.
+        orchestrator.store.build_chunk_index(
+            orchestrator.repo.notes,
+            orchestrator.cfg.rag,
+            orchestrator.cfg.index,
+        )
+
         _, _, current_rules_map, current_label_types = orchestrator._label_maps()
         family_labeler = FamilyLabeler(
             orchestrator.llm,


### PR DESCRIPTION
## Summary
- build the corpus chunk index for random final LLM labeling runs before invoking the family labeler
- ensure the random sampling pathway reuses the same RAG context and reranking as the AI backend orchestrator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690d2321bb008327b51e0a11d233eecb