### PR TITLE
Handle labelset metadata when building AI rounds

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -1561,7 +1561,10 @@ class RoundBuilder:
             "labels": schema_labels,
         }
         if labelset_id is not None:
-            payload["labelset_name"] = labelset_id
+            labelset_name = None
+            if isinstance(labelset, Mapping):
+                labelset_name = labelset.get("labelset_name")
+            payload["labelset_name"] = labelset_name or labelset_id
         if isinstance(labelset, Mapping):
             for key in ("created_by", "created_at", "notes"):
                 value = labelset.get(key)

--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -85,6 +85,12 @@ def _load_label_config_bundle(
     round_labelsets: Dict[str, str] = {}
     current_config: Optional[Dict[str, Any]] = overrides.copy() if overrides else None
     current_labelset_id = labelset_id
+    if current_config is not None and not current_labelset_id:
+        meta = current_config.get("_meta") if isinstance(current_config, Mapping) else None
+        if isinstance(meta, Mapping):
+            inferred = meta.get("labelset_id") or meta.get("labelset_name")
+            if inferred:
+                current_labelset_id = str(inferred)
 
     if not project_db.exists():
         return LabelConfigBundle(


### PR DESCRIPTION
## Summary
- infer a label set identifier from label config metadata when starting AI rounds
- preserve label set names from database metadata when exporting label schema payloads

## Testing
- pytest -q *(fails: missing libGL.so.1 in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4851068c8327bf0a5dac781622ab)