### PR TITLE
Improve BM25 tokenization and global idf handling

### DIFF
--- a/vaannotate/vaannotate_ai_backend/engine.py
+++ b/vaannotate/vaannotate_ai_backend/engine.py
@@ -1803,6 +1803,14 @@ class RAGRetriever:
             return []
         return re.findall(r"\b\w+\b", str(text).lower())
 
+    def _tokenize_for_bm25(self, text: str) -> List[str]:
+        if hasattr(self.store, "_tokenize_for_bm25"):
+            try:
+                return self.store._tokenize_for_bm25(text)
+            except Exception:
+                pass
+        return self._tokenize(text)
+
     def _bm25_index_for_patient(self, unit_id: str) -> Optional[dict]:
         uid = str(unit_id)
         cached = self._bm25_cache.get(uid)


### PR DESCRIPTION
## Summary
- normalize and tokenize BM25 text with clinical-friendly regex and stopword filtering
- compute BM25 IDF globally across all chunks and persist shared statistics
- use global IDF with per-patient docs when scoring keyword queries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a6f07f40883278fee49f554da6aef)