### PR TITLE
Add backend session helper for shared models

### DIFF
--- a/vaannotate/vaannotate_ai_backend/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/__init__.py
@@ -7,6 +7,7 @@ workflows via :func:`build_next_batch` and :func:`run_inference`.
 __version__ = "0.1.0"
 
 from .orchestrator import build_next_batch, run_inference
+from .orchestration import BackendSession
 from .adapters import BackendResult, export_inputs_from_repo, run_ai_backend_and_collect
 from .utils.runtime import CancelledError
 
@@ -25,4 +26,5 @@ __all__ = [
     "export_inputs_from_repo",
     "run_ai_backend_and_collect",
     "CancelledError",
+    "BackendSession",
 ]


### PR DESCRIPTION
## Summary
- add a BackendSession helper to hold shared models and embedding store and build pipelines
- export BackendSession for reuse and ensure dataclass import is available
- re-export BackendSession from the package facade for direct imports

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934db8036ec8327a77e48a59e9dddc6)