### PR TITLE
Add artifacts_dir to backend result

### DIFF
--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -25,6 +25,7 @@ class BackendResult:
     dataframe: pd.DataFrame
     artifacts: Dict[str, Any]
     params_path: Path
+    artifacts_dir: Optional[Path] = None
     metrics: Dict[str, float] = field(default_factory=dict)
 
 
@@ -920,6 +921,7 @@ def run_ai_backend_and_collect(
                 "mode": "inference_only",
             },
             params_path=params_path,
+            artifacts_dir=ai_dir,
             metrics={},
         )
     if consensus_only:
@@ -1032,5 +1034,6 @@ def run_ai_backend_and_collect(
         dataframe=final_df,
         artifacts=artifacts,
         params_path=params_path,
+        artifacts_dir=ai_dir,
         metrics=dict(metrics) if isinstance(metrics, Mapping) else {},
     )


### PR DESCRIPTION
## Summary
- add an optional artifacts_dir field to BackendResult
- populate artifacts_dir when preparing inference-only or standard backend outputs to avoid attribute errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693353e625a483279e7dbb116eb9fed8)