### PR TITLE
Normalize RAG top-k overrides in experiments

### DIFF
--- a/vaannotate/vaannotate_ai_backend/services/context_builder.py
+++ b/vaannotate/vaannotate_ai_backend/services/context_builder.py
@@ -331,8 +331,14 @@ class ContextBuilder:
             return dedup
 
         cfg_rag = getattr(self, "cfg", None) or self.cfg
+
+        # top_k_final is canonical; any legacy per_label_topk has been normalized
+        # into this already. Do not consult per_label_topk here.
         cfg_final_k = getattr(cfg_rag, "top_k_final", None)
-        final_k_raw = topk_override or cfg_final_k or getattr(cfg_rag, "per_label_topk", 6)
+        if cfg_final_k is None:
+            cfg_final_k = 6
+
+        final_k_raw = topk_override or cfg_final_k
         try:
             final_k = max(1, int(final_k_raw))
         except Exception:

--- a/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
+++ b/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
@@ -480,8 +480,14 @@ class RAGRetriever:
         
         # ---- config ----
         cfg_rag = getattr(self, "cfg", getattr(self, "rag", None)) or self.cfg
+
+        # top_k_final is canonical; any legacy per_label_topk has already been
+        # folded into this via config/normalization. Do not consult per_label_topk here.
         cfg_final_k = getattr(cfg_rag, "top_k_final", None)
-        final_k_raw = topk_override or cfg_final_k or getattr(cfg_rag, "per_label_topk", 6)
+        if cfg_final_k is None:
+            cfg_final_k = 6  # hard default if nothing was set
+
+        final_k_raw = topk_override or cfg_final_k
         try:
             final_k = max(1, int(final_k_raw))
         except Exception:


### PR DESCRIPTION
## Summary
- normalize rag overrides in experiments to promote legacy per_label_topk into top_k_final
- mirror the canonical top_k_final back into per_label_topk for compatibility while runtime uses top_k_final

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693743d284f88327bacc3499683bb0d4)