### PR TITLE
Add labelset keywords and few-shot defaults

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -1524,6 +1524,8 @@ class RoundBuilder:
                     "range": {"min": entry.get("min"), "max": entry.get("max")},
                     "gating_expr": entry.get("gating_expr"),
                     "options": options,
+                    "keywords": entry.get("keywords", []),
+                    "few_shot_examples": entry.get("few_shot_examples", []),
                 }
             )
 

--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -65,6 +65,8 @@ PROJECT_SCHEMA = [
         unit TEXT,
         min REAL,
         max REAL,
+        keywords_json TEXT,
+        few_shot_json TEXT,
         PRIMARY KEY(labelset_id, label_id)
     );
     """,

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -170,6 +170,8 @@ class Label(Record):
     unit: Optional[str]
     min: Optional[float]
     max: Optional[float]
+    keywords_json: Optional[str] = None
+    few_shot_json: Optional[str] = None
 
     __tablename__ = "labels"
     __schema__ = (
@@ -187,6 +189,8 @@ class Label(Record):
             unit TEXT NULL,
             min REAL NULL,
             max REAL NULL,
+            keywords_json TEXT NULL,
+            few_shot_json TEXT NULL,
             PRIMARY KEY(labelset_id, label_id),
             FOREIGN KEY(labelset_id) REFERENCES label_sets(labelset_id)
         )


### PR DESCRIPTION
## Summary
- add storage for label-level keywords and few-shot examples in label sets
- extend label set builder UI with per-label keywords and context/response editors
- preload RoundBuilder AI settings with label set keywords and examples

## Testing
- python -m compileall vaannotate/AdminApp/main.py vaannotate/rounds.py vaannotate/shared/models.py vaannotate/schema.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f3dc4cc8c8327a92660903747925f)