### PR TITLE
Ensure Admin MMR sweep drives master switch

### DIFF
--- a/vaannotate/vaannotate_ai_backend/services/context_builder.py
+++ b/vaannotate/vaannotate_ai_backend/services/context_builder.py
@@ -350,11 +350,12 @@ class ContextBuilder:
         keyword_fraction = max(0.0, min(1.0, keyword_fraction))
         use_kw = keyword_fraction > 0.0 and bool(getattr(cfg_rag, "use_keywords", True))
         mmr_select_k = final_k * mmr_mult
+        mmr_enabled = bool(getattr(cfg_rag, "use_mmr", True))
 
         lam = mmr_lambda_override
         if lam is None:
             lam = getattr(cfg_rag, "mmr_lambda", None)
-        lam = None if lam is None else float(lam)
+        lam = None if lam is None or not mmr_enabled else float(lam)
         if lam is not None:
             lam = max(0.0, min(1.0, lam))
         diagnostics.update(
@@ -363,7 +364,12 @@ class ContextBuilder:
                 "rag_mode": "patient_local",
                 "final_k": final_k,
                 "min_k": min_k,
-                "mmr": {"lambda": lam, "multiplier": mmr_mult, "select_k": mmr_select_k},
+                "mmr": {
+                    "enabled": mmr_enabled,
+                    "lambda": lam,
+                    "multiplier": mmr_mult,
+                    "select_k": mmr_select_k,
+                },
             }
         )
 

--- a/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
+++ b/vaannotate/vaannotate_ai_backend/services/rag_retriever.py
@@ -499,19 +499,27 @@ class RAGRetriever:
         keyword_fraction = max(0.0, min(1.0, keyword_fraction))
         use_kw    = keyword_fraction > 0.0 and bool(getattr(cfg_rag, "use_keywords", True))
         mmr_select_k = final_k * mmr_mult
+        mmr_enabled = bool(getattr(cfg_rag, "use_mmr", True))
 
         # λ (0..1)
         lam = mmr_lambda_override
-        if lam is None: lam = getattr(cfg_rag, "mmr_lambda", None)
-        lam = None if lam is None else float(lam)
-        if lam is not None: lam = max(0.0, min(1.0, lam))
+        if lam is None:
+            lam = getattr(cfg_rag, "mmr_lambda", None)
+        lam = None if lam is None or not mmr_enabled else float(lam)
+        if lam is not None:
+            lam = max(0.0, min(1.0, lam))
         diagnostics.update(
             {
                 "stage": "config",
                 "rag_mode": "patient_local",
                 "final_k": final_k,
                 "min_k": min_k,
-                "mmr": {"lambda": lam, "multiplier": mmr_mult, "select_k": mmr_select_k},
+                "mmr": {
+                    "enabled": mmr_enabled,
+                    "lambda": lam,
+                    "multiplier": mmr_mult,
+                    "select_k": mmr_select_k,
+                },
             }
         )
 


### PR DESCRIPTION
## Summary
- ensure the inference experiment MMR sweep explicitly toggles the RAG `use_mmr` master switch
- add regression coverage that sweep configs propagate the master toggle through project experiments

## Testing
- python -m pytest tests/ai_backend/test_project_experiments.py::test_inference_sweeps_toggle_mmr_master_switch


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384c269adc8327abd72f4b2526a449)