### PR TITLE
Ensure local AI backend selection ignores Azure env defaults

### DIFF
--- a/tests/test_ai_backend_config.py
+++ b/tests/test_ai_backend_config.py
@@ -1,0 +1,87 @@
+"""Tests for AI backend configuration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+import importlib.util
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+
+def _install_stub_modules() -> None:
+    class _DummyModel:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple stub
+            pass
+
+    stubs = {
+        "numpy": {},
+        "pandas": {},
+        "sentence_transformers": {
+            "SentenceTransformer": _DummyModel,
+            "CrossEncoder": _DummyModel,
+        },
+        "langchain_text_splitters": {
+            "RecursiveCharacterTextSplitter": type("RecursiveCharacterTextSplitter", (), {}),
+        },
+        "langchain": {},
+        "langchain.text_splitter": {
+            "RecursiveCharacterTextSplitter": type("RecursiveCharacterTextSplitter", (), {}),
+        },
+    }
+    for name, attrs in stubs.items():
+        if name in sys.modules:
+            continue
+        module = types.ModuleType(name)
+        for attr, value in attrs.items():
+            setattr(module, attr, value)
+        sys.modules[name] = module
+
+
+_install_stub_modules()
+
+
+def _load_engine_module():
+    module_path = ROOT / "vaannotate" / "vaannotate_ai_backend" / "engine.py"
+    spec = importlib.util.spec_from_file_location(
+        "vaannotate.vaannotate_ai_backend.engine", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load engine module for testing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ENGINE_MODULE = _load_engine_module()
+
+
+def test_llm_config_respects_runtime_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """LLMConfig should read environment variables at instantiation time."""
+
+    LLMConfig = ENGINE_MODULE.LLMConfig
+
+    local_dir = tmp_path / "LocalModel"
+    local_dir.mkdir()
+
+    monkeypatch.setenv("LLM_BACKEND", "exllamav2")
+    monkeypatch.setenv("LOCAL_LLM_MODEL_DIR", str(local_dir))
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+
+    cfg_local = LLMConfig()
+    assert cfg_local.backend == "exllamav2"
+    assert cfg_local.local_model_dir == str(local_dir)
+
+    monkeypatch.setenv("LLM_BACKEND", "azure")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "key")
+
+    cfg_azure = LLMConfig()
+    assert cfg_azure.backend == "azure"
+    assert cfg_azure.azure_endpoint == "https://example.azure.com"
+    assert cfg_azure.azure_api_key == "key"

--- a/vaannotate/vaannotate_ai_backend/engine.py
+++ b/vaannotate/vaannotate_ai_backend/engine.py
@@ -118,8 +118,10 @@ def _env_int(name: str, default: Optional[int] = None) -> Optional[int]:
 
 @dataclass
 class LLMConfig:
-    model_name: str = os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
-    backend: str = os.getenv("LLM_BACKEND", "azure")
+    model_name: str = field(
+        default_factory=lambda: os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
+    )
+    backend: str = field(default_factory=lambda: os.getenv("LLM_BACKEND", "azure"))
     temperature: float = 0.2
     n_consistency: int = 3
     logprobs: bool = True
@@ -132,13 +134,25 @@ class LLMConfig:
     rpm_limit: Optional[int] = 30
     include_reasoning: bool = False
     # Azure OpenAI specific knobs
-    azure_api_key: Optional[str] = os.getenv("AZURE_OPENAI_API_KEY")
-    azure_api_version: str = os.getenv("AZURE_OPENAI_API_VERSION", "2024-06-01")
-    azure_endpoint: Optional[str] = os.getenv("AZURE_OPENAI_ENDPOINT")
+    azure_api_key: Optional[str] = field(
+        default_factory=lambda: os.getenv("AZURE_OPENAI_API_KEY")
+    )
+    azure_api_version: str = field(
+        default_factory=lambda: os.getenv("AZURE_OPENAI_API_VERSION", "2024-06-01")
+    )
+    azure_endpoint: Optional[str] = field(
+        default_factory=lambda: os.getenv("AZURE_OPENAI_ENDPOINT")
+    )
     # Local ExLlamaV2 specific knobs
-    local_model_dir: Optional[str] = os.getenv("LOCAL_LLM_MODEL_DIR")
-    local_max_seq_len: Optional[int] = _env_int("LOCAL_LLM_MAX_SEQ_LEN")
-    local_max_new_tokens: Optional[int] = _env_int("LOCAL_LLM_MAX_NEW_TOKENS")
+    local_model_dir: Optional[str] = field(
+        default_factory=lambda: os.getenv("LOCAL_LLM_MODEL_DIR")
+    )
+    local_max_seq_len: Optional[int] = field(
+        default_factory=lambda: _env_int("LOCAL_LLM_MAX_SEQ_LEN")
+    )
+    local_max_new_tokens: Optional[int] = field(
+        default_factory=lambda: _env_int("LOCAL_LLM_MAX_NEW_TOKENS")
+    )
     
 @dataclass
 class SelectionConfig:


### PR DESCRIPTION
## Summary
- ensure `LLMConfig` evaluates backend-related environment variables at instantiation time so runtime overrides pick the correct inference backend
- add a regression test that exercises the new behavior using stubbed dependencies to avoid importing heavy modules

## Testing
- pytest tests/test_ai_backend_config.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd66d25388327aeade5eb9d852000)