### PR TITLE
Propagate advanced LLM settings and exclude prior units

### DIFF
--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -783,8 +783,14 @@ def run_ai_backend_and_collect(
     if sampling_metadata:
         artifacts.setdefault("sampling", dict(sampling_metadata))
     if excluded_ids:
+        applicable_mask = None
+        if "selection_reason" in final_df.columns:
+            reasons = final_df["selection_reason"].astype(str)
+            applicable_mask = reasons.str.startswith("llm_") | reasons.str.startswith("diversity")
         identifiers = final_df.apply(lambda row: _unit_identifier_from_row(row, level), axis=1)
         mask = identifiers.isin(excluded_ids)
+        if applicable_mask is not None:
+            mask &= applicable_mask
         removed = int(mask.sum())
         if removed:
             final_df = final_df.loc[~mask].reset_index(drop=True)

--- a/vaannotate/vaannotate_ai_backend/engine.py
+++ b/vaannotate/vaannotate_ai_backend/engine.py
@@ -5001,7 +5001,9 @@ class ActiveLearningLLMFirst:
                 print("[1/4] Disagreement quota is zero; refreshing schema only ...")
             check_cancelled()
             dis_pairs = self.build_disagreement_bucket(seen_pairs, legacy_rules_map, legacy_label_types)
-            dis_pairs = _filter_units(dis_pairs, seen_units | selected_units)
+            # Keep prior-round units eligible for disagreement reviews while still
+            # preventing duplicates within the current batch.
+            dis_pairs = _filter_units(dis_pairs, selected_units)
             dis_units = _head_units(_to_unit_only(dis_pairs), n_dis)
         dis_units.to_parquet(dis_path, index=False)
         selected_rows.append(dis_units)


### PR DESCRIPTION
## Summary
- apply AI advanced configuration overrides to final LLM labeling, including consistency, include_reasoning, and engine settings from the RoundBuilder dialog
- store sampling metadata and honor independent sampling by excluding previously reviewed units from AI backend suggestions

## Testing
- python -m pytest tests/test_ai_log_progress.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6e8aaae88327bff8cb1c79c40c17)