### PR TITLE
Fix embedding temp file extension

### DIFF
--- a/vaannotate/vaannotate_ai_backend/engine.py
+++ b/vaannotate/vaannotate_ai_backend/engine.py
@@ -1303,7 +1303,7 @@ class EmbeddingStore:
         os.replace(tmp, meta_p)
         # Save embeddings (np.save is atomic-ish via temp file on most FS; to be safe, write to tmp then replace)
         X_to_save = X.astype(np.float16)
-        emb_tmp = emb_p + ".tmp"
+        emb_tmp = emb_p + ".tmp.npz"
         np.savez_compressed(emb_tmp, embeddings=X_to_save)
         os.replace(emb_tmp, emb_p)
         if emb_legacy and os.path.exists(emb_legacy):


### PR DESCRIPTION
## Summary
- prevent chunk embedding cache writes from pointing to non-existent temporary file paths by using a .npz-suffixed temp file

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f432129d88327ab21805d97556e0a)