### PR TITLE
Convert round listings to dicts

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -1254,13 +1254,14 @@ class ProjectContext(QtCore.QObject):
             ).fetchone()
         return row
 
-    def list_rounds(self, pheno_id: str) -> List[sqlite3.Row]:
+    def list_rounds(self, pheno_id: str) -> List[Dict[str, object]]:
         db = self.require_db()
         with db.connect() as conn:
-            return conn.execute(
+            rows = conn.execute(
                 "SELECT * FROM rounds WHERE pheno_id=? ORDER BY round_number",
                 (pheno_id,),
             ).fetchall()
+        return [dict(row) for row in rows]
 
     def list_label_sets(self) -> List[sqlite3.Row]:
         db = self.require_db()


### PR DESCRIPTION
## Summary
- convert rounds fetched from the database into standard dictionaries to support mapping-style access when building UI options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de2458b0083279aa23aefc43f2425)