### PR TITLE
Fix context order selection for LLM snippet sorting

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -5176,15 +5176,15 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             if not isinstance(mode_value, str) or not mode_value:
                 mode_value = "rag"
             llmfirst_overrides["single_doc_context"] = mode_value
-        if isinstance(getattr(self, "ai_context_order_combo", None), QtWidgets.QComboBox):
-            order_value = self.ai_context_order_combo.currentData()
-            if isinstance(order_value, str) and order_value:
-                llmfirst_overrides["context_order"] = order_value
         if llmfirst_overrides:
             overrides["llmfirst"] = llmfirst_overrides
         llm_overrides: Dict[str, Any] = {}
         if isinstance(overrides.get("llm"), Mapping):
             llm_overrides.update(overrides.get("llm", {}))
+        if isinstance(getattr(self, "ai_context_order_combo", None), QtWidgets.QComboBox):
+            order_value = self.ai_context_order_combo.currentData()
+            if isinstance(order_value, str) and order_value:
+                llm_overrides["context_order"] = order_value
         backend_choice = self._current_ai_backend()
         if backend_choice:
             llm_overrides["backend"] = backend_choice

--- a/vaannotate/AdminApp/prompt_builder.py
+++ b/vaannotate/AdminApp/prompt_builder.py
@@ -81,6 +81,8 @@ class PromptBuilderConfig:
             llm_cfg["embedding_model_dir"] = self.embedding_model_dir
         if self.reranker_model_dir:
             llm_cfg["reranker_model_dir"] = self.reranker_model_dir
+        if self.context_order:
+            llm_cfg["context_order"] = self.context_order
 
         rag_cfg: Dict[str, object] = {
             "chunk_size": self.rag_chunk_size,
@@ -94,15 +96,11 @@ class PromptBuilderConfig:
             "system_prompt": self.system_prompt,
         }
 
-        llmfirst_cfg: Dict[str, object] = {}
-        if self.context_order:
-            llmfirst_cfg["context_order"] = self.context_order
-
         return {
             "llm": llm_cfg,
             "rag": rag_cfg,
             "prompt_builder": prompt_cfg,
-            "llmfirst": llmfirst_cfg,
+            "llmfirst": {},
         }
 
 

--- a/vaannotate/vaannotate_ai_backend/engine.py
+++ b/vaannotate/vaannotate_ai_backend/engine.py
@@ -157,6 +157,8 @@ class LLMConfig:
     local_max_new_tokens: Optional[int] = field(
         default_factory=lambda: _env_int("LOCAL_LLM_MAX_NEW_TOKENS")
     )
+    # Context ordering for snippets
+    context_order: str = "relevance"  # relevance | chronological
     
 @dataclass
 class SelectionConfig:


### PR DESCRIPTION
## Summary
- add context_order to the LLM configuration to honor chronological ordering requests
- propagate context order selection from the Admin UI and prompt builder into the LLM config overrides
- ensure context ordering preference is used during snippet sorting

## Testing
- python -m pytest tests/test_ai_backend_config.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930613314c083278c892473088df417)