### PR TITLE
Improve label map fallbacks and stub compatibility

### DIFF
--- a/vaannotate/vaannotate_ai_backend/label_configs.py
+++ b/vaannotate/vaannotate_ai_backend/label_configs.py
@@ -78,5 +78,161 @@ class LabelConfigBundle:
         labelset_id = self.round_labelsets.get(str(round_identifier))
         return self.config_for_labelset(labelset_id)
 
+    @staticmethod
+    def _normalize_type(raw: Optional[object]) -> Optional[str]:
+        if raw is None:
+            return None
+        text = str(raw).strip().lower()
+        if not text:
+            return None
+        mapping = {
+            "boolean": "binary",
+            "bool": "binary",
+            "yes/no": "binary",
+            "yesno": "binary",
+            "y/n": "binary",
+            "yn": "binary",
+            "binary": "binary",
+            "categorical": "categorical",
+            "category": "categorical",
+            "multiclass": "categorical",
+            "multi": "categorical",
+            "options": "categorical",
+            "option": "categorical",
+            "text": "categorical",
+            "string": "categorical",
+            "free_text": "categorical",
+            "numeric": "numeric",
+            "number": "numeric",
+            "int": "numeric",
+            "integer": "numeric",
+            "float": "numeric",
+            "double": "numeric",
+            "decimal": "numeric",
+            "ordinal": "ordinal",
+            "rank": "ordinal",
+            "ranking": "ordinal",
+            "date": "date",
+            "datetime": "date",
+            "timestamp": "date",
+        }
+        return mapping.get(text, "categorical")
+
+    @staticmethod
+    def _extract_rule_text(entry: Mapping[str, object] | None) -> Optional[str]:
+        if not isinstance(entry, Mapping):
+            return None
+        for key in ("rule", "rules", "why", "query", "text"):
+            val = entry.get(key)
+            if isinstance(val, str):
+                text = val.strip()
+                if text:
+                    return text
+            elif isinstance(val, list):
+                for item in reversed(val):
+                    if isinstance(item, str):
+                        text = item.strip()
+                        if text:
+                            return text
+                    elif isinstance(item, Mapping):
+                        text = str(item.get("text") or item.get("rule") or "").strip()
+                        if text:
+                            return text
+            elif isinstance(val, Mapping):
+                text = str(val.get("text") or val.get("rule") or "").strip()
+                if text:
+                    return text
+        return None
+
+    def legacy_rules_map(self) -> dict[str, str]:
+        legacy_rules: Dict[str, str] = {}
+        for config in (self.legacy or {}).values():
+            for key, entry in (config or {}).items():
+                if str(key) == "_meta":
+                    continue
+                label_entry = entry if isinstance(entry, Mapping) else {}
+                raw_id = label_entry.get("label_id") if isinstance(label_entry, Mapping) else None
+                label_id = str(raw_id or key).strip()
+                if not label_id:
+                    continue
+
+                rule_text = self._extract_rule_text(label_entry)
+                if rule_text is not None:
+                    legacy_rules[label_id] = rule_text
+                elif label_id not in legacy_rules:
+                    legacy_rules[label_id] = ""
+        return legacy_rules
+
+    def legacy_label_types(self) -> dict[str, str]:
+        legacy_types: Dict[str, str] = {}
+        for config in (self.legacy or {}).values():
+            for key, entry in (config or {}).items():
+                if str(key) == "_meta":
+                    continue
+                label_entry = entry if isinstance(entry, Mapping) else {}
+                raw_id = label_entry.get("label_id") if isinstance(label_entry, Mapping) else None
+                label_id = str(raw_id or key).strip()
+                if not label_id:
+                    continue
+
+                normalized_type = self._normalize_type(
+                    label_entry.get("type") if isinstance(label_entry, Mapping) else None
+                )
+                if normalized_type:
+                    legacy_types[label_id] = normalized_type
+                elif label_id not in legacy_types:
+                    legacy_types[label_id] = "categorical"
+        return legacy_types
+
+    def current_rules_map(self, label_config: Mapping[str, object] | None = None) -> dict[str, str]:
+        if not (label_config or self.current):
+            return {}
+
+        config = label_config if label_config is not None else self.current or {}
+        rules_map: Dict[str, str] = {}
+
+        for key, entry in (config or {}).items():
+            if str(key) == "_meta":
+                continue
+            label_entry = entry if isinstance(entry, Mapping) else {}
+            raw_id = label_entry.get("label_id") if isinstance(label_entry, Mapping) else None
+            label_id = str(raw_id or key).strip()
+            if not label_id:
+                continue
+
+            rule_text = self._extract_rule_text(label_entry)
+            if rule_text is not None:
+                rules_map[label_id] = rule_text
+            elif label_id not in rules_map:
+                rules_map[label_id] = ""
+
+        return rules_map
+
+    def current_label_types(self, label_config: Mapping[str, object] | None = None) -> dict[str, str]:
+        if not (label_config or self.current):
+            return {}
+
+        config = label_config if label_config is not None else self.current or {}
+        label_types: Dict[str, str] = {}
+
+        for key, entry in (config or {}).items():
+            if str(key) == "_meta":
+                continue
+            label_entry = entry if isinstance(entry, Mapping) else {}
+            raw_id = label_entry.get("label_id") if isinstance(label_entry, Mapping) else None
+            label_id = str(raw_id or key).strip()
+            if not label_id:
+                continue
+
+            normalized_type = self._normalize_type(
+                label_entry.get("type") if isinstance(label_entry, Mapping) else None
+            )
+            if normalized_type:
+                label_types[label_id] = normalized_type
+            elif label_id not in label_types:
+                label_types[label_id] = "categorical"
+
+        return label_types
+
 
 EMPTY_BUNDLE = LabelConfigBundle()


### PR DESCRIPTION
## Summary
- add annotation-derived legacy label map fallback when bundles lack legacy configs
- tolerate bundles whose label map helpers omit optional parameters
- guard ActiveLearningPipeline test stubs that bypass __init__ to avoid missing attributes

## Testing
- pytest tests/ai_backend tests/test_active_learning_recorder.py tests/test_ai_engine_label_overlays.py tests/test_ai_adapters.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934c3e17728832794b860720505a86a)