### PR TITLE
Default cross encoder max length to 512

### DIFF
--- a/tests/test_ai_backend_config.py
+++ b/tests/test_ai_backend_config.py
@@ -85,3 +85,20 @@ def test_llm_config_respects_runtime_env(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert cfg_azure.backend == "azure"
     assert cfg_azure.azure_endpoint == "https://example.azure.com"
     assert cfg_azure.azure_api_key == "key"
+
+
+def test_cross_encoder_default_max_length_applied() -> None:
+    reranker = type("_StubRerankerNoMax", (), {})()
+
+    ENGINE_MODULE._ensure_default_ce_max_length(reranker, default=777)
+
+    assert hasattr(reranker, "max_length")
+    assert reranker.max_length == 777
+
+
+def test_cross_encoder_existing_max_length_preserved() -> None:
+    reranker = type("_StubRerankerWithMax", (), {"max_length": 1024})()
+
+    ENGINE_MODULE._ensure_default_ce_max_length(reranker, default=777)
+
+    assert reranker.max_length == 1024


### PR DESCRIPTION
## Summary
- add a helper to apply a default cross encoder max length when none is configured
- apply the fallback during reranker initialization
- add tests to ensure the default is set while preserving explicit values

## Testing
- pytest tests/test_ai_backend_config.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b96a75fc832790e33b6e1f363020)