### PR TITLE
Include Azure key in large corpus LLM overrides

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -1656,6 +1656,7 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
 
         llm_fields = {
             "backend",
+            "azure_api_key",
             "azure_api_version",
             "azure_endpoint",
             "local_model_dir",


### PR DESCRIPTION
## Summary
- ensure Azure API keys from prior rounds are extracted into LLM overrides when loading large corpus inference defaults

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a9b726cc8327baf73aecfefe0acc)