### PR TITLE
Add single-prompt inference labeling path

### DIFF
--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -95,6 +95,18 @@ class SelectionConfig:
 
 @dataclass
 class LLMFirstConfig:
+    """Knobs for the LLM-first labeling pipeline.
+
+    Attributes:
+        inference_labeling_mode: how to label units during inference; "family"
+            uses the existing FamilyLabeler, "single_prompt" will use a single
+            multi-label LLM call per unit.
+        single_prompt_max_labels: safety clamp on how many labels can be included
+            in a single-prompt call.
+        single_prompt_max_chars: approximate cap on total characters of the
+            merged context passed to the LLM in single-prompt mode.
+    """
+
     n_probe_units: int = 10
     topk: int = 6
     json_trace_policy: str = 'fallback'
@@ -102,6 +114,9 @@ class LLMFirstConfig:
     exemplar_K: int = 1
     exemplar_generate: bool = True
     exemplar_temperature: float = 0.9
+    inference_labeling_mode: str = "family"  # "family" | "single_prompt"
+    single_prompt_max_labels: int = 64
+    single_prompt_max_chars: int = 16000
     # forced-choice micro-probe
     fc_enable: bool = True
     #label enrichment for probe

--- a/vaannotate/vaannotate_ai_backend/pipelines/inference.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/inference.py
@@ -11,6 +11,15 @@ from ..utils.jsonish import _jsonify_cols
 
 
 class InferencePipeline:
+    """Inference runner supporting family or single-prompt labeling modes.
+
+    - cfg.llmfirst.inference_labeling_mode="family" uses the existing
+      FamilyLabeler with per-label retrieval and gating.
+    - cfg.llmfirst.inference_labeling_mode="single_prompt" builds one
+      merged context per unit, calls annotate_multi, and applies label
+      dependencies as post-hoc gating. This mode is intended for
+      inference experiments and large-scale corpus labeling.
+    """
     def __init__(self, data_repo, emb_store, ctx_builder, llm_labeler, config, paths):
         self.repo = data_repo
         self.store = emb_store
@@ -44,6 +53,14 @@ class InferencePipeline:
         return current_rules_map, current_label_types
 
     def _label_units(self, unit_ids: Iterable[str], label_types: dict[str, str], rules_map: dict[str, str]) -> pd.DataFrame:
+        mode = getattr(self.cfg.llmfirst, "inference_labeling_mode", "family")
+        if mode == "single_prompt":
+            return self._label_units_single_prompt(unit_ids, label_types, rules_map)
+        return self._label_units_family(unit_ids, label_types, rules_map)
+
+    def _label_units_family(
+        self, unit_ids: Iterable[str], label_types: dict[str, str], rules_map: dict[str, str]
+    ) -> pd.DataFrame:
         from ..services.family_labeler import build_family_labeler, run_family_labeling_for_units
 
         fam = build_family_labeler(
@@ -73,6 +90,70 @@ class InferencePipeline:
         # The JSON-safe view is still handled by _jsonify_cols in run(), so we
         # simply return the tall DataFrame here.
         return df
+
+    def _label_units_single_prompt(
+        self, unit_ids: Iterable[str], label_types: dict[str, str], rules_map: dict[str, str]
+    ) -> pd.DataFrame:
+        label_ids = sorted(label_types.keys())
+        max_labels = int(getattr(self.cfg.llmfirst, "single_prompt_max_labels", 64) or 64)
+        label_ids = label_ids[:max_labels]
+
+        rows: list[dict] = []
+
+        from ..services.label_dependencies import build_label_dependencies, evaluate_gating
+
+        _parent_to_children, _child_to_parents, _roots = build_label_dependencies(self.label_config)
+
+        for uid in unit_ids:
+            ctx = self.ctx_builder.build_context_for_family(
+                uid,
+                label_ids=label_ids,
+                rules_map=rules_map,
+                topk_per_label=self.cfg.rag.top_k_final,
+                max_snippets=None,
+                max_chars=getattr(self.cfg.llmfirst, "single_prompt_max_chars", None),
+            )
+
+            res = self.llm.annotate_multi(
+                unit_id=uid,
+                label_ids=label_ids,
+                label_types=label_types,
+                rules_map=rules_map,
+                ctx_snippets=ctx,
+            )
+            preds = res.get("predictions") or {}
+
+            parent_preds: dict[tuple[str, str], str] = {}
+            for lid, info in preds.items():
+                parent_preds[(uid, str(lid))] = info.get("prediction") if isinstance(info, dict) else None
+
+            for lid in label_ids:
+                info = preds.get(str(lid)) or {}
+                value = info.get("prediction") if isinstance(info, dict) else None
+                gated_ok = evaluate_gating(
+                    label_id=str(lid),
+                    unit_id=uid,
+                    parent_preds=parent_preds,
+                    label_types=label_types,
+                    label_config=self.label_config,
+                )
+                if not gated_ok:
+                    value = None
+
+                rows.append(
+                    {
+                        "unit_id": uid,
+                        "label_id": str(lid),
+                        "label_type": label_types.get(str(lid), "categorical"),
+                        "llm_prediction": value,
+                        "llm_consistency": None,
+                        "llm_reasoning": info.get("reasoning") if isinstance(info, dict) else None,
+                        "rag_context": ctx,
+                        "llm_runs": res.get("runs", []),
+                    }
+                )
+
+        return pd.DataFrame(rows)
 
     def run(self, unit_ids: Optional[List[str]] = None) -> pd.DataFrame:
         run_id = time.strftime("%Y%m%d-%H%M%S")

--- a/vaannotate/vaannotate_ai_backend/project_experiments.py
+++ b/vaannotate/vaannotate_ai_backend/project_experiments.py
@@ -170,6 +170,8 @@ def run_project_inference_experiments(
     should avoid reusing a shared :class:`BackendSession`, because the
     embedding store is specific to the embedder; sweeps that only tweak
     RAG/LLM knobs can safely share the session for speed.
+    Sweeps or inference experiments can switch to single-prompt label inference
+    with a cfg override like ``{"llmfirst": {"inference_labeling_mode": "single_prompt"}}``.
     """
 
     notes_df, ann_df = export_inputs_from_repo(


### PR DESCRIPTION
## Summary
- branch inference pipeline on llmfirst.inference_labeling_mode and preserve existing family flow
- add single-prompt inference path that builds merged context, calls annotate_multi, and applies post-hoc gating

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935966058fc8327a9b61ed41aacb1fc)