### PR TITLE
Improve date parsing for experiment metrics

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -999,6 +999,8 @@ class InferenceMetricsDialog(QtWidgets.QDialog):
             name = str(exp.get("name", row))
             metrics = exp.get("metrics") or {}
             global_metrics = metrics.get("global") if isinstance(metrics, Mapping) else {}
+            if not isinstance(global_metrics, Mapping):
+                global_metrics = {}
 
             summary_table.setItem(row, 0, QtWidgets.QTableWidgetItem(name))
             summary_table.setItem(

--- a/vaannotate/vaannotate_ai_backend/experiment_metrics.py
+++ b/vaannotate/vaannotate_ai_backend/experiment_metrics.py
@@ -8,6 +8,8 @@ from typing import Dict, Mapping, Optional, Tuple
 
 import pandas as pd
 
+from vaannotate.shared.metadata import normalize_date_value
+
 from vaannotate.vaannotate_ai_backend.label_configs import LabelConfigBundle
 from vaannotate.vaannotate_ai_backend.services.label_dependencies import build_label_dependencies
 
@@ -64,9 +66,15 @@ def _parse_date(value: object) -> Optional[pd.Timestamp]:
     if value is None:
         return None
 
-    parsed = pd.to_datetime(value, errors="coerce")
+    if isinstance(value, pd.Timestamp):
+        return value if not pd.isna(value) else None
+
+    normalized = normalize_date_value(str(value))
+    parsed = pd.to_datetime(normalized or value, errors="coerce")
+
     if pd.isna(parsed):
         return None
+
     if isinstance(parsed, pd.Timestamp):
         return parsed
 


### PR DESCRIPTION
## Summary
- normalize inference experiment date parsing with shared metadata helpers
- allow tolerance across differing date formats so date agreement metrics populate

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937376356908327a053a8fe3cabeb1f)