### PR TITLE
Handle extra kwargs in LLM json_call

### DIFF
--- a/vaannotate/vaannotate_ai_backend/llm_backends.py
+++ b/vaannotate/vaannotate_ai_backend/llm_backends.py
@@ -163,6 +163,7 @@ class LLMBackend:
         logprobs: bool,
         top_logprobs: Optional[int],
         response_format: Optional[Mapping[str, Any]] = None,
+        **_: Any,
     ) -> JSONCallResult:
         raise NotImplementedError
 
@@ -209,6 +210,7 @@ class AzureOpenAIBackend(LLMBackend):
         logprobs: bool,
         top_logprobs: Optional[int],
         response_format: Optional[Mapping[str, Any]] = None,
+        **_: Any,
     ) -> JSONCallResult:
         self._respect_rpm_limit()
         kwargs: Dict[str, Any] = {
@@ -612,6 +614,7 @@ class ExLlamaV2Backend(LLMBackend):  # pragma: no cover - requires heavy optiona
         logprobs: bool,
         top_logprobs: Optional[int],
         response_format: Optional[Mapping[str, Any]] = None,
+        **_: Any,
     ) -> JSONCallResult:
         prompt = self._format_messages(messages)
         max_new = int(self.cfg.local_max_new_tokens or 1024)


### PR DESCRIPTION
## Summary
- allow llm backend json_call implementations to accept optional kwargs used by the labeler

## Testing
- python -m pytest tests/vaannotate_ai_backend -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b24ecae08327823436c1faef40c1)