### PR TITLE
Define options helper in RAG retriever to fix assisted review

### DIFF
--- a/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
+++ b/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
@@ -38,6 +38,15 @@ except Exception:
                 old, _ = self._order.popitem(last=False)
                 super().pop(old, None)
 
+
+def _options_for_label(label_id: str, label_type: str, label_config: dict) -> list[str]:
+    cfg = label_config.get(label_id, {}) if isinstance(label_config, dict) else {}
+    if label_type == "categorical":
+        return cfg.get("options", []) or []
+    if label_type == "binary":
+        return ["yes", "no"]
+    return []
+
         def get(self, k, default=None):
             if k in self._order:
                 self._order.move_to_end(k)


### PR DESCRIPTION
## Summary
- add a local `_options_for_label` helper to the RAG retriever so label options are available during retrieval
- prevent NameError during assisted chart review snippet generation when label options are needed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935bf4ab6248327b0dcc2ac42cf5f65)