### PR TITLE
Limit inference to selected compatible rounds

### DIFF
--- a/tests/test_ai_adapters.py
+++ b/tests/test_ai_adapters.py
@@ -225,6 +225,113 @@ def test_export_inputs_filters_rounds_by_labelset(tmp_path: Path) -> None:
     assert any("label set mismatches" in msg for msg in messages)
 
 
+def test_export_inputs_filters_rounds_before_corpus_lookup(tmp_path: Path) -> None:
+    project_root = tmp_path / "Project"
+    paths = init_project(project_root, "proj", "Project", "tester")
+
+    pheno_id = "ph_labelset_corpus"
+    storage_relative = Path("phenotypes") / pheno_id
+    phenotype_dir = project_root / storage_relative
+    (phenotype_dir / "rounds").mkdir(parents=True, exist_ok=True)
+
+    corpus_dir = project_root / "corpora" / pheno_id
+    corpus_dir.mkdir(parents=True, exist_ok=True)
+    primary_corpus = corpus_dir / "primary.db"
+    secondary_corpus = corpus_dir / "secondary.db"
+
+    for path, doc_id, patient_icn in [
+        (primary_corpus, "doc_primary", "p1"),
+        (secondary_corpus, "doc_secondary", "p2"),
+    ]:
+        with initialize_corpus_db(path) as conn:
+            conn.execute("INSERT INTO patients(patient_icn) VALUES (?)", (patient_icn,))
+            conn.execute(
+                """
+                INSERT INTO documents(doc_id, patient_icn, date_note, hash, text, metadata_json)
+                VALUES (?,?,?,?,?,?)
+                """,
+                (doc_id, patient_icn, "2020-01-01", "hash", f"{doc_id} text", "{}"),
+            )
+            conn.execute("ALTER TABLE documents ADD COLUMN patienticn TEXT")
+            conn.execute("UPDATE documents SET patienticn = patient_icn")
+            conn.execute("ALTER TABLE documents ADD COLUMN notetype TEXT")
+            conn.execute("UPDATE documents SET notetype = ''")
+            conn.commit()
+
+    with get_connection(paths.project_db) as conn:
+        add_phenotype(
+            conn,
+            pheno_id=pheno_id,
+            project_id="proj",
+            name="Phenotype",
+            level="single_doc",
+            storage_path=str(storage_relative.as_posix()),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO rounds(round_id, pheno_id, round_number, labelset_id, config_hash, rng_seed, status, created_at)
+            VALUES (?,?,?,?,?,?,?,?)
+            """,
+            ("ph_labelset_corpus_r1", pheno_id, 1, "ls_primary", "hash", 0, "finalized", "2020-01-01T00:00:00"),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO rounds(round_id, pheno_id, round_number, labelset_id, config_hash, rng_seed, status, created_at)
+            VALUES (?,?,?,?,?,?,?,?)
+            """,
+            ("ph_labelset_corpus_r2", pheno_id, 2, "ls_secondary", "hash", 0, "finalized", "2020-01-02T00:00:00"),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO round_configs(round_id, config_json) VALUES (?, ?)",
+            (
+                "ph_labelset_corpus_r1",
+                json.dumps({"corpus_path": str(primary_corpus.relative_to(project_root))}),
+            ),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO round_configs(round_id, config_json) VALUES (?, ?)",
+            (
+                "ph_labelset_corpus_r2",
+                json.dumps({"corpus_path": str(secondary_corpus.relative_to(project_root))}),
+            ),
+        )
+        conn.commit()
+
+    round_dir = phenotype_dir / "rounds" / "round_1"
+    imports_dir = round_dir / "imports"
+    imports_dir.mkdir(parents=True, exist_ok=True)
+    assignment_db = imports_dir / "rev_assignment.db"
+    with initialize_assignment_db(assignment_db) as conn:
+        conn.execute(
+            "INSERT INTO units(unit_id, display_rank, patient_icn, doc_id, note_count) VALUES (?,?,?,?,?)",
+            ("unit_1", 1, "p1", "doc_primary", 1),
+        )
+        conn.execute(
+            "INSERT INTO documents(doc_id, hash, text, metadata_json) VALUES (?,?,?,?)",
+            ("doc_primary", "hash", "doc_primary text", "{}"),
+        )
+        conn.execute(
+            "INSERT INTO unit_notes(unit_id, doc_id, order_index) VALUES (?,?,?)",
+            ("unit_1", "doc_primary", 0),
+        )
+        conn.execute(
+            "INSERT INTO annotations(unit_id, label_id, value, value_num, na, notes) VALUES (?,?,?,?,?,?)",
+            ("unit_1", "LabelA", "yes", None, 0, "note"),
+        )
+        conn.commit()
+
+    notes_df, ann_df = export_inputs_from_repo(
+        project_root,
+        pheno_id,
+        [1, 2],
+        labelset_id="ls_primary",
+    )
+
+    assert set(notes_df["doc_id"]) == {"doc_primary"}
+    assert set(ann_df.get("round_id", [])) == {"ph_labelset_corpus_r1"}
+    assert "doc_secondary" not in notes_df.get("doc_id", []).tolist()
+
+
 def test_export_inputs_cold_start_uses_selected_corpus(tmp_path: Path) -> None:
     project_root = tmp_path / "Project"
     paths = init_project(project_root, "proj", "Project", "tester")

--- a/vaannotate/AdminApp/prompt_builder.py
+++ b/vaannotate/AdminApp/prompt_builder.py
@@ -348,6 +348,7 @@ class PromptInferenceJob:
                     corpus_path=str(self.corpus_path) if self.corpus_path else None,
                     scope_corpus_to_annotations=True,
                     consensus_only=True,
+                    inference_only=True,
                 )
                 result = PromptExperimentResult(
                     name=variant.name,

--- a/vaannotate/AdminApp/prompt_builder.py
+++ b/vaannotate/AdminApp/prompt_builder.py
@@ -259,11 +259,33 @@ class PromptInferenceJob:
             else self.run_root / f"{pheno_id}_prompt_checkpoint.json"
         )
 
+    def _checkpoint_matches(self, ckpt: PromptInferenceCheckpoint) -> bool:
+        corpus_path = str(self.corpus_path) if self.corpus_path else None
+        return (
+            Path(ckpt.project_root) == self.project_root
+            and ckpt.pheno_id == self.pheno_id
+            and ckpt.labelset_id == self.labelset_id
+            and ckpt.phenotype_level == self.phenotype_level
+            and sorted(ckpt.adjudicated_rounds) == self.adjudicated_rounds
+            and (ckpt.corpus_id or None) == (self.corpus_id or None)
+            and (ckpt.corpus_path or None) == corpus_path
+        )
+
     def _load_or_create_checkpoint(
-        self, variants: Iterable[PromptExperimentConfig]
+        self,
+        variants: Iterable[PromptExperimentConfig],
+        *,
+        log_callback: Optional[Callable[[str], None]] = None,
     ) -> PromptInferenceCheckpoint:
+        log = log_callback or (lambda msg: None)
         if self.checkpoint_path.exists():
-            return PromptInferenceCheckpoint.load(self.checkpoint_path)
+            ckpt = PromptInferenceCheckpoint.load(self.checkpoint_path)
+            if self._checkpoint_matches(ckpt):
+                return ckpt
+            log(
+                "Existing checkpoint is incompatible with current inference settings; "
+                "starting a new run."
+            )
         return PromptInferenceCheckpoint.new(
             project_root=self.project_root,
             pheno_id=self.pheno_id,
@@ -289,7 +311,7 @@ class PromptInferenceJob:
         """Run the experiment sweep with checkpointing and resume support."""
 
         log = log_callback or (lambda msg: None)
-        ckpt = self._load_or_create_checkpoint(variants)
+        ckpt = self._load_or_create_checkpoint(variants, log_callback=log_callback)
         results: List[PromptExperimentResult] = []
 
         for idx, variant in enumerate(

--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -701,6 +701,20 @@ def export_inputs_from_repo(
     prior_rounds = sorted({int(r) for r in prior_rounds})
     root = Path(project_root)
     phenotype_dir = _resolve_phenotype_dir(root, pheno_id)
+    round_details = _load_round_details(project_root, pheno_id, prior_rounds)
+
+    skipped_rounds: list[int] = []
+    filtered_rounds: list[int] = []
+    for r in prior_rounds:
+        detail = round_details.get(r, {})
+        if labelset_id:
+            round_labelset = detail.get("labelset_id")
+            if round_labelset and str(round_labelset) != str(labelset_id):
+                skipped_rounds.append(r)
+                continue
+        filtered_rounds.append(r)
+
+    prior_rounds = filtered_rounds
     corpus_db = _find_corpus_db(
         root,
         pheno_id,
@@ -712,8 +726,6 @@ def export_inputs_from_repo(
     notes_df = _read_corpus_db(corpus_db)
 
     ann_frames = []
-    round_details = _load_round_details(project_root, pheno_id, prior_rounds)
-    skipped_rounds: list[int] = []
     for r in prior_rounds:
         round_dir = phenotype_dir / "rounds" / f"round_{r}"
         if not round_dir.exists():


### PR DESCRIPTION
## Summary
- ensure inference uses only user-selected adjudicated rounds that match the chosen label set, recreating checkpoints when settings change
- filter backend exports to skip rounds with mismatched label sets and surface warnings to keep inference corpora scoped
- add coverage verifying export inputs exclude incompatible rounds

## Testing
- pytest tests/test_ai_adapters.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334cdd83e8832785c12a4fdab34fd1)