### PR TITLE
Clean engine surfaces for pipelines

### DIFF
--- a/vaannotate/vaannotate_ai_backend/pipelines/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/__init__.py
@@ -1,0 +1,2 @@
+from .active_learning import ActiveLearningPipeline
+from .inference import InferencePipeline

--- a/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+import pandas as pd
+
+from ..services import LLM_RECORDER
+
+
+class ActiveLearningPipeline:
+    def __init__(
+        self,
+        data_repo,
+        emb_store,
+        ctx_builder,
+        llm_labeler,
+        disagreement_scorer,
+        uncertainty_scorer,
+        diversity_selector,
+        selector,
+        config,
+        paths,
+        *,
+        pooler=None,
+        retriever=None,
+        label_config=None,
+        label_config_bundle=None,
+        excluded_unit_ids: Optional[Set[str]] = None,
+        check_cancelled_fn: Optional[Callable[[], None]] = None,
+        iter_with_bar_fn: Optional[Callable[..., object]] = None,
+        jsonify_cols_fn: Optional[Callable[[pd.DataFrame, List[str]], pd.DataFrame]] = None,
+        attach_metadata_fn: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None,
+        label_maps_fn: Optional[Callable[[], Tuple[Dict[str, str], Dict[str, str], Dict[str, str], Dict[str, str]]]] = None,
+        unseen_pairs_fn: Optional[Callable[[Optional[Set[str]]], List[Tuple[str, str]]]] = None,
+        disagreement_builder_fn: Optional[Callable[[Set[Tuple[str, str]], Dict[str, str], Dict[str, str]], pd.DataFrame]] = None,
+        uncertain_builder_fn: Optional[Callable[[Dict[str, str], Dict[str, str], Optional[Set[str]]], pd.DataFrame]] = None,
+        certain_builder_fn: Optional[Callable[[Dict[str, str], Dict[str, str], Optional[Set[str]]], pd.DataFrame]] = None,
+        rerank_override_fn: Optional[Callable[[Dict[str, str]], Dict[str, str]]] = None,
+    ):
+        self.repo = data_repo
+        self.store = emb_store
+        self.ctx_builder = ctx_builder
+        self.llm = llm_labeler
+        self.disagreement_scorer = disagreement_scorer
+        self.uncertainty_scorer = uncertainty_scorer
+        self.diversity_selector = diversity_selector
+        self.selector = selector
+        self.cfg = config
+        self.paths = paths
+        self.pooler = pooler
+        self.retriever = retriever or getattr(ctx_builder, "retriever", None)
+        self.label_config = label_config if label_config is not None else getattr(llm_labeler, "label_config", None)
+        self.label_config_bundle = label_config_bundle if label_config_bundle is not None else getattr(ctx_builder, "label_config_bundle", None)
+        self.excluded_unit_ids = excluded_unit_ids or set()
+        self.check_cancelled = check_cancelled_fn
+        self.iter_with_bar = iter_with_bar_fn
+        self.jsonify_cols = jsonify_cols_fn
+        self.attach_metadata = attach_metadata_fn
+        self.label_maps_fn = label_maps_fn
+        self.unseen_pairs_fn = unseen_pairs_fn
+        self.disagreement_builder_fn = disagreement_builder_fn
+        self.uncertain_builder_fn = uncertain_builder_fn
+        self.certain_builder_fn = certain_builder_fn
+        self.rerank_override_fn = rerank_override_fn
+
+    def _apply_excluded_units(self) -> int:
+        removed = self.repo.exclude_units(self.excluded_unit_ids)
+        if removed and self.retriever is not None:
+            self.retriever._notes_by_doc = self.repo.notes_by_doc()
+        return removed
+
+    def _label_maps(self) -> Tuple[Dict[str, str], Dict[str, str], Dict[str, str], Dict[str, str]]:
+        if self.label_maps_fn:
+            return self.label_maps_fn()
+        legacy_rules_map = getattr(self.label_config_bundle, "legacy_rules_map", lambda: {})()
+        legacy_label_types = getattr(self.label_config_bundle, "legacy_label_types", lambda: {})()
+        current_rules_map = getattr(self.label_config_bundle, "current_rules_map", lambda: {})()
+        current_label_types = getattr(self.label_config_bundle, "current_label_types", lambda: {})()
+
+        if not current_rules_map and legacy_rules_map:
+            current_rules_map = dict(legacy_rules_map)
+        if not current_label_types and legacy_label_types:
+            current_label_types = dict(legacy_label_types)
+
+        return legacy_rules_map, legacy_label_types, current_rules_map, current_label_types
+
+    def _build_disagreement_bucket(self, seen_pairs: Set[Tuple[str, str]], rules_map: Dict[str, str], label_types: Dict[str, str]) -> pd.DataFrame:
+        if self.disagreement_builder_fn:
+            return self.disagreement_builder_fn(seen_pairs, rules_map, label_types)
+        return self.disagreement_scorer.compute_disagreement(seen_pairs, rules_map, label_types)
+
+    def _build_unseen_pairs(self, label_ids: Optional[Set[str]] = None) -> List[Tuple[str, str]]:
+        if self.unseen_pairs_fn:
+            return self.unseen_pairs_fn(label_ids)
+        seen = set(zip(self.repo.ann["unit_id"], self.repo.ann["label_id"]))
+        all_units = sorted(self.repo.notes["unit_id"].unique().tolist())
+
+        if label_ids is None:
+            legacy_labels = {str(l) for l in self.repo.ann["label_id"].unique().tolist()}
+            config_labels: set[str] = set()
+            for key, entry in (self.label_config or {}).items():
+                if str(key) == "_meta":
+                    continue
+                if isinstance(entry, dict):
+                    lid = str(entry.get("label_id") or key).strip()
+                else:
+                    lid = str(key).strip()
+                if lid:
+                    config_labels.add(lid)
+            use_labels = legacy_labels | config_labels
+        else:
+            use_labels = {str(l) for l in label_ids if str(l)}
+
+        all_labels = sorted(use_labels)
+        return [(u, l) for u in all_units for l in all_labels if (u, l) not in seen]
+
+    def _build_llm_uncertain_bucket(self, label_types: Dict[str, str], rules_map: Dict[str, str], exclude_units: Optional[Set[str]] = None) -> pd.DataFrame:
+        if self.uncertain_builder_fn:
+            return self.uncertain_builder_fn(label_types, rules_map, exclude_units)
+        fam_cls = getattr(self.llm, "family_labeler_cls", None)
+        fam = fam_cls(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst) if fam_cls else None
+        if fam is None:
+            from ..engine import FamilyLabeler  # type: ignore
+
+            fam = FamilyLabeler(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst)
+        probe_df = fam.probe_units_label_tree(self.cfg.llmfirst.enrich, label_types, rules_map, exclude_units=exclude_units)
+        probe_df = self.uncertainty_scorer.score_probe_results(probe_df)
+        if self.jsonify_cols:
+            safe_cols = [c for c in ["fc_probs", "rag_context", "why", "runs"] if c in probe_df.columns]
+            self.jsonify_cols(probe_df, safe_cols).to_parquet(os.path.join(self.paths.outdir, "llm_probe.parquet"), index=False)
+        from ..engine import direct_uncertainty_selection  # type: ignore
+
+        n_unc = int(self.cfg.select.batch_size * self.cfg.select.pct_uncertain)
+        return direct_uncertainty_selection(probe_df, n_unc, select_most_certain=False)
+
+    def _build_llm_certain_bucket(self, label_types: Dict[str, str], rules_map: Dict[str, str], exclude_units: Optional[Set[str]] = None) -> pd.DataFrame:
+        if self.certain_builder_fn:
+            return self.certain_builder_fn(label_types, rules_map, exclude_units)
+        p = os.path.join(self.paths.outdir, "llm_probe.parquet")
+        if os.path.exists(p):
+            probe_df = pd.read_parquet(p)
+        else:
+            fam_cls = getattr(self.llm, "family_labeler_cls", None)
+            fam = fam_cls(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst) if fam_cls else None
+            if fam is None:
+                from ..engine import FamilyLabeler  # type: ignore
+
+                fam = FamilyLabeler(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst)
+            probe_df = fam.probe_units_label_tree(self.cfg.llmfirst.enrich, label_types, rules_map, exclude_units=exclude_units)
+        probe_df = self.uncertainty_scorer.score_probe_results(probe_df)
+        from ..engine import direct_uncertainty_selection  # type: ignore
+
+        n_cer = int(self.cfg.select.batch_size * self.cfg.select.pct_easy_qc)
+        return direct_uncertainty_selection(probe_df, n_cer, select_most_certain=True)
+
+    def run(self) -> pd.DataFrame:
+        import pandas as pd
+
+        t0 = time.time()
+        check_cancelled = self.check_cancelled or (lambda: None)
+        iter_with_bar = self.iter_with_bar or (lambda **kwargs: kwargs.get("iterable", []))
+
+        run_id = time.strftime("%Y%m%d-%H%M%S")
+        LLM_RECORDER.start(
+            outdir=self.paths.outdir,
+            run_id=run_id,
+            meta={
+                "model": getattr(self.cfg.llm, "model_name", None),
+                "project": os.path.basename(self.paths.outdir.rstrip(os.sep)),
+            },
+        )
+
+        print("Indexing chunks ...")
+        check_cancelled()
+        self.store.build_chunk_index(self.repo.notes, self.cfg.rag, self.cfg.index)
+        removed = self._apply_excluded_units()
+        if removed:
+            print(f"Excluded {removed} previously reviewed units from candidate pool")
+        if self.repo.notes.empty:
+            raise RuntimeError("No candidate units remain after excluding previously reviewed units.")
+        print("Building label prototypes ...")
+        check_cancelled()
+        if self.pooler is not None:
+            self.pooler.build_prototypes()
+
+        legacy_rules_map, legacy_label_types, current_rules_map, current_label_types = self._label_maps()
+        legacy_label_ids = {str(l) for l in self.repo.ann["label_id"].unique().tolist()}
+        if not legacy_label_ids:
+            legacy_label_ids = set(legacy_rules_map.keys())
+        current_label_ids = set(current_rules_map.keys())
+        if not current_label_ids:
+            current_label_ids = set(legacy_label_ids)
+
+        if hasattr(self.retriever, "rerank_rule_overrides"):
+            overrides = self.rerank_override_fn(current_rules_map) if self.rerank_override_fn else {}
+            self.retriever.rerank_rule_overrides = overrides or getattr(self.retriever, "rerank_rule_overrides", {}) or {}
+
+        seen_units = set(self.repo.ann["unit_id"].unique().tolist())
+        seen_pairs = set(zip(self.repo.ann["unit_id"], self.repo.ann["label_id"]))
+        unseen_pairs_current = self._build_unseen_pairs(label_ids=current_label_ids)
+
+        selector = self.selector
+        selector.label_types = current_label_types
+        selector.current_label_ids = current_label_ids
+        selector.seen_units = seen_units
+        selector.unseen_pairs = unseen_pairs_current
+
+        total = int(self.cfg.select.batch_size)
+        n_dis = int(total * self.cfg.select.pct_disagreement)
+        n_div = int(total * self.cfg.select.pct_diversity)
+        n_unc = int(total * self.cfg.select.pct_uncertain)
+        n_cer = int(total * self.cfg.select.pct_easy_qc)
+
+        run_id = time.strftime("%Y%m%d-%H%M%S")
+        LLM_RECORDER.start(outdir=self.paths.outdir, run_id=run_id)
+
+        selected_units: set[str] = set()
+        dis_units = selector._empty_unit_frame()
+        dis_path = os.path.join(self.paths.outdir, "bucket_disagreement.parquet")
+        if self.repo.ann.empty:
+            print("[1/4] Skipping disagreement bucket (no prior rounds or quota is zero)")
+        else:
+            if n_dis > 0:
+                print("[1/4] Expanded disagreement ...")
+            else:
+                print("[1/4] Disagreement quota is zero; refreshing schema only ...")
+            check_cancelled()
+            dis_pairs = self._build_disagreement_bucket(seen_pairs, legacy_rules_map, legacy_label_types)
+            dis_units = selector.select_disagreement(dis_pairs, selected_units=selected_units)
+        dis_units.to_parquet(dis_path, index=False)
+        selected_units |= set(dis_units["unit_id"])
+
+        print("[2/4] Diversity ...")
+        check_cancelled()
+        want_div = min(n_div, max(0, total - len(selected_units)))
+        fam_cls = getattr(self.llm, "family_labeler_cls", None)
+        fam = fam_cls(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst) if fam_cls else None
+        if fam is None:
+            from ..engine import FamilyLabeler  # type: ignore
+
+            fam = FamilyLabeler(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst)
+        div_candidates = pd.DataFrame(unseen_pairs_current, columns=["unit_id", "label_id"])
+        sel_div_pairs = self.diversity_selector.select_diverse_units(
+            div_candidates,
+            n_div=want_div,
+            already_selected=[(r.unit_id, getattr(r, "label_id", "")) for r in dis_units.itertuples(index=False)],
+            pooler=self.pooler,
+            retriever=self.retriever,
+            rules_map=current_rules_map,
+            label_types=current_label_types,
+            label_config=self.label_config,
+            rag_k=getattr(self.cfg.diversity, "rag_topk", 4),
+            min_rel_quantile=getattr(self.cfg.diversity, "min_rel_quantile", 0.30),
+            mmr_lambda=getattr(self.cfg.diversity, "mmr_lambda", 0.7),
+            sample_cap=getattr(self.cfg.diversity, "sample_cap", 2000),
+            adaptive_relax=getattr(self.cfg.diversity, "adaptive_relax", True),
+            relax_steps=getattr(self.cfg.diversity, "relax_steps", (0.20, 0.10, 0.05)),
+            pool_factor=getattr(self.cfg.diversity, "pool_factor", 4.0),
+            use_proto=getattr(self.cfg.diversity, "use_proto", False),
+            family_labeler=fam,
+            ensure_exemplars=True,
+            exclude_units=seen_units | selected_units,
+            iter_with_bar_fn=iter_with_bar,
+        )
+        sel_div_pairs = selector._filter_units(sel_div_pairs, seen_units | selected_units)
+        sel_div_units = selector._head_units(selector._to_unit_only(sel_div_pairs), want_div)
+        sel_div_units.to_parquet(os.path.join(self.paths.outdir, "bucket_diversity.parquet"), index=False)
+        selected_units |= set(sel_div_units["unit_id"])
+
+        if n_unc > 0:
+            print("[3/4] LLM-uncertain ...")
+            check_cancelled()
+            want_unc = min(n_unc, max(0, total - len(selected_units)))
+            if want_unc > 0:
+                sel_unc_pairs = self._build_llm_uncertain_bucket(
+                    current_label_types,
+                    current_rules_map,
+                    exclude_units=seen_units | selected_units,
+                )
+                sel_unc_pairs = selector._filter_units(sel_unc_pairs, seen_units | selected_units)
+                sel_unc_units = selector._head_units(selector._to_unit_only(sel_unc_pairs), want_unc)
+                sel_unc_units.to_parquet(os.path.join(self.paths.outdir, "bucket_llm_uncertain.parquet"), index=False)
+                selected_units |= set(sel_unc_units["unit_id"])
+            else:
+                print("Uncertain bucket skipped: no remaining quota.")
+
+        if n_cer > 0:
+            print("[4/4] LLM-certain ...")
+            check_cancelled()
+            want_cer = min(n_cer, max(0, total - len(selected_units)))
+            if want_cer > 0:
+                sel_cer_pairs = self._build_llm_certain_bucket(
+                    current_label_types,
+                    current_rules_map,
+                    exclude_units=seen_units | selected_units,
+                )
+                sel_cer_pairs = selector._filter_units(sel_cer_pairs, seen_units | selected_units)
+                sel_cer_units = selector._head_units(selector._to_unit_only(sel_cer_pairs), want_cer)
+                sel_cer_units.to_parquet(os.path.join(self.paths.outdir, "bucket_llm_certain.parquet"), index=False)
+                selected_units |= set(sel_cer_units["unit_id"])
+            else:
+                print("Certain bucket skipped: no remaining quota.")
+
+        final = selector.build_next_batch(
+            disagree_df=dis_units,
+            uncertainty_df=sel_unc_units if "sel_unc_units" in locals() else selector._empty_unit_frame(),
+            easy_df=sel_cer_units if "sel_cer_units" in locals() else selector._empty_unit_frame(),
+            diversity_df=sel_div_units,
+            prefiltered=True,
+        )
+
+        final.to_parquet(os.path.join(self.paths.outdir, "final_selection.parquet"), index=False)
+        result_df = final
+
+        final_out = None
+        if getattr(self.cfg, "final_llm_labeling", False):
+            fam_cls = getattr(self.llm, "family_labeler_cls", None)
+            fam = fam_cls(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst) if fam_cls else None
+            if fam is None:
+                from ..engine import FamilyLabeler  # type: ignore
+
+                fam = FamilyLabeler(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst)
+            unit_ids = final["unit_id"].tolist()
+            rules_map = current_rules_map
+            types = current_label_types
+            _progress_every = float(getattr(fam.cfg, "progress_min_interval_s", 1) or 1)
+            fam_rows = []
+            for uid in iter_with_bar(
+                step="Final family labeling",
+                iterable=unit_ids,
+                total=len(unit_ids),
+                min_interval_s=_progress_every,
+            ):
+                fam_rows.extend(
+                    fam.label_family_for_unit(
+                        uid,
+                        types,
+                        rules_map,
+                        json_only=True,
+                        json_n_consistency=getattr(self.cfg.llmfirst, "final_llm_label_consistency", 1),
+                        json_jitter=False,
+                    )
+                )
+            fam_df = pd.DataFrame(fam_rows)
+            if not fam_df.empty:
+                if "runs" in fam_df.columns:
+                    fam_df.rename(columns={"runs": "llm_runs"}, inplace=True)
+                if "consistency" in fam_df.columns:
+                    fam_df.rename(columns={"consistency": "llm_consistency"}, inplace=True)
+                if "prediction" in fam_df.columns:
+                    fam_df.rename(columns={"prediction": "llm_prediction"}, inplace=True)
+                if "llm_runs" in fam_df.columns:
+                    fam_df["llm_reasoning"] = fam_df["llm_runs"].map(
+                        lambda rs: (rs[0].get("raw", {}).get("reasoning") if isinstance(rs, list) and rs else None)
+                    )
+                if self.jsonify_cols:
+                    fam_df = self.jsonify_cols(fam_df, [c for c in ["rag_context", "llm_runs", "fc_probs"] if c in fam_df.columns])
+            fam_df.to_parquet(os.path.join(self.paths.outdir, "final_llm_family_probe.parquet"), index=False)
+
+            if not fam_df.empty:
+                pv = fam_df[["unit_id", "label_id", "llm_prediction"]].copy()
+                pv["col"] = pv["label_id"].astype(str) + "_llm"
+                fam_wide = pv.pivot_table(index="unit_id", columns="col", values="llm_prediction", aggfunc="first").reset_index()
+                if "llm_reasoning" in fam_df.columns:
+                    rv = fam_df[["unit_id", "label_id", "llm_reasoning"]].copy()
+                    rv["colr"] = rv["label_id"].astype(str) + "_llm_reason"
+                    fam_reason_wide = rv.pivot_table(index="unit_id", columns="colr", values="llm_reasoning", aggfunc="first").reset_index()
+                    fam_wide = fam_wide.merge(fam_reason_wide, on="unit_id", how="left")
+                final_units = final[["unit_id", "label_id", "label_type", "selection_reason"]].drop_duplicates()
+                final_out = final_units.merge(fam_wide, on="unit_id", how="left")
+                final_out.to_parquet(os.path.join(self.paths.outdir, "final_selection_with_llm.parquet"), index=False)
+
+                labels_path = Path(self.paths.outdir) / "final_llm_labels.parquet"
+                try:
+                    fam_wide.to_parquet(labels_path, index=False)
+                except Exception:
+                    pass
+                else:
+                    try:
+                        labels_path.with_suffix(".json").write_text(
+                            fam_wide.to_json(orient="records", indent=2, force_ascii=False),
+                            encoding="utf-8",
+                        )
+                    except TypeError:
+                        labels_path.with_suffix(".json").write_text(
+                            fam_wide.to_json(orient="records"),
+                            encoding="utf-8",
+                        )
+
+            try:
+                probe_json_path = Path(self.paths.outdir) / "final_llm_family_probe.json"
+                fam_df.to_json(probe_json_path, orient="records", indent=2, force_ascii=False)
+            except TypeError:
+                fam_df.to_json(probe_json_path, orient="records")
+        if final_out is not None:
+            result_df = final_out
+
+        diagnostics = {
+            "total_selected": int(len(final)),
+            "bucket_sizes": {
+                "disagreement": int(len(dis_units) if "dis_units" in locals() else 0),
+                "diversity": int(len(sel_div_units) if "sel_div_units" in locals() else 0),
+                "uncertain": int(len(sel_unc_units) if "sel_unc_units" in locals() else 0),
+                "certain": int(len(sel_cer_units) if "sel_cer_units" in locals() else 0),
+            },
+            "unique_units": int(len(final["unit_id"].unique())),
+        }
+
+        try:
+            rec_path = LLM_RECORDER.flush()
+            if rec_path:
+                import logging
+
+                LOGGER = logging.getLogger(__name__)
+                LOGGER.info("llm_run_log_written", extra={"path": rec_path, "n_calls": len(LLM_RECORDER.calls)})
+        except Exception:
+            import logging
+
+            LOGGER = logging.getLogger(__name__)
+            LOGGER.warning("llm_run_log_write_failed")
+
+        total_seconds = time.time() - t0
+        hours, remainder = divmod(total_seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        print(f"Done. Total elapsed: {int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}")
+
+        if self.attach_metadata:
+            result_df = self.attach_metadata(result_df)
+        return result_df

--- a/vaannotate/vaannotate_ai_backend/pipelines/inference.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/inference.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Iterable, List, Mapping, Optional, Tuple
+
+import pandas as pd
+
+from ..services import LLM_RECORDER
+
+
+def _jsonify_cols(df: pd.DataFrame, cols: List[str]) -> pd.DataFrame:
+    if df.empty:
+        return df
+    out = df.copy()
+    for col in cols:
+        if col in out.columns:
+            out[col] = out[col].apply(
+                lambda x: json.dumps(x, ensure_ascii=False) if isinstance(x, (list, dict)) else x
+            )
+    return out
+
+
+class InferencePipeline:
+    def __init__(self, data_repo, emb_store, ctx_builder, llm_labeler, config, paths):
+        self.repo = data_repo
+        self.store = emb_store
+        self.ctx_builder = ctx_builder
+        self.llm = llm_labeler
+        self.cfg = config
+        self.paths = paths
+        self.retriever = getattr(ctx_builder, "retriever", None)
+        self.label_config = getattr(llm_labeler, "label_config", {})
+        self.label_config_bundle = getattr(ctx_builder, "label_config_bundle", None)
+
+    def _label_maps(self) -> Tuple[dict[str, str], dict[str, str]]:
+        def _normalize_type(raw_type: object) -> str:
+            if raw_type is None:
+                return ""
+            t = str(raw_type).strip().lower()
+            if not t:
+                return ""
+            if t in {"binary", "categorical", "categorical_single", "categorical_multi", "ordinal", "date", "numeric"}:
+                return t
+            return "categorical"
+
+        def _extract_rule_text(entry: Mapping[str, object] | None) -> str:
+            if not isinstance(entry, Mapping):
+                return ""
+            for key in ("rule", "rules", "why", "query", "text"):
+                val = entry.get(key)
+                if isinstance(val, str):
+                    val = val.strip()
+                    if val:
+                        return val
+                elif isinstance(val, list):
+                    for item in reversed(val):
+                        if isinstance(item, str):
+                            text = item.strip()
+                            if text:
+                                return text
+                        elif isinstance(item, Mapping):
+                            text = str(item.get("text") or item.get("rule") or "").strip()
+                            if text:
+                                return text
+                elif isinstance(val, Mapping):
+                    text = str(val.get("text") or val.get("rule") or "").strip()
+                    if text:
+                        return text
+            return ""
+
+        legacy_rules_map = (
+            getattr(self.label_config_bundle, "legacy_rules_map", lambda: {})() if self.label_config_bundle else {}
+        )
+        legacy_label_types = (
+            getattr(self.label_config_bundle, "legacy_label_types", lambda: {})() if self.label_config_bundle else {}
+        )
+
+        current_rules_map: dict[str, str] = {}
+        current_label_types: dict[str, str] = {}
+
+        for key, entry in (self.label_config or {}).items():
+            if str(key) == "_meta":
+                continue
+            label_entry = entry if isinstance(entry, Mapping) else {}
+            raw_id = label_entry.get("label_id") if isinstance(label_entry, Mapping) else None
+            label_id = str(raw_id or key).strip()
+            if not label_id:
+                continue
+
+            rule_text = _extract_rule_text(label_entry) if isinstance(label_entry, Mapping) else ""
+            if label_id not in current_rules_map:
+                current_rules_map[label_id] = rule_text
+
+            normalized_type = _normalize_type(label_entry.get("type") if isinstance(label_entry, Mapping) else None)
+            if normalized_type:
+                current_label_types[label_id] = normalized_type
+            elif label_id not in current_label_types:
+                current_label_types[label_id] = "categorical"
+
+        if not current_rules_map:
+            current_rules_map = dict(legacy_rules_map)
+        if not current_label_types:
+            current_label_types = dict(legacy_label_types)
+
+        return current_rules_map, current_label_types
+
+    def _label_units(self, unit_ids: Iterable[str], label_types: dict[str, str], rules_map: dict[str, str]) -> pd.DataFrame:
+        fam_cls = getattr(self.llm, "family_labeler_cls", None)
+        fam = fam_cls(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst) if fam_cls else None
+        if fam is None:
+            from ..engine import FamilyLabeler  # type: ignore
+
+            fam = FamilyLabeler(self.llm, self.retriever, self.repo, self.label_config, self.cfg.scjitter, self.cfg.llmfirst)
+
+        rows: List[dict] = []
+        for uid in unit_ids:
+            rows.extend(
+                fam.label_family_for_unit(
+                    uid,
+                    label_types,
+                    rules_map,
+                    json_only=True,
+                    json_n_consistency=getattr(self.cfg.llmfirst, "final_llm_label_consistency", 1),
+                    json_jitter=False,
+                )
+            )
+
+        df = pd.DataFrame(rows)
+        if df.empty:
+            return df
+        if "runs" in df.columns:
+            df.rename(columns={"runs": "llm_runs"}, inplace=True)
+        if "consistency" in df.columns:
+            df.rename(columns={"consistency": "llm_consistency"}, inplace=True)
+        if "prediction" in df.columns:
+            df.rename(columns={"prediction": "llm_prediction"}, inplace=True)
+        if "llm_runs" in df.columns:
+            df["llm_reasoning"] = df["llm_runs"].map(
+                lambda rs: (rs[0].get("raw", {}).get("reasoning") if isinstance(rs, list) and rs else None)
+            )
+        return df
+
+    def run(self, unit_ids: Optional[List[str]] = None) -> pd.DataFrame:
+        run_id = time.strftime("%Y%m%d-%H%M%S")
+        LLM_RECORDER.start(
+            outdir=self.paths.outdir,
+            run_id=run_id,
+            meta={"mode": "inference", "model": getattr(self.cfg.llm, "model_name", None)},
+        )
+
+        self.store.build_chunk_index(self.repo.notes, self.cfg.rag, self.cfg.index)
+
+        all_units = [str(u) for u in self.repo.notes["unit_id"].unique().tolist()]
+        selected_units = all_units if unit_ids is None else [str(u) for u in unit_ids if str(u)]
+
+        if not selected_units:
+            LLM_RECORDER.flush()
+            return pd.DataFrame(columns=["unit_id", "label_id", "llm_prediction"])
+
+        rules_map, label_types = self._label_maps()
+        label_df = self._label_units(selected_units, label_types, rules_map)
+
+        if label_df.empty:
+            LLM_RECORDER.flush()
+            return label_df
+
+        jsonified = _jsonify_cols(label_df, [c for c in ["rag_context", "llm_runs", "fc_probs"] if c in label_df.columns])
+        out_path = os.path.join(self.paths.outdir, "inference_predictions.parquet")
+        jsonified.to_parquet(out_path, index=False)
+
+        json_path = os.path.join(self.paths.outdir, "inference_predictions.json")
+        try:
+            jsonified.to_json(json_path, orient="records", lines=True, force_ascii=False)
+        except Exception:
+            pass
+
+        LLM_RECORDER.flush()
+        return label_df
+
+
+__all__ = ["InferencePipeline"]

--- a/vaannotate/vaannotate_ai_backend/services/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/services/__init__.py
@@ -1,7 +1,18 @@
 """Service-layer utilities for active learning and inference pipelines."""
 
 from .context_builder import ContextBuilder
+from .diversity import DiversitySelector
 from .disagreement import DisagreementScorer
 from .llm_labeler import LLMLabeler, LLM_RECORDER
+from .uncertainty import LLMUncertaintyScorer
+from .selection import ActiveLearningSelector
 
-__all__ = ["ContextBuilder", "DisagreementScorer", "LLMLabeler", "LLM_RECORDER"]
+__all__ = [
+    "ContextBuilder",
+    "DiversitySelector",
+    "DisagreementScorer",
+    "LLMLabeler",
+    "LLM_RECORDER",
+    "ActiveLearningSelector",
+    "LLMUncertaintyScorer",
+]

--- a/vaannotate/vaannotate_ai_backend/services/diversity.py
+++ b/vaannotate/vaannotate_ai_backend/services/diversity.py
@@ -1,0 +1,336 @@
+"""Diversity-focused selection helpers for active learning batches."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+
+def _options_for_label(label_id: str, label_type: str, label_cfgs: dict) -> Optional[List[str]]:
+    cfg = label_cfgs.get(label_id, {}) if isinstance(label_cfgs, dict) else {}
+    opts = cfg.get("options")
+    if isinstance(opts, list) and 2 <= len(opts) <= 26:
+        return [str(o) for o in opts]
+    return None
+
+
+class DiversitySelector:
+    """Select a diverse subset of candidate (unit, label) pairs."""
+
+    def __init__(self, data_repo, emb_store, diversity_config):
+        self.repo = data_repo
+        self.store = emb_store
+        self.cfg = diversity_config
+
+    def select_diverse_units(
+        self,
+        candidate_df: pd.DataFrame,
+        *,
+        n_div: int,
+        already_selected=None,
+        pooler=None,
+        retriever=None,
+        rules_map=None,
+        label_types=None,
+        label_config=None,
+        rag_k: int = 4,
+        min_rel_quantile: float = 0.30,
+        mmr_lambda: float = 0.7,
+        sample_cap: int = 2000,
+        adaptive_relax: bool = True,
+        relax_steps=(0.20, 0.10, 0.05),
+        pool_factor: float = 4.0,
+        use_proto: bool = False,
+        *,
+        family_labeler=None,
+        ensure_exemplars: bool = True,
+        exclude_units: set[str] | None = None,
+        iter_with_bar_fn=None,
+    ) -> pd.DataFrame:
+        """Diversity bucket without CE gating (mirrors the prior inline logic)."""
+
+        def _mmr_select_simple(vecs, rel_scores, k, lam=0.7, preselected=None):
+            """Greedy MMR: argmax lam*rel – (1–lam)*max_sim_to_selected (no label caps)."""
+            if k <= 0 or vecs is None or len(vecs) == 0:
+                return []
+            V = vecs / (np.linalg.norm(vecs, axis=1, keepdims=True) + 1e-12)
+            rel = np.asarray(rel_scores, dtype="float32")
+            N = V.shape[0]
+            selected = []
+            if preselected is not None and getattr(preselected, "size", 0):
+                P = preselected / (np.linalg.norm(preselected, axis=1, keepdims=True) + 1e-12)
+                sim_pre = (V @ P.T).max(axis=1)
+            else:
+                sim_pre = np.zeros(N, dtype="float32")
+            used = np.zeros(N, dtype=bool)
+            for _ in range(min(k, N)):
+                if selected:
+                    S = V[selected, :]
+                    sim_sel = (V @ S.T).max(axis=1)
+                    sim = np.maximum(sim_pre, sim_sel)
+                else:
+                    sim = sim_pre
+                score = lam * rel - (1.0 - lam) * sim
+                score[used] = -1e9
+                i = int(np.argmax(score))
+                if score[i] <= -1e8:
+                    break
+                selected.append(i)
+                used[i] = True
+            return selected
+
+        def _l2(v):
+            v = np.asarray(v, dtype="float32")
+            n = np.linalg.norm(v) + 1e-12
+            return v / n
+
+        def _cos(a, b):
+            return float(np.dot(_l2(a), _l2(b)))
+
+        def _kcenter_greedy(U: np.ndarray, k: int, seed_indices=None) -> list[int]:
+            if U.size == 0 or k <= 0:
+                return []
+            Un = U / (np.linalg.norm(U, axis=1, keepdims=True) + 1e-12)
+            n = Un.shape[0]
+            sel, dmin = [], np.ones(n) * np.inf
+            if seed_indices:
+                seeds = [s for s in seed_indices if 0 <= s < n]
+                if seeds:
+                    sel.extend(seeds)
+                    sims = Un @ Un[seeds].T
+                    dmin = 1 - sims.max(axis=1)
+                    dmin[seeds] = 0.0
+            if not sel:
+                s0 = int(np.random.randint(0, n))
+                sel.append(s0)
+                dmin = 1 - (Un @ Un[s0])
+            while len(sel) < min(k, n):
+                i = int(np.argmax(dmin))
+                sel.append(i)
+                dmin = np.minimum(dmin, 1 - (Un @ Un[i]))
+            return sel
+
+        def _equal_quota(group_sizes: dict[str, int], total: int) -> dict[str, int]:
+            labs = list(group_sizes.keys())
+            if not labs or total <= 0:
+                return {lab: 0 for lab in labs}
+            base, rem = total // len(labs), total % len(labs)
+            q = {lab: min(group_sizes[lab], base) for lab in labs}
+            order = sorted(labs, key=lambda x: group_sizes[x] - q[x], reverse=True)
+            for lab in order:
+                if rem <= 0:
+                    break
+                if q[lab] < group_sizes[lab]:
+                    q[lab] += 1
+                    rem -= 1
+            while rem > 0:
+                progressed = False
+                for lab in order:
+                    if q[lab] < group_sizes[lab]:
+                        q[lab] += 1
+                        rem -= 1
+                        progressed = True
+                        if rem == 0:
+                            break
+                if not progressed:
+                    break
+            return q
+
+        def _empty():
+            return pd.DataFrame(columns=["unit_id", "label_id", "label_type", "selection_reason"])
+
+        rules_map = rules_map or {}
+        label_types = label_types or {}
+        exclude_units = exclude_units or set()
+        already_selected = already_selected or []
+        pooler = pooler or getattr(self, "pooler", None)
+        retriever = retriever or getattr(self, "retriever", None)
+
+        if (
+            candidate_df is None
+            or not isinstance(candidate_df, pd.DataFrame)
+            or candidate_df.empty
+            or pooler is None
+            or retriever is None
+        ):
+            return _empty()
+
+        if ensure_exemplars and family_labeler is not None:
+            try:
+                K_use = int(getattr(getattr(family_labeler, "cfg", None), "exemplar_K", 6) or 6)
+                family_labeler.ensure_label_exemplars(rules_map, K=K_use)
+            except Exception:
+                pass
+
+        if {"unit_id", "label_id"}.issubset(set(candidate_df.columns)):
+            unseen_pairs = [
+                (str(getattr(r, "unit_id", "")), str(getattr(r, "label_id", "")))
+                for r in candidate_df.itertuples(index=False)
+                if getattr(r, "unit_id", None) is not None and getattr(r, "label_id", None) is not None
+            ]
+        else:
+            unseen_pairs = []
+
+        if n_div <= 0 or not unseen_pairs:
+            return _empty()
+
+        rem_all = [(u, l) for (u, l) in unseen_pairs if (u, l) not in set(already_selected)]
+        if exclude_units:
+            rem_all = [(u, l) for (u, l) in rem_all if u not in exclude_units]
+        np.random.shuffle(rem_all)
+        rem_all = rem_all[: max(n_div * 8, min(sample_cap, len(rem_all)))]
+        if not rem_all:
+            return _empty()
+
+        rem_df = pd.DataFrame([
+            {"unit_id": u, "label_id": str(l), "label_type": label_types.get(l, "text")}
+            for (u, l) in rem_all
+        ])
+
+        proto_cache: dict[str, np.ndarray] = {}
+
+        def _label_anchor(lid: str) -> np.ndarray:
+            if lid in proto_cache:
+                return proto_cache[lid]
+
+            proto = None
+
+            if hasattr(pooler, "label_prototype") and use_proto:
+                try:
+                    proto = pooler.label_prototype(lid, retriever, rules_map.get(lid, ""))
+                except Exception:
+                    proto = None
+
+            if proto is None:
+                Q = None
+                try:
+                    base_k = getattr(getattr(retriever, "cfg", None), "exemplar_K", None)
+                    K_use = int(base_k if base_k is not None else 6)
+                    if K_use <= 0:
+                        K_use = 6
+                    opts = _options_for_label(
+                        lid,
+                        label_types.get(str(lid), "categorical"),
+                        getattr(retriever, "label_configs", {}),
+                    ) or []
+                    if opts:
+                        K_use = max(K_use, len(opts))
+                    getQ = getattr(retriever, "_get_label_query_embs", None)
+                    if callable(getQ):
+                        Q = getQ(lid, rules_map.get(lid, ""), K_use)
+                except Exception:
+                    Q = None
+                if Q is not None and getattr(Q, "ndim", 1) == 2 and Q.shape[0] > 0:
+                    proto = Q.mean(axis=0)
+
+            if proto is None:
+                q = retriever._build_query(lid, rules_map.get(lid, ""))
+                proto = retriever.store._embed([q])[0]
+
+            proto_cache[lid] = np.asarray(proto, dtype="float32")
+            return proto_cache[lid]
+
+        iter_fn = iter_with_bar_fn or (lambda step, iterable, **kwargs: iterable)
+        vecs, rels = [], []
+        _progress_every = float(getattr(getattr(family_labeler, "cfg", None), "progress_min_interval_s", 1) or 1)
+        for r in iter_fn(
+            step="Diversity: pooling vectors",
+            iterable=rem_df.itertuples(index=False),
+            total=len(rem_df),
+            min_interval_s=_progress_every,
+        ):
+            v = pooler.pooled_vector(r.unit_id, r.label_id, retriever, rules_map.get(r.label_id, ""))
+            vecs.append(v)
+            rels.append(_cos(v, _label_anchor(r.label_id)))
+        rem_df["vec"] = vecs
+        rem_df["rel"] = np.array(rels, dtype="float32")
+
+        def _keep_by_q(df, q):
+            kept = []
+            for lid, g in df.groupby("label_id", sort=False):
+                if g.empty:
+                    continue
+                thr = float(np.quantile(g["rel"].to_numpy(), q)) if len(g) > 1 else g["rel"].min()
+                kept.append(g[g["rel"] >= thr])
+            return pd.concat(kept, ignore_index=True) if kept else df.head(0)
+
+        if min_rel_quantile is not None:
+            gated = _keep_by_q(rem_df, float(min_rel_quantile))
+            if adaptive_relax and len(gated) < n_div:
+                for q in relax_steps:
+                    gated = _keep_by_q(rem_df, float(q))
+                    if len(gated) >= n_div:
+                        break
+        else:
+            gated = rem_df
+        if gated.empty:
+            return gated
+
+        pool_total = int(min(len(gated), max(n_div, int(n_div * pool_factor))))
+        sizes = {lid: len(g) for lid, g in gated.groupby("label_id", sort=False)}
+        quotas = _equal_quota(sizes, pool_total)
+
+        pools, sel_pairs = [], set()
+        preV_by_label: dict[str, np.ndarray] = {}
+
+        for lid, g in gated.groupby("label_id", sort=False):
+            k_lab = quotas.get(lid, 0)
+            if k_lab <= 0 or g.empty:
+                continue
+            V = np.stack(g["vec"].to_list()).astype("float32")
+            rel = g["rel"].to_numpy().astype("float32")
+            preV = preV_by_label.get(lid)
+            order = _mmr_select_simple(V, rel, k=k_lab, lam=mmr_lambda, preselected=preV)
+            choice = g.iloc[order].head(k_lab) if order else g.sort_values("rel", ascending=False).head(k_lab)
+            for r in choice.itertuples(index=False):
+                key = (r.unit_id, r.label_id)
+                if key in sel_pairs:
+                    continue
+                sel_pairs.add(key)
+                pools.append(r)
+
+        if not pools:
+            add_df = gated.sort_values("rel", ascending=False).head(n_div).copy()
+            add_df["selection_reason"] = "diversity_toprel_fallback"
+            return add_df[["unit_id", "label_id", "label_type", "selection_reason"]]
+
+        pool_df = pd.DataFrame(pools)
+        if len(pool_df) > pool_total:
+            pool_df = pool_df.sample(pool_total).reset_index(drop=True)
+
+        by_unit = {}
+        for r in pool_df.itertuples(index=False):
+            by_unit.setdefault(r.unit_id, {"labels": [], "vecs": [], "best_label": None, "best_rel": -1.0})
+            by_unit[r.unit_id]["labels"].append(r.label_id)
+            by_unit[r.unit_id]["vecs"].append(np.asarray(r.vec, dtype="float32"))
+            if float(r.rel) > by_unit[r.unit_id]["best_rel"]:
+                by_unit[r.unit_id]["best_rel"] = float(r.rel)
+                by_unit[r.unit_id]["best_label"] = r.label_id
+
+        units = list(by_unit.keys())
+        if not units:
+            return _empty()
+
+        U = np.stack([np.mean(np.stack(v["vecs"], axis=0), axis=0) for v in by_unit.values()], axis=0)
+        idx_map = {u: i for i, u in enumerate(units)}
+        seed_units = {u for (u, _l) in already_selected}
+        seeds = [idx_map[u] for u in seed_units if u in idx_map]
+
+        picks = _kcenter_greedy(U, k=n_div, seed_indices=seeds)
+
+        rows = []
+        for i in picks:
+            u = units[i]
+            lab = by_unit[u]["best_label"]
+            rows.append({
+                "unit_id": u,
+                "label_id": lab,
+                "label_type": label_types.get(lab, "text"),
+                "selection_reason": "diversity_mmr_kcenter",
+            })
+        return pd.DataFrame(rows)
+
+
+__all__ = ["DiversitySelector"]

--- a/vaannotate/vaannotate_ai_backend/services/selection.py
+++ b/vaannotate/vaannotate_ai_backend/services/selection.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Set, Tuple
+
+import pandas as pd
+import random
+
+
+@dataclass
+class ActiveLearningSelector:
+    select_config: object
+    label_types: Optional[dict[str, str]] = None
+    current_label_ids: Optional[Set[str]] = None
+    seen_units: Optional[Set[str]] = None
+    unseen_pairs: Optional[Sequence[Tuple[str, str]]] = None
+
+    def _empty_unit_frame(self) -> "pd.DataFrame":
+        return pd.DataFrame(
+            {
+                "unit_id": pd.Series(dtype="string"),
+                "label_id": pd.Series(dtype="string"),
+                "label_type": pd.Series(dtype="string"),
+                "selection_reason": pd.Series(dtype="string"),
+            }
+        )
+
+    def _ensure_unit_schema(self, df: "pd.DataFrame" | None) -> "pd.DataFrame":
+        base = self._empty_unit_frame()
+        if df is None:
+            return base
+        result = df.copy()
+        for col in base.columns:
+            if col not in result.columns:
+                result[col] = pd.Series(dtype=base[col].dtype)
+        return result[base.columns.tolist()]
+
+    def _to_unit_only(self, df: "pd.DataFrame") -> "pd.DataFrame":
+        if df is None:
+            return self._empty_unit_frame()
+        cols = [c for c in ["unit_id", "label_id", "label_type", "selection_reason"] if c in df.columns]
+        if not cols:
+            return self._empty_unit_frame()
+        subset = df[cols].drop_duplicates(subset=["unit_id"], keep="first")
+        return self._ensure_unit_schema(subset)
+
+    def _filter_units(self, df: "pd.DataFrame", excluded: Set[str]) -> "pd.DataFrame":
+        if df is None or df.empty or not excluded:
+            return df if df is not None else pd.DataFrame(columns=["unit_id"])
+        return df[~df["unit_id"].isin(excluded)].copy()
+
+    def _head_units(self, df: "pd.DataFrame", k: int) -> "pd.DataFrame":
+        ensured = self._ensure_unit_schema(df)
+        if ensured.empty or k <= 0:
+            return ensured.iloc[0:0].copy()
+        return ensured.head(k).copy()
+
+    def _select_bucket(self, df: "pd.DataFrame", k: int, excluded: Iterable[str] | None = None) -> "pd.DataFrame":
+        excluded_set = set(excluded or [])
+        filtered = self._filter_units(df, excluded_set)
+        return self._head_units(self._to_unit_only(filtered), k)
+
+    def select_disagreement(self, disagree_df: "pd.DataFrame", *, selected_units: Optional[Set[str]] = None) -> "pd.DataFrame":
+        total = int(getattr(self.select_config, "batch_size", 0))
+        n_dis = int(total * getattr(self.select_config, "pct_disagreement", 0))
+        return self._select_bucket(disagree_df, n_dis, excluded=selected_units or set())
+
+    def top_off_random(self, current_sel: pd.DataFrame, target_n: int) -> pd.DataFrame:
+        sel = current_sel.copy()
+        need = int(target_n) - len(sel)
+        if need <= 0:
+            return sel
+
+        label_types = self.label_types or {}
+        seen_units = self.seen_units or set()
+        taken = set(zip(sel["unit_id"].astype(str), sel["label_id"].astype(str)))
+        excluded_units = seen_units | set(sel["unit_id"].astype(str))
+        cand = [
+            (str(u), str(l))
+            for (u, l) in (self.unseen_pairs or [])
+            if (str(u), str(l)) not in taken and str(u) not in excluded_units
+        ]
+        if not cand:
+            return sel
+
+        rng = random.Random()
+        rng.shuffle(cand)
+
+        take = cand[:need]
+        if not take:
+            return sel
+
+        add = pd.DataFrame(
+            [
+                {
+                    "unit_id": u,
+                    "label_id": l,
+                    "label_type": label_types.get(l, "text"),
+                    "selection_reason": "random_topoff",
+                }
+                for (u, l) in take
+            ]
+        )
+
+        return pd.concat([sel, add], ignore_index=True)
+
+    def build_next_batch(
+        self,
+        disagree_df: pd.DataFrame,
+        uncertainty_df: pd.DataFrame,
+        easy_df: pd.DataFrame,
+        diversity_df: pd.DataFrame,
+        *,
+        prefiltered: bool = False,
+    ) -> pd.DataFrame:
+        total = int(getattr(self.select_config, "batch_size", 0))
+        n_dis = int(total * getattr(self.select_config, "pct_disagreement", 0))
+        n_div = int(total * getattr(self.select_config, "pct_diversity", 0))
+        n_unc = int(total * getattr(self.select_config, "pct_uncertain", 0))
+        n_cer = int(total * getattr(self.select_config, "pct_easy_qc", 0))
+
+        selected_rows: list[pd.DataFrame] = []
+        selected_units: set[str] = set()
+        seen_units = self.seen_units or set()
+
+        if prefiltered:
+            dis_units = self._ensure_unit_schema(disagree_df)
+        else:
+            dis_units = self._select_bucket(disagree_df, n_dis, excluded=selected_units)
+        selected_rows.append(dis_units)
+        selected_units |= set(dis_units["unit_id"])
+
+        want_div = min(n_div, max(0, total - len(selected_units)))
+        if prefiltered:
+            sel_div_units = self._ensure_unit_schema(diversity_df)
+        else:
+            sel_div_units = self._select_bucket(
+                diversity_df,
+                want_div,
+                excluded=seen_units | selected_units,
+            )
+        selected_rows.append(sel_div_units)
+        selected_units |= set(sel_div_units["unit_id"])
+
+        want_unc = min(n_unc, max(0, total - len(selected_units)))
+        if prefiltered:
+            sel_unc_units = self._ensure_unit_schema(uncertainty_df)
+        else:
+            sel_unc_units = self._select_bucket(
+                uncertainty_df,
+                want_unc,
+                excluded=seen_units | selected_units,
+            )
+        if not sel_unc_units.empty:
+            selected_rows.append(sel_unc_units)
+            selected_units |= set(sel_unc_units["unit_id"])
+
+        want_cer = min(n_cer, max(0, total - len(selected_units)))
+        if prefiltered:
+            sel_cer_units = self._ensure_unit_schema(easy_df)
+        else:
+            sel_cer_units = self._select_bucket(
+                easy_df,
+                want_cer,
+                excluded=seen_units | selected_units,
+            )
+        if not sel_cer_units.empty:
+            selected_rows.append(sel_cer_units)
+            selected_units |= set(sel_cer_units["unit_id"])
+
+        final = (
+            pd.concat(selected_rows, ignore_index=True)
+            if selected_rows
+            else self._empty_unit_frame()
+        )
+        final = final.drop_duplicates(subset=["unit_id"], keep="first").copy()
+
+        if len(final) < total:
+            print("Topping off to target batch_size ...")
+            final = self.top_off_random(final, target_n=total)
+            final = final.drop_duplicates(subset=["unit_id"], keep="first")
+
+        return final

--- a/vaannotate/vaannotate_ai_backend/services/uncertainty.py
+++ b/vaannotate/vaannotate_ai_backend/services/uncertainty.py
@@ -1,0 +1,44 @@
+"""Uncertainty scoring for LLM probe results."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+class LLMUncertaintyScorer:
+    """Compute uncertainty/easiness signals for LLM-first probes."""
+
+    def __init__(self, llm_first_config):
+        self.cfg = llm_first_config
+
+    def score_probe_results(self, probe_df: pd.DataFrame) -> pd.DataFrame:
+        """Attach uncertainty scores/flags expected by downstream selection.
+
+        The scoring mirrors the inline logic previously in ``engine.py``:
+        - Prefer forced-choice entropy when available (already stored as ``U``).
+        - Fall back to ``1 - consistency`` when forced-choice data is absent.
+        - Ensure the ``U`` column exists for downstream selectors.
+        """
+
+        if probe_df is None or not isinstance(probe_df, pd.DataFrame):
+            return pd.DataFrame()
+
+        df = probe_df.copy()
+
+        if "U" not in df.columns:
+            df["U"] = np.nan
+
+        if "fc_entropy" in df.columns:
+            idx = df["U"].isna()
+            if "consistency" in df.columns:
+                df.loc[idx, "U"] = 1.0 - pd.to_numeric(
+                    df.loc[idx, "consistency"], errors="coerce"
+                ).fillna(0.0)
+        elif "consistency" in df.columns:
+            df["U"] = 1.0 - pd.to_numeric(df["consistency"], errors="coerce").fillna(0.0)
+
+        return df
+
+
+__all__ = ["LLMUncertaintyScorer"]


### PR DESCRIPTION
## Summary
- remove legacy bucket and top-off helpers now handled by pipeline/services
- streamline engine imports to use service package re-exports and rely on pipeline defaults

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693490623ee08327b83c559129dec3c2)