### PR TITLE
Import unicodedata for BM25 tokenization

### DIFF
--- a/vaannotate/vaannotate_ai_backend/core/embeddings.py
+++ b/vaannotate/vaannotate_ai_backend/core/embeddings.py
@@ -10,6 +10,7 @@ import os
 import random
 import re
 import time
+import unicodedata
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional


### PR DESCRIPTION
## Summary
- import `unicodedata` in the embeddings module
- prevent NameError during BM25 tokenization when normalizing text

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b9f8342083278378bfb7e4d583f7)