### PR TITLE
Defer BackendSession import in experiments

### DIFF
--- a/vaannotate/vaannotate_ai_backend/adapters.py
+++ b/vaannotate/vaannotate_ai_backend/adapters.py
@@ -11,7 +11,6 @@ import pandas as pd
 
 from . import __version__
 from .label_configs import LabelConfigBundle, EMPTY_BUNDLE
-from .orchestrator import build_next_batch
 from vaannotate.project import (
     build_label_config,
     fetch_labelset,
@@ -681,6 +680,7 @@ def run_ai_backend_and_collect(
     exclude_unit_ids: Optional[Iterable[str]] = None,
     sampling_metadata: Optional[Mapping[str, object]] = None,
 ) -> BackendResult:
+    from .orchestrator import build_next_batch
     log = log_callback or (lambda message: None)
     log("Preparing AI backend inputs…")
     excluded_ids = {str(uid) for uid in (exclude_unit_ids or []) if str(uid)}

--- a/vaannotate/vaannotate_ai_backend/experiments.py
+++ b/vaannotate/vaannotate_ai_backend/experiments.py
@@ -4,13 +4,14 @@ import copy
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional
 import pandas as pd
 
 from .config import OrchestratorConfig, Paths
 from .label_configs import LabelConfigBundle, EMPTY_BUNDLE
-from .orchestration import BackendSession
-from .orchestrator import _apply_overrides, run_inference
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .orchestration import BackendSession
 
 
 def _normalize_local_model_overrides(
@@ -171,7 +172,7 @@ def run_inference_experiments(
     cache_dir: Optional[Path] = None,
     cancel_callback: Optional[Callable[[], bool]] = None,
     log_callback: Optional[Callable[[str], None]] = None,
-    session: Optional[BackendSession] = None,
+    session: Optional["BackendSession"] = None,
 ) -> Dict[str, InferenceExperimentResult]:
     """Run multiple inference configurations (sweeps) and collect their outputs.
 
@@ -237,6 +238,9 @@ def run_inference_experiments(
     Dict[str, InferenceExperimentResult]
         Mapping from experiment name to result objects.
     """
+    from .orchestration import BackendSession
+    from .orchestrator import _apply_overrides, run_inference
+
     base_outdir = Path(base_outdir)
     base_outdir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- avoid eager BackendSession import in `experiments` by using lazy imports inside `run_inference_experiments`
- keep type checking support via `TYPE_CHECKING` guard while reducing circular import risk

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402b44eeac83278f659ca5f848d80f)