### PR TITLE
Fix gating call in single prompt inference

### DIFF
--- a/vaannotate/vaannotate_ai_backend/pipelines/inference.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/inference.py
@@ -144,7 +144,7 @@ class InferencePipeline:
                 info = preds.get(str(lid)) or {}
                 value = info.get("prediction") if isinstance(info, dict) else None
                 gated_ok = evaluate_gating(
-                    label_id=str(lid),
+                    child_id=str(lid),
                     unit_id=uid,
                     parent_preds=parent_preds,
                     label_types=label_types,


### PR DESCRIPTION
## Summary
- fix single-prompt inference gating to use correct evaluate_gating argument name

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69387704a380832797d1d4478fe52558)