### PR TITLE
Surface RAG pool controls in advanced settings

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -260,17 +260,21 @@ AI_CONFIG_TOOLTIPS: Dict[str, Dict[str, str]] = {
         "chunk_size": "Maximum characters per text chunk before embedding.",
         "chunk_overlap": "Overlap between consecutive chunks to preserve context.",
         "normalize_embeddings": "L2-normalize embeddings before indexing/searching.",
-        "per_label_topk": "Top-k chunks to keep per label during retrieval.",
+        "per_label_topk": "Top-k chunks to keep per label during retrieval (legacy; use top_k_final).",
+        "top_k_final": "Final number of chunks kept per label after reranking.",
         "use_mmr": "Use maximal marginal relevance to diversify retrieved chunks.",
         "mmr_lambda": "MMR trade-off between relevance (1.0) and diversity (0.0).",
         "mmr_candidates": "Candidate pool size for MMR selection.",
-        "use_keywords": "Blend keyword search results into retrieval.",
+        "use_keywords": "Enable keyword/BM25 retrieval when keyword_fraction > 0.",
+        "keyword_fraction": "Blend between BM25 keywords and semantic search when constructing the pre–rerank pool (0=semantic only, 1=keywords only).",
         "keyword_topk": "How many keyword hits to include when enabled.",
         "keywords": "Comma-separated keywords to seed lexical retrieval across all labels.",
         "label_keywords": "Optional JSON mapping of label_id → keywords (list or comma-separated string) for BM25 search.",
         "min_context_chunks": "Minimum chunks of context to pass to the LLM.",
         "mmr_multiplier": "Scale the number of chunks considered for MMR diversification.",
         "neighbor_hops": "How many hops to explore around selected chunks for neighbors.",
+        "pool_factor": "Multiplier for the combined semantic/keyword pool size before reranking.",
+        "pool_oversample": "Oversample factor for each channel before deduplication to boost recall.",
     },
     "llm": {
         "model_name": "LLM deployment/model identifier.",
@@ -698,8 +702,11 @@ class AIAdvancedConfigDialog(QtWidgets.QDialog):
             form.setFieldGrowthPolicy(QtWidgets.QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
             widgets: Dict[str, QtWidgets.QWidget] = {}
             for field_name, value in section_values.items():
-                if key == "rag" and self._label_schema_labels and field_name == "label_queries":
-                    continue
+                if key == "rag":
+                    if self._label_schema_labels and field_name == "label_queries":
+                        continue
+                    if field_name in {"per_label_topk", "use_keywords", "keyword_topk"}:
+                        continue
                 widget = self._build_field_widget(
                     key, field_name, value, section_values=section_values
                 )

--- a/vaannotate/vaannotate_ai_backend/retrieval_coordinator.py
+++ b/vaannotate/vaannotate_ai_backend/retrieval_coordinator.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Tuple
+
+
+@dataclass
+class SemanticQuery:
+    text: str
+    embedding: object
+    source: str = "semantic"
+
+
+class RetrievalCoordinator:
+    """Coordinate semantic + keyword retrieval into a single candidate pool."""
+
+    def __init__(
+        self,
+        semantic_searcher: Callable[[SemanticQuery, int], List[dict]],
+        keyword_searcher: Callable[[List[str], int], List[dict]],
+    ):
+        self.semantic_searcher = semantic_searcher
+        self.keyword_searcher = keyword_searcher
+
+    def build_candidate_pool(
+        self,
+        *,
+        semantic_queries: Iterable[SemanticQuery],
+        keywords: Iterable[str],
+        top_k_final: int,
+        keyword_fraction: float,
+        pool_factor: int = 3,
+        oversample: float = 1.5,
+    ) -> tuple[list[dict], dict]:
+        keyword_fraction = max(0.0, min(1.0, float(keyword_fraction)))
+        pool_target = max(1, int(math.ceil(top_k_final * pool_factor * oversample)))
+        keyword_fraction = 0.0 if not keywords else keyword_fraction
+        semantic_only = keyword_fraction <= 0.0
+        keyword_only = keyword_fraction >= 1.0
+
+        semantic_target = pool_target if semantic_only else int(
+            math.ceil(pool_target * (1.0 - keyword_fraction))
+        )
+        keyword_target = pool_target if keyword_only else int(
+            math.ceil(pool_target * keyword_fraction)
+        )
+
+        def _need(target: int) -> int:
+            return max(1, int(math.ceil(max(target, top_k_final) * oversample)))
+
+        semantic_hits = self._run_semantic_search(
+            semantic_queries, need=_need(semantic_target)
+        )
+        keyword_hits = self._run_keyword_search(list(keywords), need=_need(keyword_target))
+
+        semantic_best = self._dedup_channel(semantic_hits, channel="semantic")
+        keyword_best = self._dedup_channel(keyword_hits, channel="keyword")
+
+        combined: Dict[Tuple[str, int], dict] = {}
+        selected = self._select_from_channel(combined, semantic_best, semantic_target)
+        selected += self._select_from_channel(combined, keyword_best, keyword_target)
+
+        remaining = self._remaining_candidates(
+            semantic_best, keyword_best, semantic_target, keyword_target
+        )
+        for hit in remaining:
+            if len(selected) >= pool_target:
+                break
+            key = (str(hit.get("doc_id")), int(hit.get("chunk_id", -1)))
+            if key in combined:
+                continue
+            combined[key] = hit
+            selected.append(hit)
+
+        selected.sort(key=lambda h: float(h.get("score", 0.0)), reverse=True)
+
+        diagnostics = {
+            "pool_target": pool_target,
+            "semantic_target": semantic_target,
+            "keyword_target": keyword_target,
+            "semantic_hits": len(semantic_hits),
+            "keyword_hits": len(keyword_hits),
+            "semantic_kept": len(semantic_best),
+            "keyword_kept": len(keyword_best),
+            "final_pool": len(selected),
+        }
+
+        return selected, diagnostics
+
+    def _run_semantic_search(
+        self, semantic_queries: Iterable[SemanticQuery], need: int
+    ) -> list[dict]:
+        hits: list[dict] = []
+        for query in semantic_queries:
+            run_hits = self.semantic_searcher(query, need) or []
+            for hit in run_hits:
+                hit = dict(hit)
+                hit.setdefault("source", f"patient_{query.source}")
+                hits.append(hit)
+        return hits
+
+    def _run_keyword_search(self, keywords: List[str], need: int) -> list[dict]:
+        if not keywords:
+            return []
+        hits = self.keyword_searcher(keywords, need) or []
+        for hit in hits:
+            hit.setdefault("source", "keyword")
+        return hits
+
+    def _dedup_channel(self, hits: list[dict], channel: str) -> list[dict]:
+        best: Dict[Tuple[str, int], dict] = {}
+        for hit in hits:
+            key = (str(hit.get("doc_id")), int(hit.get("chunk_id", -1)))
+            score = float(hit.get("score", 0.0))
+            prev = best.get(key)
+            if prev is None or score > float(prev.get("score", 0.0)):
+                updated = dict(hit)
+                updated[channel + "_score"] = score
+                updated["score"] = score
+                best[key] = updated
+        return sorted(best.values(), key=lambda h: float(h.get("score", 0.0)), reverse=True)
+
+    def _select_from_channel(
+        self, combined: Dict[Tuple[str, int], dict], hits: list[dict], target: int
+    ) -> list[dict]:
+        selected: list[dict] = []
+        for hit in hits[:target]:
+            key = (str(hit.get("doc_id")), int(hit.get("chunk_id", -1)))
+            if key in combined:
+                existing = combined[key]
+                existing["score"] = max(
+                    float(existing.get("score", 0.0)), float(hit.get("score", 0.0))
+                )
+                existing.update({k: v for k, v in hit.items() if k.endswith("_score")})
+                continue
+            combined[key] = hit
+            selected.append(hit)
+        return selected
+
+    def _remaining_candidates(
+        self,
+        semantic_hits: list[dict],
+        keyword_hits: list[dict],
+        semantic_target: int,
+        keyword_target: int,
+    ) -> list[dict]:
+        leftovers = semantic_hits[semantic_target:] + keyword_hits[keyword_target:]
+        leftovers.sort(key=lambda h: float(h.get("score", 0.0)), reverse=True)
+        return leftovers
+


### PR DESCRIPTION
## Summary
- expose top_k_final, keyword_fraction, pool_factor, and pool_oversample in the advanced RAG settings with updated tooltips
- prefer top_k_final in the retriever configuration and clamp keyword fractions used to build the candidate pool

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693219a6014483278bec1621d7d715cf)