### PR TITLE
Fix single-doc RAG context resolution

### DIFF
--- a/tests/test_ai_adapters.py
+++ b/tests/test_ai_adapters.py
@@ -39,6 +39,7 @@ if "langchain" not in sys.modules:
 from vaannotate.project import add_phenotype, get_connection, init_project
 from vaannotate.schema import initialize_assignment_db, initialize_corpus_db
 from vaannotate.vaannotate_ai_backend.adapters import export_inputs_from_repo
+from vaannotate.vaannotate_ai_backend.engine import DataRepository, _contexts_for_unit_label
 
 
 def test_export_inputs_uses_storage_path(tmp_path: Path) -> None:
@@ -189,4 +190,131 @@ def test_export_inputs_cold_start_uses_selected_corpus(tmp_path: Path) -> None:
     assert not notes_df.empty
     assert notes_df.loc[0, "doc_id"] == "doc_1"
     assert ann_df.empty
+
+
+def test_contexts_for_unit_label_full_mode() -> None:
+    notes_df = pd.DataFrame(
+        [
+            {
+                "patient_icn": "p1",
+                "doc_id": "doc_full",
+                "text": "Full document context text",
+                "unit_id": "assign-1",
+            },
+        ]
+    )
+    ann_df = pd.DataFrame(
+        {
+            "round_id": pd.Series(dtype="object"),
+            "unit_id": pd.Series(dtype="object"),
+            "doc_id": pd.Series(dtype="object"),
+            "label_id": pd.Series(dtype="object"),
+            "reviewer_id": pd.Series(dtype="object"),
+            "label_value": pd.Series(dtype="object"),
+        }
+    )
+
+    repo = DataRepository(notes_df, ann_df, phenotype_level="single_doc")
+
+    class DummyStore:
+        def __init__(self) -> None:
+            self.chunk_meta = [
+                {"unit_id": "doc_full", "doc_id": "doc_full", "chunk_id": "0", "text": "chunk"}
+            ]
+
+        def get_patient_chunk_indices(self, unit_id: str) -> list[int]:
+            if str(unit_id) == "doc_full":
+                return [0]
+            return []
+
+    class DummyRetriever:
+        def __init__(self) -> None:
+            self.store = DummyStore()
+            self.called = False
+
+        def _extract_meta(self, meta: dict) -> dict:
+            return {"note_type": "demo", "other_meta": "meta"}
+
+        def retrieve_for_patient_label(self, *args: object, **kwargs: object) -> list[dict]:
+            self.called = True
+            return [{"text": "fallback"}]
+
+    retriever = DummyRetriever()
+
+    contexts = _contexts_for_unit_label(
+        retriever,
+        repo,
+        "doc_full",
+        "label1",
+        "",
+        single_doc_context_mode="full",
+        full_doc_char_limit=50,
+    )
+
+    assert len(contexts) == 1
+    ctx = contexts[0]
+    assert ctx["source"] == "full_doc"
+    assert ctx["doc_id"] == "doc_full"
+    assert ctx["text"] == "Full document context text"[:50]
+    assert ctx["metadata"].get("other_meta") == "meta"
+    assert not retriever.called
+
+
+def test_contexts_for_unit_label_maps_assignment_ids() -> None:
+    notes_df = pd.DataFrame(
+        [
+            {
+                "patient_icn": "p1",
+                "doc_id": "doc_full",
+                "text": "Some text",
+                "unit_id": "assign-1",
+            }
+        ]
+    )
+    ann_df = pd.DataFrame(
+        [
+            {
+                "round_id": "r1",
+                "unit_id": "assign-1",
+                "doc_id": "doc_full",
+                "label_id": "lab",
+                "reviewer_id": "rev",
+                "label_value": "",
+            }
+        ]
+    )
+    repo = DataRepository(notes_df, ann_df, phenotype_level="single_doc")
+
+    class DummyStore:
+        def get_patient_chunk_indices(self, unit_id: str) -> list[int]:
+            assert unit_id == "doc_full"
+            return []
+
+        chunk_meta: list[dict] = []
+
+    class DummyRetriever:
+        def __init__(self) -> None:
+            self.store = DummyStore()
+            self.calls: list[str] = []
+
+        def _extract_meta(self, meta: dict) -> dict:
+            return {}
+
+        def retrieve_for_patient_label(self, unit_id: str, *args: object, **kwargs: object) -> list[dict]:
+            self.calls.append(unit_id)
+            return [{"text": "rag"}]
+
+    retriever = DummyRetriever()
+
+    contexts = _contexts_for_unit_label(
+        retriever,
+        repo,
+        "assign-1",
+        "lab",
+        "",
+        single_doc_context_mode="rag",
+    )
+
+    assert contexts == [{"text": "rag"}]
+    assert retriever.calls == ["doc_full"]
 

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -2335,6 +2335,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             edit.setText(directory)
 
     def _setup_ui(self) -> None:
+        self.ai_single_doc_context_combo: Optional[QtWidgets.QComboBox] = None
         layout = QtWidgets.QVBoxLayout(self)
         scroll = QtWidgets.QScrollArea()
         scroll.setWidgetResizable(True)
@@ -2619,6 +2620,14 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.ai_final_llm_checkbox = QtWidgets.QCheckBox("Run final LLM labeling")
         self.ai_final_llm_checkbox.setChecked(True)
         ai_config_layout.addRow("Final LLM labeling", self.ai_final_llm_checkbox)
+        if str(self.pheno_row["level"] or "single_doc") == "single_doc":
+            self.ai_single_doc_context_combo = QtWidgets.QComboBox()
+            self.ai_single_doc_context_combo.addItem("RAG snippets", "rag")
+            self.ai_single_doc_context_combo.addItem("Full document", "full")
+            self.ai_single_doc_context_combo.setToolTip(
+                "Choose how the LLM context is built for single-document phenotypes."
+            )
+            ai_config_layout.addRow("Single-doc context", self.ai_single_doc_context_combo)
         pct_hint = QtWidgets.QLabel("Fractions should sum to ≤ 1.0; remaining slots are auto-filled.")
         pct_hint.setWordWrap(True)
         ai_config_layout.addRow(pct_hint)
@@ -3080,6 +3089,20 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             azure_endpoint = self.ai_azure_endpoint_edit.text().strip()
             if azure_endpoint:
                 backend_cfg["azure_endpoint"] = azure_endpoint
+        if (
+            pheno_level == "single_doc"
+            and isinstance(self.ai_single_doc_context_combo, QtWidgets.QComboBox)
+        ):
+            mode_value = self.ai_single_doc_context_combo.currentData()
+            if not isinstance(mode_value, str) or not mode_value:
+                mode_value = "rag"
+            existing_llmfirst = backend_cfg.get("llmfirst")
+            if isinstance(existing_llmfirst, dict):
+                llmfirst_cfg = existing_llmfirst
+            else:
+                llmfirst_cfg = {}
+                backend_cfg["llmfirst"] = llmfirst_cfg
+            llmfirst_cfg["single_doc_context"] = mode_value
 
         return RoundCreationContext(
             pheno_id=pheno_id,
@@ -3357,6 +3380,17 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             overrides["select"] = select
         if hasattr(self, "ai_final_llm_checkbox"):
             overrides["final_llm_labeling"] = bool(self.ai_final_llm_checkbox.isChecked())
+        llmfirst_overrides: Dict[str, Any] = {}
+        if (
+            str(self.pheno_row["level"] or "single_doc") == "single_doc"
+            and isinstance(self.ai_single_doc_context_combo, QtWidgets.QComboBox)
+        ):
+            mode_value = self.ai_single_doc_context_combo.currentData()
+            if not isinstance(mode_value, str) or not mode_value:
+                mode_value = "rag"
+            llmfirst_overrides["single_doc_context"] = mode_value
+        if llmfirst_overrides:
+            overrides["llmfirst"] = llmfirst_overrides
         return overrides
 
     def _on_ai_thread_finished(self) -> None:

--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -461,6 +461,7 @@ class RoundBuilder:
                 FamilyLabeler,
                 OrchestratorConfig,
                 Paths,
+                _contexts_for_unit_label,
             )
         except ImportError as exc:  # pragma: no cover - runtime guard
             raise RuntimeError("AI backend components are required for assisted chart review") from exc
@@ -501,6 +502,22 @@ class RoundBuilder:
         paths = Paths(str(notes_path), str(ann_path), str(work_dir / "engine_outputs"))
 
         ai_backend_config = config.get("ai_backend") if isinstance(config.get("ai_backend"), Mapping) else {}
+        llmfirst_overrides = (
+            ai_backend_config.get("llmfirst")
+            if isinstance(ai_backend_config.get("llmfirst"), Mapping)
+            else {}
+        )
+        mode_override = llmfirst_overrides.get("single_doc_context")
+        if mode_override:
+            setattr(cfg.llmfirst, "single_doc_context", str(mode_override))
+        limit_override = llmfirst_overrides.get("single_doc_full_context_max_chars")
+        if limit_override is not None:
+            try:
+                limit_value = int(limit_override)
+            except (TypeError, ValueError):
+                limit_value = None
+            if limit_value and limit_value > 0:
+                setattr(cfg.llmfirst, "single_doc_full_context_max_chars", limit_value)
         env_overrides: Dict[str, str] = {}
         embed_path = self._resolve_optional_path(ai_backend_config.get("embedding_model_dir"), config_base)
         if embed_path:
@@ -551,11 +568,15 @@ class RoundBuilder:
                 unit_map: Dict[str, list[dict[str, Any]]] = {}
                 for label_id in sorted(current_label_types.keys()):
                     rules_text = current_rules_map.get(label_id, "")
-                    contexts = orchestrator.rag.retrieve_for_patient_label(
+                    contexts = _contexts_for_unit_label(
+                        orchestrator.rag,
+                        orchestrator.repo,
                         unit_id,
                         label_id,
                         rules_text,
                         topk_override=top_n,
+                        single_doc_context_mode=getattr(orchestrator.cfg.llmfirst, "single_doc_context", "rag"),
+                        full_doc_char_limit=getattr(orchestrator.cfg.llmfirst, "single_doc_full_context_max_chars", None),
                     )
                     if not contexts:
                         continue
@@ -820,6 +841,24 @@ class RoundBuilder:
         cfg.final_llm_labeling = True
         cfg.final_llm_labeling_n_consistency = max(1, consistency)
         setattr(cfg.llmfirst, "final_llm_label_consistency", cfg.final_llm_labeling_n_consistency)
+
+        ai_backend_config = config.get("ai_backend") if isinstance(config.get("ai_backend"), Mapping) else {}
+        llmfirst_overrides = (
+            ai_backend_config.get("llmfirst")
+            if isinstance(ai_backend_config.get("llmfirst"), Mapping)
+            else {}
+        )
+        mode_override = llmfirst_overrides.get("single_doc_context")
+        if mode_override:
+            setattr(cfg.llmfirst, "single_doc_context", str(mode_override))
+        limit_override = llmfirst_overrides.get("single_doc_full_context_max_chars")
+        if limit_override is not None:
+            try:
+                limit_value = int(limit_override)
+            except (TypeError, ValueError):
+                limit_value = None
+            if limit_value and limit_value > 0:
+                setattr(cfg.llmfirst, "single_doc_full_context_max_chars", limit_value)
 
         phenotype_level = str(pheno_row["level"] or "multi_doc")
         label_config_payload = build_label_config(labelset)


### PR DESCRIPTION
## Summary
- map single-document assignment unit identifiers back to their document ids inside `DataRepository` and expose a `doc_id_for_unit` helper
- ensure `_contexts_for_unit_label` always resolves the correct doc id before fetching either full-doc or RAG snippets so contexts reach the LLM
- add regression coverage confirming the helper works when `unit_id` differs from `doc_id`

## Testing
- pytest tests/test_ai_adapters.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150c84d08c8327982af61fdefe06cb)