### PR TITLE
Reset annotation widgets when loading new unit

### DIFF
--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -1357,8 +1357,12 @@ class AnnotationForm(QtWidgets.QScrollArea):
         self.current_annotations = annotations
         self.current_rationales = rationales
         with self._suspend_widget_signals():
+            for widgets in self.label_widgets.values():
+                self._reset_widgets(widgets)
             for label_id, widgets in self.label_widgets.items():
-                self._apply_annotation(label_id, widgets, annotations.get(label_id, {}))
+                annotation = annotations.get(label_id)
+                if annotation:
+                    self._apply_annotation(label_id, widgets, annotation)
                 self._refresh_highlights(label_id)
         self._update_gating()
         self._update_completion()


### PR DESCRIPTION
## Summary
- reset all annotation widgets before applying cached data when a unit is loaded
- ensure highlight panes still refresh after clearing previous selections

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161d39a26c8327ac081ed56f5c3407)