### PR TITLE
Handle non-boolean label_na values

### DIFF
--- a/vaannotate/vaannotate_ai_backend/project_experiments.py
+++ b/vaannotate/vaannotate_ai_backend/project_experiments.py
@@ -66,7 +66,8 @@ def build_gold_from_ann(
         ann_df = ann_df[ann_df["labelset_id"].astype(str) == str(labelset_id)]
 
     if "label_na" in ann_df.columns:
-        ann_df = ann_df[~ann_df["label_na"].fillna(False)]
+        label_na_mask = ann_df["label_na"].fillna(False).astype(bool)
+        ann_df = ann_df[~label_na_mask]
 
     if "label_value" not in ann_df.columns:
         raise KeyError("Expected column 'label_value' in annotations")


### PR DESCRIPTION
## Summary
- cast `label_na` to boolean before filtering gold annotations to avoid treating integer flags as column labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937155b1f748327989810a260e733c7)