### PR TITLE
Add option to drop reasoning field from LLM outputs

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -1134,6 +1134,7 @@ class RoundBuilder:
         cfg.final_llm_labeling = True
         cfg.final_llm_labeling_n_consistency = max(1, consistency)
         setattr(cfg.llmfirst, "final_llm_label_consistency", cfg.final_llm_labeling_n_consistency)
+        setattr(cfg.llm, "include_reasoning", bool(include_reasoning))
 
         ai_backend_config = config.get("ai_backend") if isinstance(config.get("ai_backend"), Mapping) else {}
         llmfirst_overrides = (


### PR DESCRIPTION
## Summary
- allow RoundBuilder to propagate a final LLM include_reasoning flag down to the orchestrator configuration
- teach the engine to honor that flag by omitting the reasoning key from prompts and stored JSON payloads
- cover the new behavior with a focused unit test that exercises the annotator without a real backend

## Testing
- pytest tests/test_llm_reasoning.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb424f54c8327b271b9b210bf65df)