### PR TITLE
Defer LLM backend until after embedding load

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -839,6 +839,7 @@ class RoundBuilder:
                 orchestrator.cfg.rag,
                 orchestrator.cfg.index,
             )
+            orchestrator.ensure_llm_backend()
             _, _, current_rules_map, current_label_types = orchestrator._label_maps()
             family_labeler = FamilyLabeler(
                 orchestrator.llm,


### PR DESCRIPTION
## Summary
- add lazy LLM backend initialization so embeddings/cross-encoders load before ExLlamaV2
- ensure orchestrator loads the LLM backend after building chunk indexes in both CLI and rounds workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f3c60244c8327828d69fa5bedf1e7)