### PR TITLE
Fix AI cold-start corpus resolution

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -237,6 +237,8 @@ class AIRoundWorker(QtCore.QObject):
                     label_config=label_config_payload,
                     log_callback=self.log_message.emit,
                     cancel_callback=self._cancel_event.is_set,
+                    corpus_record=self.job.context.corpus_record,
+                    corpus_id=self.job.context.corpus_id,
                 )
             finally:
                 for key, prior in original_env.items():


### PR DESCRIPTION
## Summary
- expand the AI backend corpus lookup to accept explicit corpus metadata for new rounds
- pass the selected corpus record from the Admin app when launching the AI backend
- add a regression test covering cold-start corpus selection without prior rounds

## Testing
- pytest tests/test_ai_adapters.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5a58add883279dc3c14eee42bde9)