### PR TITLE
Add custom search query overrides to RAG retrieval

### DIFF
--- a/tests/test_project_label_config.py
+++ b/tests/test_project_label_config.py
@@ -5,6 +5,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
 
+from vaannotate.rounds import RoundBuilder
 from vaannotate.project import (
     add_labelset,
     add_phenotype,
@@ -226,3 +227,20 @@ def test_label_keywords_and_examples_round_trip(tmp_path: Path) -> None:
     assert entry.get("few_shot_examples") == [
         {"context": "example context", "answer": "answer text"}
     ]
+
+
+def test_apply_label_queries_and_extract(tmp_path: Path) -> None:
+    base_config = {"lab1": {"label_id": "lab1", "name": "Query label"}}
+    merged = RoundBuilder._apply_label_queries(base_config, {"lab1": "custom query text"})
+    assert merged["lab1"]["search_query"] == "custom query text"
+
+    config_override = {
+        "rag": {
+            "label_queries": {
+                "lab1": "override query",
+                "lab2": " second ",
+            }
+        }
+    }
+    extracted = RoundBuilder._extract_label_queries(config_override)
+    assert extracted == {"lab1": "override query", "lab2": "second"}


### PR DESCRIPTION
## Summary
- allow per-label custom search queries to be entered alongside keywords and propagate them into label configs
- adjust retrieval to favor exemplar-based semantic queries by default and honor manual overrides for reranking
- add coverage for applying and extracting label-level query overrides

## Testing
- python -m pytest tests/test_project_label_config.py::test_apply_label_queries_and_extract


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931df3118c8832795e9c1047c1d54e2)