### PR TITLE
Add test for inference experiment runner

### DIFF
--- a/tests/ai_backend/test_experiments.py
+++ b/tests/ai_backend/test_experiments.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vaannotate.vaannotate_ai_backend import (
+    InferenceExperimentResult,
+    run_inference_experiments,
+)
+from vaannotate.vaannotate_ai_backend.label_configs import LabelConfigBundle
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data" / "ai_backend"
+
+
+def _load_label_config() -> dict:
+    with open(DATA_DIR / "label_config.json", "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_inputs() -> tuple[pd.DataFrame, pd.DataFrame]:
+    notes = pd.read_csv(DATA_DIR / "notes.csv")
+    annotations = pd.read_csv(DATA_DIR / "annotations.csv")
+    return notes, annotations
+
+
+def test_run_inference_experiments_smoke(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Basic smoke test for the experiment runner.
+
+    Verifies that:
+    - we get one result per experiment name
+    - each experiment writes its predictions files
+    - the manifest JSON contains the expected keys
+    """
+
+    label_config = _load_label_config()
+    bundle = LabelConfigBundle(
+        current=label_config,
+        current_labelset_id=label_config.get("_meta", {}).get("labelset_id"),
+    )
+
+    notes_df, ann_df = _load_inputs()
+    captured_backends: list[str | None] = []
+
+    class _StubInference:
+        def __init__(self, paths, cfg=None, **_kwargs):
+            self.paths = paths
+            self.cfg = cfg
+
+        def run(self, unit_ids=None):  # noqa: ANN001 - match real signature
+            parquet_notes = pd.read_parquet(self.paths.notes_path)
+            outdir = Path(self.paths.outdir)
+            df = pd.DataFrame(
+                {
+                    "unit_id": parquet_notes["unit_id"].astype(str),
+                    "doc_id": parquet_notes.get("doc_id", parquet_notes.get("note_id")),
+                    "label_id": "pneumonitis",
+                    "label_option_id": "yes",
+                }
+            )
+            df.to_parquet(outdir / "inference_predictions.parquet", index=False)
+            df.to_json(outdir / "inference_predictions.json", orient="records", lines=True)
+            if self.cfg is not None:
+                captured_backends.append(self.cfg.llm.backend)
+            else:
+                captured_backends.append(None)
+            return df
+
+    def _build_stub_runner(*args, **kwargs):
+        paths = kwargs.get("paths") if "paths" in kwargs else args[0]
+        cfg = kwargs.get("cfg")
+        return _StubInference(paths, cfg=cfg)
+
+    # Ensure our experiments use the stubbed inference pipeline instead of
+    # actually loading models or calling an LLM backend.
+    monkeypatch.setattr(
+        "vaannotate.vaannotate_ai_backend.orchestrator.build_inference_runner",
+        _build_stub_runner,
+    )
+
+    sweeps = {
+        "local_backend": {"llm": {"backend": "local"}},
+        "azure_backend": {"llm": {"backend": "azure"}},
+    }
+
+    results = run_inference_experiments(
+        notes_df=notes_df,
+        ann_df=ann_df,
+        base_outdir=tmp_path,
+        sweeps=sweeps,
+        label_config_bundle=bundle,
+    )
+
+    # One result per experiment
+    assert set(results.keys()) == set(sweeps.keys())
+
+    for name, result in results.items():
+        assert isinstance(result, InferenceExperimentResult)
+        assert result.name == name
+        # Predictions files should exist under each experiment's outdir
+        parquet_path = result.outdir / "inference_predictions.parquet"
+        json_path = result.outdir / "inference_predictions.json"
+        assert parquet_path.exists()
+        assert json_path.exists()
+        assert result.artifacts["predictions"].endswith("inference_predictions.parquet")
+        assert result.artifacts["predictions_json"].endswith("inference_predictions.json")
+
+        df = result.dataframe
+        assert not df.empty
+        assert set(df["unit_id"].unique()) >= {"1001", "1002"}
+
+    # We should have one captured backend per experiment, with the expected values
+    assert sorted(captured_backends) == ["azure", "local"]
+
+    # Manifest should list all experiments
+    manifest_path = tmp_path / "experiments.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert set(manifest.keys()) == set(sweeps.keys())

--- a/vaannotate/vaannotate_ai_backend/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/__init__.py
@@ -9,6 +9,7 @@ __version__ = "0.1.0"
 from .orchestrator import build_next_batch, run_inference
 from .orchestration import BackendSession
 from .adapters import BackendResult, export_inputs_from_repo, run_ai_backend_and_collect
+from .experiments import InferenceExperimentResult, run_inference_experiments
 from .utils.runtime import CancelledError
 
 # Layering overview:
@@ -27,4 +28,6 @@ __all__ = [
     "run_ai_backend_and_collect",
     "CancelledError",
     "BackendSession",
+    "InferenceExperimentResult",
+    "run_inference_experiments",
 ]

--- a/vaannotate/vaannotate_ai_backend/experiments.py
+++ b/vaannotate/vaannotate_ai_backend/experiments.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Optional
+
+import json
+import pandas as pd
+
+from .label_configs import LabelConfigBundle, EMPTY_BUNDLE
+from .orchestrator import run_inference
+
+
+@dataclass
+class InferenceExperimentResult:
+    """Container for the outputs of a single inference experiment.
+
+    Attributes
+    ----------
+    name:
+        Human-readable experiment name (key from the sweeps mapping).
+    cfg_overrides:
+        The configuration overrides used for this experiment, in the same
+        nested format accepted by ``run_inference``.
+    outdir:
+        Directory where this experiment's outputs were written.
+    dataframe:
+        The predictions DataFrame returned by ``run_inference``.
+    artifacts:
+        The artifacts dict returned by ``run_inference`` (e.g. file paths).
+    """
+
+    name: str
+    cfg_overrides: Dict[str, Any]
+    outdir: Path
+    dataframe: pd.DataFrame
+    artifacts: Dict[str, Any]
+
+
+def run_inference_experiments(
+    notes_df: pd.DataFrame,
+    ann_df: pd.DataFrame,
+    base_outdir: Path,
+    sweeps: Mapping[str, Mapping[str, Any]],
+    *,
+    label_config_bundle: LabelConfigBundle | None = None,
+    label_config: Optional[Dict[str, Any]] = None,
+    unit_ids: Optional[list[str]] = None,
+    cache_dir: Optional[Path] = None,
+    cancel_callback: Optional[Callable[[], bool]] = None,
+    log_callback: Optional[Callable[[str], None]] = None,
+) -> Dict[str, InferenceExperimentResult]:
+    """Run multiple inference configurations (sweeps) and collect their outputs.
+
+    Each entry in ``sweeps`` is a mapping from experiment name to a nested
+    ``cfg_overrides`` dict in the same format accepted by :func:`run_inference`.
+
+    For each experiment ``name``, this function:
+
+    * creates an output directory at ``base_outdir / name``
+    * calls :func:`run_inference` with that directory and the provided overrides
+    * stores the resulting predictions DataFrame and artifacts
+
+    The embeddings cache directory can be shared across experiments via the
+    ``cache_dir`` argument; if not provided, a ``cache`` subdirectory under
+    ``base_outdir`` is used by default.
+
+    Parameters
+    ----------
+    notes_df:
+        Notes DataFrame in the same format expected by :func:`run_inference`.
+    ann_df:
+        Annotations DataFrame in the same format expected by :func:`run_inference`.
+    base_outdir:
+        Directory under which per-experiment subdirectories will be created.
+    sweeps:
+        Mapping from experiment name to ``cfg_overrides`` dictionaries.
+    label_config_bundle:
+        Optional pre-materialised :class:`LabelConfigBundle`. If not provided,
+        :func:`run_inference` will fall back to an empty bundle.
+    label_config:
+        Optional label_config overlay passed through to :func:`run_inference`.
+    unit_ids:
+        Optional list of unit IDs to restrict inference to.
+    cache_dir:
+        Optional shared cache directory for embeddings. If omitted, a
+        ``cache`` subdirectory under ``base_outdir`` is used.
+    cancel_callback:
+        Optional cancellation callback passed through to :func:`run_inference`.
+    log_callback:
+        Optional logging callback; if provided, messages are prefixed with the
+        experiment name.
+
+    Returns
+    -------
+    Dict[str, InferenceExperimentResult]
+        Mapping from experiment name to result objects.
+    """
+    base_outdir = Path(base_outdir)
+    base_outdir.mkdir(parents=True, exist_ok=True)
+
+    shared_cache_dir: Optional[Path] = cache_dir or (base_outdir / "cache")
+    if shared_cache_dir is not None:
+        shared_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    bundle = label_config_bundle or EMPTY_BUNDLE
+    results: Dict[str, InferenceExperimentResult] = {}
+
+    def _make_log_callback(name: str) -> Optional[Callable[[str], None]]:
+        if log_callback is None:
+            return None
+
+        def _wrapped(message: str) -> None:
+            log_callback(f"[{name}] {message}")
+
+        return _wrapped
+
+    for name, overrides in sweeps.items():
+        exp_outdir = base_outdir / name
+        exp_log_cb = _make_log_callback(name)
+
+        df, artifacts = run_inference(
+            notes_df=notes_df,
+            ann_df=ann_df,
+            outdir=exp_outdir,
+            label_config_bundle=bundle,
+            label_config=label_config,
+            cfg_overrides=dict(overrides),
+            unit_ids=unit_ids,
+            cancel_callback=cancel_callback,
+            log_callback=exp_log_cb,
+            cache_dir=shared_cache_dir,
+        )
+
+        results[name] = InferenceExperimentResult(
+            name=name,
+            cfg_overrides=dict(overrides),
+            outdir=exp_outdir,
+            dataframe=df,
+            artifacts=artifacts,
+        )
+
+    # Persist a simple manifest for downstream tooling or inspection.
+    manifest_path = base_outdir / "experiments.json"
+    try:
+        manifest_payload = {
+            name: {
+                "cfg_overrides": result.cfg_overrides,
+                "outdir": str(result.outdir),
+                "artifacts": result.artifacts,
+            }
+            for name, result in results.items()
+        }
+        manifest_path.write_text(json.dumps(manifest_payload, indent=2), encoding="utf-8")
+    except Exception:
+        # The experiments themselves have already completed; a failure to write
+        # the manifest should not cause the sweep to be treated as failed.
+        pass
+
+    return results
+
+
+__all__ = [
+    "InferenceExperimentResult",
+    "run_inference_experiments",
+]


### PR DESCRIPTION
## Summary
- add smoke test covering the inference experiment runner and manifest generation
- stub backend inference to validate experiment configuration handling

## Testing
- pytest tests/ai_backend/test_experiments.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934dce739fc83279173a896236d62e9)