### PR TITLE
Handle dict overrides safely

### DIFF
--- a/vaannotate/vaannotate_ai_backend/orchestrator.py
+++ b/vaannotate/vaannotate_ai_backend/orchestrator.py
@@ -24,6 +24,20 @@ def _default_paths(outdir: Path, cache_dir: Path | None = None) -> engine.Paths:
 
 
 def _apply_overrides(target: object, overrides: Mapping[str, Any]) -> None:
+    if isinstance(target, dict):
+        for key, value in overrides.items():
+            if isinstance(value, Mapping):
+                current = target.get(key)
+                if isinstance(current, Mapping):
+                    nested = dict(current)
+                    _apply_overrides(nested, value)
+                    target[key] = nested
+                else:
+                    target[key] = dict(value)
+            else:
+                target[key] = value
+        return
+
     for key, value in overrides.items():
         if isinstance(value, Mapping):
             current = getattr(target, key, None)


### PR DESCRIPTION
## Summary
- update override application helper to handle dict targets instead of using attribute access
- allow configuration keys with spaces or other non-attribute-safe names without raising errors

## Testing
- pytest tests/test_ai_engine_label_overlays.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4b77ae78832784bdf7ffe3327323)