### PR TITLE
Add coverage for prior round annotation collation

### DIFF
--- a/tests/ai_backend/test_project_experiments.py
+++ b/tests/ai_backend/test_project_experiments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 from vaannotate.vaannotate_ai_backend import project_experiments
 
@@ -131,3 +132,74 @@ def test_run_project_inference_experiments_applies_configs(monkeypatch, tmp_path
     assert captured["run_kwargs"]["unit_ids"] == ["1", "2"]
     metrics_path = tmp_path / "out" / "baseline" / "metrics.json"
     assert metrics_path.exists()
+
+
+def test_run_project_inference_experiments_passes_prior_annotations(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    notes_df = pd.DataFrame(
+        [
+            {"doc_id": "1", "patient_icn": "p1", "text": "Note A"},
+            {"doc_id": "2", "patient_icn": "p2", "text": "Note B"},
+        ]
+    )
+    ann_df = pd.DataFrame(
+        [
+            {"unit_id": "1", "label_id": "l1", "label_value": "yes", "labelset_id": "ls1"},
+            {"unit_id": "2", "label_id": "l1", "label_value": "no", "labelset_id": "ls1"},
+        ]
+    )
+
+    def _fake_export_inputs_from_repo(*args, **kwargs):
+        captured["export_inputs"] = {"args": args, "kwargs": kwargs}
+        return notes_df.copy(), ann_df.copy()
+
+    def _fake_load_label_config_bundle(*_args, **_kwargs):
+        return {"bundle": True}
+
+    def _fake_session_from_env(paths, config):
+        captured["session_paths"] = paths
+        captured["session_config"] = config
+        return "session"
+
+    def _fake_run_inference_experiments(**kwargs):
+        captured["run_kwargs"] = kwargs
+        df = pd.DataFrame(
+            [
+                {"unit_id": "1", "label_id": "l1", "prediction_value": "yes"},
+                {"unit_id": "2", "label_id": "l1", "prediction_value": "no"},
+            ]
+        )
+        return {"baseline": _DummyResult(df)}
+
+    monkeypatch.setattr(
+        project_experiments, "export_inputs_from_repo", _fake_export_inputs_from_repo
+    )
+    monkeypatch.setattr(
+        project_experiments, "_load_label_config_bundle", _fake_load_label_config_bundle
+    )
+    monkeypatch.setattr(
+        project_experiments.BackendSession, "from_env", staticmethod(_fake_session_from_env)
+    )
+    monkeypatch.setattr(
+        project_experiments, "run_inference_experiments", _fake_run_inference_experiments
+    )
+
+    results, gold_df = project_experiments.run_project_inference_experiments(
+        project_root=tmp_path,
+        pheno_id="pheno1",
+        prior_rounds=[1, 2],
+        labelset_id="ls1",
+        phenotype_level="single_doc",
+        sweeps={"baseline": {}},
+        base_outdir=tmp_path / "out",
+        corpus_id=None,
+        corpus_path=None,
+        cfg_overrides_base=None,
+    )
+
+    assert isinstance(results.get("baseline"), _DummyResult)
+    assert gold_df.shape == (2, 3)
+    assert list(gold_df["unit_id"]) == ["1", "2"]
+    assert_frame_equal(captured["run_kwargs"]["ann_df"].reset_index(drop=True), ann_df)
+    assert captured["run_kwargs"]["unit_ids"] == ["1", "2"]


### PR DESCRIPTION
## Summary
- add adapter test to verify multiple prior rounds are collated with labelset metadata
- add project inference experiment test ensuring prior annotations are passed through to inference sweeps

## Testing
- pytest tests/ai_backend/test_project_experiments.py tests/test_ai_adapters.py *(fails: pandas dependency missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ff8a51c483279deffeadfea21c1c)