### PR TITLE
Skip AL buckets in admin inference mode

### DIFF
--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -917,6 +917,11 @@ def run_ai_backend_and_collect(
         select_overrides: Dict[str, Any] = dict(overrides.get("select", {}))
         select_overrides["batch_size"] = max(int(select_overrides.get("batch_size", 0) or 0), len(notes_df))
         select_overrides["write_buckets"] = False
+        select_overrides["skip_active_learning"] = True
+        select_overrides["pct_disagreement"] = 0.0
+        select_overrides["pct_diversity"] = 0.0
+        select_overrides["pct_uncertain"] = 0.0
+        select_overrides["pct_easy_qc"] = 0.0
         overrides["select"] = select_overrides
         cfg_overrides = overrides
     if consensus_only:


### PR DESCRIPTION
## Summary
- ensure inference-only runs force selection settings that bypass active learning buckets
- add configuration flag allowing the engine to skip bucket generation and use inference corpus units directly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335c571be083279932a542d907330b)