### PR TITLE
Add inference config matrix coverage

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+- `tests/data/ai_backend` holds a small "golden" corpus (notes, annotations, and label config) used by automated end-to-end AI backend tests.

--- a/tests/ai_backend/test_cli_smoke.py
+++ b/tests/ai_backend/test_cli_smoke.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "ai_backend"
+
+
+@pytest.mark.parametrize("with_label_config", [True, False])
+def test_cli_active_learning_smoke(tmp_path: Path, with_label_config: bool) -> None:
+    env = os.environ.copy()
+    env["VAANNOTATE_TEST_STUB_ACTIVE_RUNNER"] = "1"
+
+    if with_label_config:
+        label_config_flag = ["--label-config", str(DATA_DIR / "label_config.json")]
+    else:
+        label_config_flag = []
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "vaannotate.vaannotate_ai_backend.cli",
+        "--notes",
+        str(DATA_DIR / "notes.csv"),
+        "--annotations",
+        str(DATA_DIR / "annotations.csv"),
+        "--outdir",
+        str(tmp_path),
+        *label_config_flag,
+    ]
+
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+
+    csv_path = tmp_path / "ai_next_batch.csv"
+    assert csv_path.exists()
+
+    df = pd.read_csv(csv_path)
+    assert not df.empty
+    assert set(df["unit_id"].astype(str).unique()) >= {"1001", "1002"}
+
+    stdout = result.stdout.strip().splitlines()
+    assert any("ai_next_batch" in line for line in stdout)
+
+
+def test_cli_active_learning_outputs(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["VAANNOTATE_TEST_STUB_ACTIVE_RUNNER"] = "1"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "vaannotate.vaannotate_ai_backend.cli",
+        "--notes",
+        str(DATA_DIR / "notes.csv"),
+        "--annotations",
+        str(DATA_DIR / "annotations.csv"),
+        "--label-config",
+        str(DATA_DIR / "label_config.json"),
+        "--outdir",
+        str(tmp_path),
+    ]
+
+    subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+
+    expected = {
+        "ai_next_batch.csv",
+        "bucket_disagreement.parquet",
+        "bucket_llm_uncertain.parquet",
+        "bucket_llm_certain.parquet",
+        "bucket_diversity.parquet",
+    }
+
+    for name in expected:
+        assert (tmp_path / name).exists()
+
+    df = pd.read_csv(tmp_path / "ai_next_batch.csv")
+    assert "selection_reason" in df.columns
+

--- a/tests/ai_backend/test_e2e_active_learning.py
+++ b/tests/ai_backend/test_e2e_active_learning.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vaannotate.vaannotate_ai_backend import build_next_batch, run_inference
+from vaannotate.vaannotate_ai_backend.label_configs import LabelConfigBundle
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "ai_backend"
+
+
+def _load_label_config() -> dict:
+    with open(DATA_DIR / "label_config.json", "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_inputs() -> tuple[pd.DataFrame, pd.DataFrame]:
+    notes = pd.read_csv(DATA_DIR / "notes.csv")
+    annotations = pd.read_csv(DATA_DIR / "annotations.csv")
+    return notes, annotations
+
+
+def test_active_learning_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    label_config = _load_label_config()
+    bundle = LabelConfigBundle(
+        current=label_config,
+        current_labelset_id=label_config.get("_meta", {}).get("labelset_id"),
+    )
+
+    notes_df, ann_df = _load_inputs()
+
+    class _StubPipeline:
+        def __init__(self, paths):
+            self.paths = paths
+
+        def run(self):
+            parquet_notes = pd.read_parquet(self.paths.notes_path)
+            outdir = Path(self.paths.outdir)
+
+            buckets = {
+                "bucket_disagreement.parquet": pd.DataFrame({"unit_id": [], "label_id": []}),
+                "bucket_llm_uncertain.parquet": pd.DataFrame({"unit_id": [], "label_id": []}),
+                "bucket_llm_certain.parquet": pd.DataFrame({"unit_id": [], "label_id": []}),
+                "bucket_diversity.parquet": pd.DataFrame({"unit_id": [], "label_id": []}),
+            }
+            for name, df in buckets.items():
+                df.to_parquet(outdir / name, index=False)
+
+            return pd.DataFrame(
+                {
+                    "unit_id": parquet_notes["unit_id"].astype(str),
+                    "doc_id": parquet_notes.get("doc_id", parquet_notes.get("note_id")),
+                    "label_id": "pneumonitis",
+                    "selection_reason": "dummy",
+                }
+            )
+
+    def _build_stub_runner(*_args, **_kwargs):
+        paths = _kwargs.get("paths") if "paths" in _kwargs else _args[0]
+        return _StubPipeline(paths)
+
+    monkeypatch.setattr(
+        "vaannotate.vaannotate_ai_backend.orchestrator.build_active_learning_runner",
+        _build_stub_runner,
+    )
+
+    final_df, artifacts = build_next_batch(
+        notes_df,
+        ann_df,
+        tmp_path,
+        label_config_bundle=bundle,
+    )
+
+    assert not final_df.empty
+    assert set(final_df["unit_id"].unique()) == {"1001", "1002", "1003"}
+    assert (tmp_path / "ai_next_batch.csv").exists()
+
+    for bucket in (
+        "bucket_disagreement.parquet",
+        "bucket_llm_uncertain.parquet",
+        "bucket_llm_certain.parquet",
+        "bucket_diversity.parquet",
+    ):
+        assert (tmp_path / bucket).exists()
+
+    assert artifacts["ai_next_batch_csv"].endswith("ai_next_batch.csv")
+
+
+@pytest.mark.parametrize(
+    "backend, assisted_review, disagreement_enabled, diversity_enabled",
+    [
+        ("local", False, False, False),
+        ("local", True, True, False),
+        ("azure", False, True, True),
+    ],
+)
+def test_active_learning_config_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    assisted_review: bool,
+    disagreement_enabled: bool,
+    diversity_enabled: bool,
+) -> None:
+    label_config = _load_label_config()
+    bundle = LabelConfigBundle(
+        current=label_config,
+        current_labelset_id=label_config.get("_meta", {}).get("labelset_id"),
+    )
+
+    notes_df, ann_df = _load_inputs()
+    captured = {}
+
+    class _StubPipeline:
+        def __init__(self, paths):
+            self.paths = paths
+
+        def run(self):
+            parquet_notes = pd.read_parquet(self.paths.notes_path)
+            outdir = Path(self.paths.outdir)
+
+            (outdir / "bucket_disagreement.parquet").touch()
+            (outdir / "bucket_llm_uncertain.parquet").touch()
+            (outdir / "bucket_llm_certain.parquet").touch()
+            (outdir / "bucket_diversity.parquet").touch()
+
+            return pd.DataFrame(
+                {
+                    "unit_id": parquet_notes["unit_id"].astype(str),
+                    "doc_id": parquet_notes.get("doc_id", parquet_notes.get("note_id")),
+                    "label_id": "pneumonitis",
+                    "selection_reason": "matrix",
+                }
+            )
+
+    def _build_stub_runner(*_args, **_kwargs):
+        paths = _kwargs.get("paths") if "paths" in _kwargs else _args[0]
+        cfg = _kwargs.get("cfg")
+        captured["backend"] = cfg.llm.backend
+        captured["assisted_review"] = getattr(cfg, "assisted_review", {})
+        captured["pct_disagreement"] = cfg.select.pct_disagreement
+        captured["pct_diversity"] = cfg.select.pct_diversity
+        return _StubPipeline(paths)
+
+    monkeypatch.setattr(
+        "vaannotate.vaannotate_ai_backend.orchestrator.build_active_learning_runner",
+        _build_stub_runner,
+    )
+
+    overrides = {
+        "llm": {"backend": backend},
+        "assisted_review": {"enabled": assisted_review, "top_snippets": 1},
+        "select": {
+            "pct_disagreement": 0.3 if disagreement_enabled else 0.0,
+            "pct_diversity": 0.3 if diversity_enabled else 0.0,
+        },
+    }
+
+    final_df, _ = build_next_batch(
+        notes_df,
+        ann_df,
+        tmp_path,
+        label_config_bundle=bundle,
+        cfg_overrides=overrides,
+    )
+
+    assert not final_df.empty
+    assert (tmp_path / "ai_next_batch.csv").exists()
+    assert captured["backend"] == backend
+    assert captured["assisted_review"].get("enabled") is assisted_review
+    assert (
+        captured["pct_disagreement"] == (0.3 if disagreement_enabled else 0.0)
+    )
+    assert captured["pct_diversity"] == (0.3 if diversity_enabled else 0.0)
+
+
+@pytest.mark.parametrize(
+    "backend, rag_enabled, include_reasoning",
+    [
+        ("local", False, False),
+        ("local", True, False),
+        ("azure", True, True),
+    ],
+)
+def test_inference_config_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    rag_enabled: bool,
+    include_reasoning: bool,
+) -> None:
+    label_config = _load_label_config()
+    bundle = LabelConfigBundle(
+        current=label_config,
+        current_labelset_id=label_config.get("_meta", {}).get("labelset_id"),
+    )
+
+    notes_df, ann_df = _load_inputs()
+    captured = {}
+
+    class _StubInference:
+        def __init__(self, paths):
+            self.paths = paths
+
+        def run(self, unit_ids=None):  # noqa: ANN001 - match real signature
+            parquet_notes = pd.read_parquet(self.paths.notes_path)
+            outdir = Path(self.paths.outdir)
+            df = pd.DataFrame(
+                {
+                    "unit_id": parquet_notes["unit_id"].astype(str),
+                    "doc_id": parquet_notes.get("doc_id", parquet_notes.get("note_id")),
+                    "label_id": "pneumonitis",
+                    "label_option_id": "yes",
+                }
+            )
+            df.to_parquet(outdir / "inference_predictions.parquet", index=False)
+            df.to_json(outdir / "inference_predictions.json", orient="records", lines=True)
+            return df
+
+    def _build_stub_runner(*_args, **_kwargs):
+        paths = _kwargs.get("paths") if "paths" in _kwargs else _args[0]
+        cfg = _kwargs.get("cfg")
+        captured["backend"] = cfg.llm.backend
+        captured["rag_use_keywords"] = cfg.rag.use_keywords
+        captured["rag_use_mmr"] = cfg.rag.use_mmr
+        captured["include_reasoning"] = cfg.llm.include_reasoning
+        return _StubInference(paths)
+
+    monkeypatch.setattr(
+        "vaannotate.vaannotate_ai_backend.orchestrator.build_inference_runner",
+        _build_stub_runner,
+    )
+
+    overrides = {
+        "llm": {"backend": backend, "include_reasoning": include_reasoning},
+        "rag": {"use_keywords": rag_enabled, "use_mmr": rag_enabled},
+    }
+
+    predictions, artifacts = run_inference(
+        notes_df,
+        ann_df,
+        tmp_path,
+        label_config_bundle=bundle,
+        cfg_overrides=overrides,
+    )
+
+    assert not predictions.empty
+    assert (tmp_path / "inference_predictions.parquet").exists()
+    assert (tmp_path / "inference_predictions.json").exists()
+    assert set(predictions["unit_id"].unique()) == {"1001", "1002", "1003"}
+    assert artifacts["predictions"].endswith("inference_predictions.parquet")
+    assert captured["backend"] == backend
+    assert captured["rag_use_keywords"] is rag_enabled
+    assert captured["rag_use_mmr"] is rag_enabled
+    assert captured["include_reasoning"] is include_reasoning

--- a/tests/data/ai_backend/annotations.csv
+++ b/tests/data/ai_backend/annotations.csv
@@ -1,0 +1,4 @@
+round_id,unit_id,doc_id,label_id,reviewer_id,label_value,labelset_id
+r1,1001,n1,pneumonitis,gold,pneumonitis_yes,pneumo_labels
+r1,1002,n2,pneumonitis,gold,pneumonitis_no,pneumo_labels
+r1,1003,n3,pneumonitis,gold,pneumonitis_uncertain,pneumo_labels

--- a/tests/data/ai_backend/label_config.json
+++ b/tests/data/ai_backend/label_config.json
@@ -1,0 +1,21 @@
+{
+  "_meta": {
+    "labelset_id": "pneumo_labels",
+    "labelset_name": "Pneumonitis",
+    "notes": "Golden test labelset for AI backend",
+    "created_by": "tests"
+  },
+  "pneumonitis": {
+    "label_id": "pneumonitis",
+    "name": "Pneumonitis",
+    "type": "categorical",
+    "required": true,
+    "na_allowed": false,
+    "options": ["pneumonitis_yes", "pneumonitis_no", "pneumonitis_uncertain"],
+    "option_details": [
+      {"value": "pneumonitis_yes", "display": "Yes"},
+      {"value": "pneumonitis_no", "display": "No"},
+      {"value": "pneumonitis_uncertain", "display": "Uncertain"}
+    ]
+  }
+}

--- a/tests/data/ai_backend/notes.csv
+++ b/tests/data/ai_backend/notes.csv
@@ -1,0 +1,4 @@
+unit_id,note_id,patient_icn,doc_id,text
+1001,n1,1001,n1,"Patient started high-dose prednisone for immune-related pneumonitis after checkpoint therapy; breathing improving."
+1002,n2,1002,n2,"Follow-up visit notes clear lungs and no signs of pneumonitis; patient off steroids."
+1003,n3,1003,n3,"Mild cough and fatigue noted; unclear if early pneumonitis or seasonal allergy."

--- a/tests/test_ai_backend_dummy_llm.py
+++ b/tests/test_ai_backend_dummy_llm.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vaannotate.vaannotate_ai_backend.core.data import DataRepository
+from vaannotate.vaannotate_ai_backend.testing import DummyLLMLabeler, make_dummy_llm_labeler
+
+
+DATA_DIR = Path(__file__).resolve().parent / "data" / "ai_backend"
+
+
+def _load_repo() -> DataRepository:
+    notes = pd.read_csv(DATA_DIR / "notes.csv")
+    annotations = pd.read_csv(DATA_DIR / "annotations.csv")
+    return DataRepository(notes, annotations)
+
+
+def _load_label_config() -> dict:
+    with open(DATA_DIR / "label_config.json", "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _stubs(repo: DataRepository) -> tuple[SimpleNamespace, SimpleNamespace]:
+    context_builder = SimpleNamespace(repo=repo)
+    retriever = SimpleNamespace(_repo=repo, get_last_diagnostics=lambda *_args, **_kwargs: {})
+    return context_builder, retriever
+
+
+def test_dummy_llm_labeler_uses_keyword_rules() -> None:
+    repo = _load_repo()
+    context_builder, retriever = _stubs(repo)
+    label_config = _load_label_config()
+    label_types = {"pneumonitis": "categorical"}
+    per_label_rules = {"pneumonitis": ""}
+
+    labeler = DummyLLMLabeler(label_config)
+    rows = labeler.label_unit(
+        "1001",
+        ["pneumonitis"],
+        label_types=label_types,
+        per_label_rules=per_label_rules,
+        context_builder=context_builder,
+        retriever=retriever,
+        llmfirst_cfg=SimpleNamespace(),
+        json_only=True,
+        json_n_consistency=1,
+        json_jitter=False,
+    )
+
+    assert rows and rows[0]["prediction"] == "pneumonitis_yes"
+    assert labeler.calls == ["1001"]
+
+
+def test_dummy_llm_labeler_handles_negative_context() -> None:
+    repo = _load_repo()
+    context_builder, retriever = _stubs(repo)
+    label_types = {"pneumonitis": "categorical"}
+    per_label_rules = {"pneumonitis": ""}
+
+    labeler = make_dummy_llm_labeler(_load_label_config())
+    rows = labeler.label_unit(
+        "1002",
+        ["pneumonitis"],
+        label_types=label_types,
+        per_label_rules=per_label_rules,
+        context_builder=context_builder,
+        retriever=retriever,
+        llmfirst_cfg=SimpleNamespace(),
+        json_only=True,
+        json_n_consistency=1,
+        json_jitter=False,
+    )
+
+    assert rows and rows[0]["prediction"] == "pneumonitis_no"
+    assert labeler.calls == ["1002"]

--- a/vaannotate/vaannotate_ai_backend/testing/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/testing/__init__.py
@@ -1,0 +1,5 @@
+"""Test utilities for the AI backend."""
+
+from .dummy_llm import DummyLLMLabeler, make_dummy_llm_labeler
+
+__all__ = ["DummyLLMLabeler", "make_dummy_llm_labeler"]

--- a/vaannotate/vaannotate_ai_backend/testing/dummy_llm.py
+++ b/vaannotate/vaannotate_ai_backend/testing/dummy_llm.py
@@ -1,0 +1,123 @@
+"""Deterministic test double for the LLM labeler.
+
+This avoids external model calls for end-to-end AI backend tests.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+from ..label_configs import LabelConfigBundle
+
+
+class DummyLLMLabeler:
+    """Keyword-based, deterministic labeler for tests."""
+
+    def __init__(self, label_config: Mapping[str, object] | LabelConfigBundle | None = None):
+        self.calls: list[str] = []
+        if isinstance(label_config, LabelConfigBundle):
+            self.label_config = label_config.current or {}
+        else:
+            self.label_config = label_config or {}
+
+    def _label_options(self, label_id: str) -> list[str]:
+        cfg = self.label_config.get(str(label_id), {}) if isinstance(self.label_config, Mapping) else {}
+        opts = cfg.get("options") if isinstance(cfg, Mapping) else None
+        return [str(o) for o in opts] if isinstance(opts, (list, tuple)) else []
+
+    @staticmethod
+    def summarize_label_rule_for_rerank(_label_id: str, label_rules: Optional[str]) -> str:
+        """Return a compact deterministic summary of a label's rules."""
+
+        text = (label_rules or "").strip()
+        if len(text) <= 200:
+            return text
+        return text[:197].rstrip() + "..."
+
+    def _resolve_label_value(self, intent: str, label_id: str) -> str:
+        opts = self._label_options(label_id)
+        lookup = {"yes": None, "no": None, "uncertain": None}
+        for opt in opts:
+            lower = opt.lower()
+            if "yes" in lower and lookup["yes"] is None:
+                lookup["yes"] = opt
+            if "no" in lower and lookup["no"] is None:
+                lookup["no"] = opt
+            if ("uncertain" in lower or "maybe" in lower) and lookup["uncertain"] is None:
+                lookup["uncertain"] = opt
+        default_map = {"yes": "yes", "no": "no", "uncertain": "uncertain"}
+        return lookup.get(intent) or default_map[intent]
+
+    @staticmethod
+    def _unit_text(unit_id: str, context_builder, retriever) -> str:
+        repo = getattr(context_builder, "repo", None) or getattr(retriever, "_repo", None)
+        if repo is None:
+            return ""
+        try:
+            notes = repo.notes
+            matches = notes[notes["unit_id"].astype(str) == str(unit_id)]
+            if matches.empty:
+                return ""
+            return str(matches.iloc[0].get("text", ""))
+        except Exception:
+            return ""
+
+    def label_unit(
+        self,
+        unit_id: str,
+        label_ids: list[str],
+        *,
+        label_types: Mapping[str, str],
+        per_label_rules: Mapping[str, str],
+        context_builder,
+        retriever,
+        llmfirst_cfg,
+        json_only: bool = False,
+        json_n_consistency: int = 1,
+        json_jitter: bool = False,
+    ) -> list[dict]:
+        """Return hard-coded predictions for each label_id."""
+
+        del json_only, json_n_consistency, json_jitter, llmfirst_cfg, per_label_rules  # unused
+        text = self._unit_text(unit_id, context_builder, retriever).lower()
+        self.calls.append(str(unit_id))
+
+        rows: list[dict] = []
+        for label_id in label_ids:
+            label_type = label_types.get(label_id, "categorical") if isinstance(label_types, Mapping) else "categorical"
+            lower = text
+            intent = "no"
+            negative_tokens = ["no pneumonitis", "without pneumonitis", "no evidence of pneumonitis", "no signs of pneumonitis"]
+            if any(tok in lower for tok in negative_tokens):
+                intent = "no"
+            elif "steroid" in lower or "pneumonitis" in lower:
+                intent = "yes"
+            prediction = self._resolve_label_value(intent, label_id)
+
+            rows.append(
+                {
+                    "unit_id": str(unit_id),
+                    "label_id": str(label_id),
+                    "label_type": label_type,
+                    "prediction": prediction,
+                    "rag_context": [],
+                    "consistency": 1.0,
+                    "runs": [
+                        {
+                            "prediction": prediction,
+                            "raw_prediction": prediction,
+                            "raw": {"reasoning": "dummy"},
+                        }
+                    ],
+                }
+            )
+        return rows
+
+
+def make_dummy_llm_labeler(label_config: Mapping[str, object] | LabelConfigBundle | None = None) -> DummyLLMLabeler:
+    """Factory helper to build a deterministic DummyLLMLabeler."""
+
+    return DummyLLMLabeler(label_config=label_config)
+
+
+__all__ = ["DummyLLMLabeler", "make_dummy_llm_labeler"]


### PR DESCRIPTION
## Summary
- add parametrized inference config matrix coverage over backend and RAG toggles using stubbed inference runner
- verify inference outputs on the golden corpus and capture config overrides during end-to-end invocation

## Testing
- pytest tests/ai_backend/test_e2e_active_learning.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934bd8395c08327ace5ee0d19dfdb16)