### PR TITLE
Intersect inference corpus with prior rounds

### DIFF
--- a/vaannotate/AdminApp/prompt_builder.py
+++ b/vaannotate/AdminApp/prompt_builder.py
@@ -347,6 +347,7 @@ class PromptInferenceJob:
                     corpus_id=self.corpus_id,
                     corpus_path=str(self.corpus_path) if self.corpus_path else None,
                     scope_corpus_to_annotations=True,
+                    intersect_corpus_with_prior_units=True,
                     consensus_only=True,
                     inference_only=True,
                 )


### PR DESCRIPTION
## Summary
- add helper to intersect selected corpora with units present in prior rounds
- apply intersection during inference-only runs to build target corpora from prior rounds and user-selected corpus
- ensure inference exports and overrides run after the corpus has been intersected and scoped

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335f711a9c8327b10c6235cff932e0)