### PR TITLE
Improve prompt builder corpus scoping

### DIFF
--- a/vaannotate/AdminApp/prompt_builder.py
+++ b/vaannotate/AdminApp/prompt_builder.py
@@ -249,7 +249,7 @@ class PromptInferenceJob:
         self.pheno_id = pheno_id
         self.labelset_id = labelset_id
         self.phenotype_level = phenotype_level
-        self.adjudicated_rounds = list(adjudicated_rounds)
+        self.adjudicated_rounds = sorted({int(r) for r in adjudicated_rounds})
         self.corpus_id = corpus_id
         self.corpus_path = Path(corpus_path) if corpus_path else None
         self.run_root = Path(run_root) if run_root else Path(project_root) / "prompt_runs"

--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -648,6 +648,7 @@ def export_inputs_from_repo(
     corpus_id: Optional[str] = None,
     corpus_path: Optional[str] = None,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    prior_rounds = sorted({int(r) for r in prior_rounds})
     root = Path(project_root)
     phenotype_dir = _resolve_phenotype_dir(root, pheno_id)
     corpus_db = _find_corpus_db(
@@ -731,12 +732,14 @@ def _scope_corpus_to_annotations(
     if ann_df.empty or "doc_id" not in ann_df.columns or "doc_id" not in notes_df.columns:
         return notes_df
 
-    ann_doc_ids = ann_df["doc_id"].dropna().astype(str)
+    ann_doc_ids = ann_df["doc_id"].dropna().astype(str).str.strip()
+    ann_doc_ids = ann_doc_ids.loc[ann_doc_ids != ""]
     if ann_doc_ids.empty:
         return notes_df
 
     scoped_notes = notes_df.copy()
-    scoped_notes["doc_id"] = scoped_notes["doc_id"].astype(str)
+    scoped_notes["doc_id"] = scoped_notes["doc_id"].astype(str).str.strip()
+    scoped_notes = scoped_notes.loc[scoped_notes["doc_id"] != ""]
     mask = scoped_notes["doc_id"].isin(set(ann_doc_ids))
     if mask.all():
         return scoped_notes


### PR DESCRIPTION
## Summary
- sanitize selected round numbers before running prompt-builder inference jobs
- ignore empty document identifiers when scoping the corpus to prior annotations so documents remain available for chunking

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333bed61a0832797aa1bcf20d6d1fb)