### PR TITLE
Handle Azure response_format schema incompatibility

### DIFF
--- a/vaannotate/vaannotate_ai_backend/llm_backends.py
+++ b/vaannotate/vaannotate_ai_backend/llm_backends.py
@@ -219,7 +219,15 @@ class AzureOpenAIBackend(LLMBackend):
             "logprobs": bool(logprobs),
         }
         if response_format:
-            kwargs["response_format"] = response_format
+            # Azure currently rejects nested JSON schema fields ("response_format.json_schema")
+            # with a 400 error. We therefore strip the schema detail and rely on the
+            # model's default JSON mode behaviour instead.
+            if "json_schema" in response_format:
+                rf_clean = dict(response_format)
+                rf_clean.pop("json_schema", None)
+                kwargs["response_format"] = rf_clean
+            else:
+                kwargs["response_format"] = response_format
         if logprobs and top_logprobs:
             kwargs["top_logprobs"] = int(top_logprobs)
         t0 = time.time()


### PR DESCRIPTION
## Summary
- avoid sending unsupported `response_format.json_schema` to Azure OpenAI chat completions
- fall back to Azure JSON mode without explicit schema when a schema is provided

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307b5667d48327b2493c5903bdad80)