### PR TITLE
Fix inference experiment backend overrides handling

### DIFF
--- a/tests/ai_backend/test_project_experiments.py
+++ b/tests/ai_backend/test_project_experiments.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from vaannotate.vaannotate_ai_backend import project_experiments
+
+
+class _DummyResult:
+    def __init__(self, df: pd.DataFrame):
+        self.dataframe = df
+        self.artifacts = {}
+        self.outdir = None
+
+
+def test_run_project_inference_experiments_applies_configs(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    notes_df = pd.DataFrame(
+        [
+            {"doc_id": "1", "patient_icn": "p1", "text": "Note A"},
+            {"doc_id": "2", "patient_icn": "p2", "text": "Note B"},
+        ]
+    )
+    ann_df = pd.DataFrame(
+        [
+            {"unit_id": "1", "label_id": "l1", "label_value": "yes"},
+            {"unit_id": "2", "label_id": "l1", "label_value": "no"},
+        ]
+    )
+
+    def _fake_export_inputs_from_repo(
+        project_root, pheno_id, prior_rounds, *, corpus_record, corpus_id, corpus_path
+    ):
+        captured["export_inputs"] = {
+            "project_root": project_root,
+            "pheno_id": pheno_id,
+            "prior_rounds": list(prior_rounds),
+            "corpus_id": corpus_id,
+            "corpus_path": corpus_path,
+        }
+        return notes_df, ann_df
+
+    def _fake_load_label_config_bundle(
+        project_root, pheno_id, labelset_id, prior_rounds, *, overrides=None
+    ):
+        captured["label_config_bundle"] = {
+            "project_root": project_root,
+            "pheno_id": pheno_id,
+            "labelset_id": labelset_id,
+            "prior_rounds": list(prior_rounds),
+            "overrides": overrides,
+        }
+        return {"bundle": True}
+
+    def _fake_session_from_env(paths, config):
+        captured["session_config"] = {
+            "backend": config.llm.backend,
+            "llm_temperature": config.llm.temperature,
+            "rag_chunk_size": config.rag.chunk_size,
+        }
+        captured["session_paths"] = paths
+        return "session"
+
+    def _fake_run_inference_experiments(**kwargs):
+        captured["run_kwargs"] = kwargs
+        df = pd.DataFrame(
+            [
+                {"unit_id": "1", "label_id": "l1", "prediction_value": "yes"},
+                {"unit_id": "2", "label_id": "l1", "prediction_value": "no"},
+            ]
+        )
+        return {"baseline": _DummyResult(df)}
+
+    monkeypatch.setattr(
+        project_experiments, "export_inputs_from_repo", _fake_export_inputs_from_repo
+    )
+    monkeypatch.setattr(
+        project_experiments, "_load_label_config_bundle", _fake_load_label_config_bundle
+    )
+    monkeypatch.setattr(
+        project_experiments.BackendSession, "from_env", staticmethod(_fake_session_from_env)
+    )
+    monkeypatch.setattr(
+        project_experiments, "run_inference_experiments", _fake_run_inference_experiments
+    )
+
+    base_overrides = {
+        "llm": {"backend": "azure", "temperature": 0.9},
+        "rag": {"chunk_size": 321},
+        "label_config": {"prompt": "custom"},
+    }
+    sweeps = {"baseline": {"llm": {"temperature": 0.2}}}
+
+    results, gold_df = project_experiments.run_project_inference_experiments(
+        project_root=tmp_path,
+        pheno_id="pheno1",
+        prior_rounds=[1],
+        labelset_id="ls1",
+        phenotype_level="single_doc",
+        sweeps=sweeps,
+        base_outdir=tmp_path / "out",
+        corpus_id="corp1",
+        corpus_path=None,
+        cfg_overrides_base=base_overrides,
+    )
+
+    assert gold_df.shape == (2, 3)
+    assert isinstance(results.get("baseline"), _DummyResult)
+
+    assert captured["export_inputs"] == {
+        "project_root": tmp_path,
+        "pheno_id": "pheno1",
+        "prior_rounds": [1],
+        "corpus_id": "corp1",
+        "corpus_path": None,
+    }
+    assert captured["label_config_bundle"]["overrides"] == {"prompt": "custom"}
+
+    assert captured["session_config"] == {
+        "backend": "azure",
+        "llm_temperature": 0.9,
+        "rag_chunk_size": 321,
+    }
+
+    merged_sweep = captured["run_kwargs"]["sweeps"]["baseline"]
+    assert merged_sweep["llm"]["temperature"] == 0.2
+    assert merged_sweep["llm"]["backend"] == "azure"
+    assert merged_sweep["rag"]["chunk_size"] == 321
+    assert merged_sweep["label_config"] == {"prompt": "custom"}
+
+    assert captured["run_kwargs"]["unit_ids"] == ["1", "2"]
+    metrics_path = tmp_path / "out" / "baseline" / "metrics.json"
+    assert metrics_path.exists()

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -338,7 +338,12 @@ class InferenceExperimentDialog(QtWidgets.QDialog):
             return
         ai_cfg = config.get("ai_backend") if isinstance(config, Mapping) else None
         if isinstance(ai_cfg, Mapping):
-            self._cfg_overrides_base = dict(ai_cfg)
+            overrides_payload = dict(ai_cfg)
+            config_overrides = ai_cfg.get("config_overrides")
+            if isinstance(config_overrides, Mapping):
+                overrides_payload = _deep_update_dict(overrides_payload, config_overrides)
+                overrides_payload.pop("config_overrides", None)
+            self._cfg_overrides_base = overrides_payload
             self.baseline_label.setText(f"Loaded from round {latest_number}")
         else:
             QtWidgets.QMessageBox.warning(
@@ -348,7 +353,9 @@ class InferenceExperimentDialog(QtWidgets.QDialog):
             )
 
     def _open_advanced_config(self) -> None:
-        dialog = AIAdvancedConfigDialog(self, self._cfg_overrides_base)
+        dialog = AIAdvancedConfigDialog(
+            self, self._cfg_overrides_base, label_schema=self._labelset_schema
+        )
         if dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             self._cfg_overrides_base = dialog.result_config or {}
 


### PR DESCRIPTION
## Summary
- ensure inference experiment builder merges backend config overrides from the latest round and exposes the full advanced settings dialog
- add coverage for run_project_inference_experiments to verify configs and experiment parameters propagate into sweeps and sessions

## Testing
- python -m pytest tests/ai_backend/test_project_experiments.py tests/ai_backend/test_experiments.py::test_run_inference_experiments_smoke


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fb20aacc8327a5c38dba5e311704)