### PR TITLE
Validate LLM auto-submit predictions

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -207,6 +207,13 @@ class RoundBuilder:
             ]
             if not unit_ids:
                 continue
+            missing_predictions = [unit_id for unit_id in unit_ids if unit_id not in predictions]
+            if missing_predictions:
+                missing_preview = ", ".join(sorted(missing_predictions))
+                raise RuntimeError(
+                    "Final LLM outputs missing predictions for reviewer "
+                    f"{reviewer_id}: {missing_preview}"
+                )
             assign_dir = round_dir / "assignments" / reviewer_id
             db_path = assign_dir / "assignment.db"
             if not db_path.exists():


### PR DESCRIPTION
## Summary
- raise an error when auto-submitting LLM assignments without predictions for every unit
- add a regression test covering missing predictions during round generation

## Testing
- pytest tests/test_round_import.py::test_generate_round_auto_submits_llm_reviewer tests/test_round_import.py::test_generate_round_auto_submit_llm_missing_predictions

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691690d3c99883278814d9e3ff67f24c)