### PR TITLE
Delay exclusions until after chunk fingerprinting

### DIFF
--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -733,27 +733,6 @@ def run_ai_backend_and_collect(
     if scope_corpus_to_annotations:
         notes_df = _scope_corpus_to_annotations(notes_df, ann_df, log)
 
-    def _exclude_reviewed(df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
-        if df.empty or not excluded_ids:
-            return df, 0
-        identifiers = df.apply(lambda row: _unit_identifier_from_row(row, level), axis=1)
-        mask = identifiers.isin(excluded_ids)
-        removed = int(mask.sum())
-        if not removed:
-            return df, 0
-        return df.loc[~mask].reset_index(drop=True), removed
-
-    notes_df, notes_removed = _exclude_reviewed(notes_df)
-    ann_df, ann_removed = _exclude_reviewed(ann_df)
-    if notes_removed or ann_removed:
-        log(
-            "Excluded "
-            f"{notes_removed} corpus rows and {ann_removed} annotations "
-            "matching previously reviewed units"
-        )
-    if notes_df.empty:
-        raise RuntimeError("No candidate units remain after excluding previously reviewed units.")
-
     ai_dir = Path(round_dir) / "imports" / "ai"
     ai_dir.mkdir(parents=True, exist_ok=True)
     log(f"Exported {len(notes_df)} corpus rows and {len(ann_df)} prior annotations")
@@ -782,6 +761,8 @@ def run_ai_backend_and_collect(
             select_overrides["pct_disagreement"] = 0.0
         log("No prior rounds detected; skipping disagreement bucket for round zero.")
     overrides["select"] = select_overrides
+    if excluded_ids:
+        overrides["excluded_unit_ids"] = sorted(excluded_ids)
     overrides.setdefault("phenotype_level", level)
 
     bundle = _load_label_config_bundle(


### PR DESCRIPTION
## Summary
- allow exclusion lists to flow into the orchestrator configuration and repository
- apply excluded units after chunk index reuse so caching is preserved while pruning candidates
- keep AI backend suggestions filtered for previously reviewed units without forcing re-embedding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693054ef913483279dbdf99b9c913fd3)