### PR TITLE
Apply CE-based MMR after reranking

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -705,7 +705,13 @@ class AIAdvancedConfigDialog(QtWidgets.QDialog):
                 if key == "rag":
                     if self._label_schema_labels and field_name == "label_queries":
                         continue
-                    if field_name in {"per_label_topk", "use_keywords", "keyword_topk"}:
+                    if field_name in {
+                        "per_label_topk",
+                        "use_keywords",
+                        "keyword_topk",
+                        "mmr_candidates",
+                        "mmr_multiplier",
+                    }:
                         continue
                 widget = self._build_field_widget(
                     key, field_name, value, section_values=section_values


### PR DESCRIPTION
## Summary
- add CE-score-based MMR that uses embedding cosine similarity to diversify the final selection
- run optional MMR after cross-encoder reranking while retaining simple top-k slicing when disabled
- keep candidate budget limiting before CE scoring and update diagnostics accordingly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321cb536b483278ee97eef73d962fd)