### PR TITLE
Fix AI probe parquet serialization for llm runs

### DIFF
--- a/tests/test_active_learning_probe_jsonify.py
+++ b/tests/test_active_learning_probe_jsonify.py
@@ -1,0 +1,63 @@
+import types
+
+import pandas as pd
+
+
+def test_llm_probe_jsonifies_llm_runs(tmp_path, monkeypatch):
+    from vaannotate.vaannotate_ai_backend.pipelines.active_learning import ActiveLearningPipeline
+    from vaannotate.vaannotate_ai_backend.utils.jsonish import _jsonify_cols
+
+    # Stub out the family labeler to return a normalized probe DataFrame that includes
+    # structured llm_runs values.
+    probe_df = pd.DataFrame(
+        {
+            "unit_id": ["u1", "u2"],
+            "label_id": ["L1", "L1"],
+            "llm_runs": [[{"raw": {"reasoning": "x"}}], None],
+            "U": [0.1, 0.2],
+        }
+    )
+
+    class DummyFamilyLabeler:
+        def probe_units_label_tree(self, *args, **kwargs):
+            return probe_df
+
+    monkeypatch.setattr(
+        "vaannotate.vaannotate_ai_backend.services.family_labeler.build_family_labeler",
+        lambda *a, **k: DummyFamilyLabeler(),
+    )
+
+    class DummyUncertainty:
+        def score_probe_results(self, df):
+            return df
+
+    cfg = types.SimpleNamespace(
+        llmfirst=types.SimpleNamespace(enrich=False),
+        scjitter=types.SimpleNamespace(),
+        select=types.SimpleNamespace(batch_size=2, pct_uncertain=0.5),
+    )
+    paths = types.SimpleNamespace(outdir=str(tmp_path))
+
+    pipeline = ActiveLearningPipeline(
+        data_repo=None,
+        emb_store=None,
+        ctx_builder=None,
+        llm_labeler=None,
+        disagreement_scorer=None,
+        uncertainty_scorer=DummyUncertainty(),
+        diversity_selector=None,
+        selector=None,
+        config=cfg,
+        paths=paths,
+        jsonify_cols_fn=_jsonify_cols,
+    )
+
+    result = pipeline._build_llm_uncertain_bucket(label_types={}, rules_map={}, exclude_units=None)
+
+    parquet_path = tmp_path / "llm_probe.parquet"
+    assert parquet_path.exists()
+
+    stored = pd.read_parquet(parquet_path)
+    # Structured runs should have been serialized to JSON strings before writing parquet.
+    assert isinstance(stored.loc[0, "llm_runs"], str)
+    assert isinstance(result, pd.DataFrame) and not result.empty

--- a/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
@@ -159,7 +159,7 @@ class ActiveLearningPipeline:
         probe_df = fam.probe_units_label_tree(self.cfg.llmfirst.enrich, label_types, rules_map, exclude_units=exclude_units)
         probe_df = self.uncertainty_scorer.score_probe_results(probe_df)
         if self.jsonify_cols:
-            safe_cols = [c for c in ["fc_probs", "rag_context", "why", "runs"] if c in probe_df.columns]
+            safe_cols = [c for c in ["fc_probs", "rag_context", "why", "runs", "llm_runs"] if c in probe_df.columns]
             self.jsonify_cols(probe_df, safe_cols).to_parquet(os.path.join(self.paths.outdir, "llm_probe.parquet"), index=False)
         n_unc = int(self.cfg.select.batch_size * self.cfg.select.pct_uncertain)
         return direct_uncertainty_selection(probe_df, n_unc, select_most_certain=False)


### PR DESCRIPTION
## Summary
- ensure probe parquet export jsonifies normalized llm_runs traces
- add regression test covering probe llm_runs serialization

## Testing
- python -m pytest tests/test_active_learning_probe_jsonify.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935cea9a9ec8327978f1024090dc220)