### PR TITLE
Ensure precompute jobs apply AI environment overrides

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -1152,14 +1152,25 @@ class _LargeCorpusJobWorker(QtCore.QObject):
         *,
         precompute_job: Optional[PromptPrecomputeJob] = None,
         inference_job: Optional[PromptInferenceJob] = None,
+        env_overrides: Optional[Dict[str, str]] = None,
     ) -> None:
         super().__init__()
         self.precompute_job = precompute_job
         self.inference_job = inference_job
+        self.env_overrides = {
+            str(key): str(value)
+            for key, value in (env_overrides or {}).items()
+            if str(value)
+        }
 
     @QtCore.Slot()
     def run(self) -> None:  # noqa: D401 - Qt slot
         try:
+            original_env: Dict[str, Optional[str]] = {}
+            for key, value in self.env_overrides.items():
+                original_env[key] = os.environ.get(key)
+                os.environ[key] = value
+
             if self.precompute_job is not None:
                 self.log_message.emit(
                     f"Starting prompt precompute job {self.precompute_job.job_id}…"
@@ -1177,6 +1188,12 @@ class _LargeCorpusJobWorker(QtCore.QObject):
         except Exception as exc:  # noqa: BLE001
             self.failed.emit(str(exc))
             return
+        finally:
+            for key, value in self.env_overrides.items():
+                if key in original_env and original_env[key] is not None:
+                    os.environ[key] = original_env[key] or ""
+                elif key in os.environ:
+                    os.environ.pop(key, None)
 
         self.finished.emit()
 
@@ -1539,9 +1556,24 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         precompute_job: Optional[PromptPrecomputeJob] = None,
         inference_job: Optional[PromptInferenceJob] = None,
     ) -> None:
+        env_overrides: Optional[Dict[str, str]] = {}
+        parent = self.parent()
+        if parent and hasattr(parent, "_collect_ai_environment"):
+            env_overrides = parent._collect_ai_environment()  # type: ignore[assignment]
+            if env_overrides is None:
+                return
+
+        if precompute_job is not None and getattr(precompute_job, "env_overrides", None) is None:
+            precompute_job.env_overrides = {  # type: ignore[assignment]
+                str(key): str(value)
+                for key, value in (env_overrides or {}).items()
+                if str(value)
+            }
+
         worker = _LargeCorpusJobWorker(
             precompute_job=precompute_job,
             inference_job=inference_job,
+            env_overrides=env_overrides,
         )
         thread = QtCore.QThread(self)
         worker.moveToThread(thread)

--- a/vaannotate/vaannotate_ai_backend/dev/large_corpus_validation.py
+++ b/vaannotate/vaannotate_ai_backend/dev/large_corpus_validation.py
@@ -108,6 +108,7 @@ def validate_large_corpus_parity(
         annotations_path=ann_path,
         job_dir=base_dir / "prompt_job",
         batch_size=len(notes_df),
+        env_overrides=None,
     )
     run_prompt_precompute_job(prompt_job)
 

--- a/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
+++ b/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
@@ -68,6 +68,7 @@ def create_prompt_precompute_job(
     notes_path: str | Path | None = None,
     annotations_path: str | Path | None = None,
     job_dir: str | Path | None = None,
+    env_overrides: dict[str, str] | None = None,
 ) -> PromptPrecomputeJob:
     """Create and run a prompt precompute job."""
 
@@ -88,6 +89,7 @@ def create_prompt_precompute_job(
         annotations_path=Path(annotations_path) if annotations_path else None,
         job_dir=Path(job_dir) if job_dir else None,
         batch_size=batch_size,
+        env_overrides={str(k): str(v) for k, v in (env_overrides or {}).items() if str(v)},
     )
 
     run_prompt_precompute_job(job)


### PR DESCRIPTION
## Summary
- apply AI environment overrides directly within prompt precompute runs so Azure/OpenAI credentials are active during batch creation
- propagate collected environment overrides into prompt precompute jobs launched from the Admin app and CLI helpers
- keep job utilities and validation harness in sync with the new precompute environment support

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a9b726cc8327baf73aecfefe0acc)