### PR TITLE
Ensure few-shot prompting in AI pipelines

### DIFF
--- a/vaannotate/vaannotate_ai_backend/orchestration.py
+++ b/vaannotate/vaannotate_ai_backend/orchestration.py
@@ -57,7 +57,8 @@ def _build_shared_components(
     # prompting layer aligned with label-set metadata for both active learning
     # and inference pipelines.
     few_shot_cfg = getattr(cfg.llm, "few_shot_examples", {}) or {}
-    if not few_shot_cfg:
+    few_shot_explicit = getattr(cfg.llm, "_few_shot_examples_overridden", False)
+    if not few_shot_cfg and not few_shot_explicit:
         label_config = label_config_bundle.current or {}
         extracted: dict[str, list[dict[str, str]]] = {}
         for label_id, entry in label_config.items():

--- a/vaannotate/vaannotate_ai_backend/orchestration.py
+++ b/vaannotate/vaannotate_ai_backend/orchestration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
-from typing import Mapping
+from typing import Mapping, Sequence
 
 from .config import OrchestratorConfig, Paths
 from .core.data import DataRepository
@@ -51,6 +51,41 @@ def _build_shared_components(
             cache_dir=paths.cache_dir,
             normalize=cfg.rag.normalize_embeddings,
         )
+
+    # If the LLM config does not already include few-shot examples, fall back to
+    # any examples embedded in the current label configuration. This keeps the
+    # prompting layer aligned with label-set metadata for both active learning
+    # and inference pipelines.
+    few_shot_cfg = getattr(cfg.llm, "few_shot_examples", {}) or {}
+    if not few_shot_cfg:
+        label_config = label_config_bundle.current or {}
+        extracted: dict[str, list[dict[str, str]]] = {}
+        for label_id, entry in label_config.items():
+            if str(label_id) == "_meta" or not isinstance(entry, Mapping):
+                continue
+            raw_examples = entry.get("few_shot_examples")
+            if not isinstance(raw_examples, Sequence):
+                continue
+            parsed: list[dict[str, str]] = []
+            for example in raw_examples:
+                if not isinstance(example, Mapping):
+                    continue
+                payload: dict[str, str] = {}
+                if example.get("context") is not None:
+                    payload["context"] = str(example.get("context"))
+                if example.get("answer") is not None:
+                    payload["answer"] = str(example.get("answer"))
+                if payload:
+                    parsed.append(payload)
+            if parsed:
+                key = str(entry.get("label_id") or label_id)
+                if key:
+                    extracted[key] = parsed
+        if extracted:
+            try:
+                setattr(cfg.llm, "few_shot_examples", extracted)
+            except Exception:
+                pass
     rag = RAGRetriever(
         store,
         models,

--- a/vaannotate/vaannotate_ai_backend/orchestrator.py
+++ b/vaannotate/vaannotate_ai_backend/orchestrator.py
@@ -43,6 +43,12 @@ def _apply_overrides(target: object, overrides: Mapping[str, Any]) -> None:
         return
 
     for key, value in overrides.items():
+        if key == "few_shot_examples":
+            try:
+                setattr(target, "_few_shot_examples_overridden", True)
+            except Exception:
+                pass
+
         if isinstance(value, Mapping):
             current = getattr(target, key, None)
             if current is not None and not isinstance(current, (str, bytes, int, float, bool)):


### PR DESCRIPTION
## Summary
- default LLM few-shot examples to label-set metadata when overrides are empty so active learning and inference share prompting examples
- include label-specific few-shot demonstrations when running single-prompt multi-label inference calls and record them for diagnostics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693629352794832781eb84da67582604)