### PR TITLE
Respect sweep overrides when reusing inference sessions

### DIFF
--- a/vaannotate/vaannotate_ai_backend/orchestrator.py
+++ b/vaannotate/vaannotate_ai_backend/orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from collections.abc import Mapping
+import copy
 import os
 from pathlib import Path
 from typing import Callable, Optional, Dict, Any, Tuple
@@ -406,6 +407,7 @@ def run_inference(
     *,
     label_config: Optional[dict] = None,
     cfg_overrides: Optional[Dict[str, Any]] = None,
+    cfg: OrchestratorConfig | None = None,
     unit_ids: Optional[list[str]] = None,
     cancel_callback: Optional[Callable[[], bool]] = None,
     log_callback: Optional[Callable[[str], None]] = None,
@@ -429,7 +431,7 @@ def run_inference(
     notes_df.to_parquet(notes_path, index=False)
     ann_df.to_parquet(ann_path, index=False)
 
-    cfg = OrchestratorConfig()
+    cfg = copy.deepcopy(cfg) if cfg is not None else OrchestratorConfig()
     overrides = dict(cfg_overrides or {})
     phenotype_level = overrides.pop("phenotype_level", None)
     rag_overrides = overrides.get("rag") if isinstance(overrides.get("rag"), Mapping) else {}

--- a/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
+++ b/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
@@ -760,14 +760,17 @@ class RAGRetriever:
                 need = min_k - len(out)
                 out.extend(rest[:need])
 
+        selected = out[:final_k]
+
         diagnostics["final_selection"] = {
-            "count": len(out),
-            "score_stats": _score_stats(out),
+            "count": len(selected),
+            "score_stats": _score_stats(selected),
+            "pre_topk_count": len(out),
         }
 
         diagnostics["stage"] = "complete"
         self.set_last_diagnostics(unit_id, label_id, diagnostics, original_unit_id=original_unit_id)
-        return out[:final_k]
+        return selected
 
     def expand_from_snippets(self, label_id: str, snippets: List[str], seen_pairs: set, per_seed_k: int=100) -> Dict[str,float]:
         out: Dict[str,float] = {}


### PR DESCRIPTION
## Summary
- build per-sweep orchestrator configs even when sharing a BackendSession so RAG overrides flow into inference
- allow run_inference to accept a pre-built config while still applying sweep overrides
- record RAG diagnostics using the selected top-k count and per_label_topk defaults for clearer llm_calls traces

## Testing
- `PYTHONPATH=. pytest tests/ai_backend/test_project_experiments.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693727767d2883278b6ec02d1a87669e)