### PR TITLE
Add LLM override support to prompt precompute stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ The client loads the assignment SQLite bundle locally, presents unit navigation,
 
 For long-running inference across large corpora, VAAnnotate provides a two-stage pipeline that decouples retrieval from LLM calls:
 
-1. **Stage A – prompt precomputation**: build RAG contexts and prompt batches with `python -m vaannotate.vaannotate_ai_backend.large_corpus_cli precompute`, which writes prompt parquet files under `admin_tools/prompt_jobs/<job_id>`.
+1. **Stage A – prompt precomputation**: build RAG contexts and prompt batches with `python -m vaannotate.vaannotate_ai_backend.large_corpus_cli precompute`, which writes prompt parquet files under `admin_tools/prompt_jobs/<job_id>`. Supply `--cfg` for general overrides and `--llm-cfg` for LLM-specific settings that should influence retrieval prompts.
 2. **Stage B – prompt inference**: run the LLM over those precomputed prompts with `python -m vaannotate.vaannotate_ai_backend.large_corpus_cli infer`, producing output batches under `admin_tools/prompt_inference/<job_id>`.
 
-Both **family** and **single_prompt** labeling modes are supported, and LLM overrides can be supplied during Stage B to evaluate alternate models without re-running retrieval.
+Both **family** and **single_prompt** labeling modes are supported, and LLM overrides can be supplied during either stage to evaluate alternate models without re-running retrieval.
 
 ## Project layout
 

--- a/vaannotate/vaannotate_ai_backend/dev/large_corpus_validation.py
+++ b/vaannotate/vaannotate_ai_backend/dev/large_corpus_validation.py
@@ -104,6 +104,7 @@ def validate_large_corpus_parity(
         phenotype_level=phenotype_level,
         labeling_mode=labeling_mode,
         cfg_overrides=cfg_overrides,
+        llm_overrides=llm_overrides,
         notes_path=notes_path,
         annotations_path=ann_path,
         job_dir=base_dir / "prompt_job",

--- a/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
+++ b/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
@@ -62,6 +62,7 @@ def create_prompt_precompute_job(
     *,
     batch_size: int = 128,
     cfg_overrides: dict[str, Any] | None = None,
+    llm_overrides: dict[str, Any] | None = None,
     experiment_name: str | None = None,
     experiments_dir: str | Path | None = None,
     job_id: str | None = None,
@@ -85,6 +86,7 @@ def create_prompt_precompute_job(
         phenotype_level=phenotype_level,
         labeling_mode=labeling_mode,
         cfg_overrides=overrides,
+        llm_overrides=llm_overrides,
         notes_path=Path(notes_path) if notes_path else None,
         annotations_path=Path(annotations_path) if annotations_path else None,
         job_dir=Path(job_dir) if job_dir else None,
@@ -160,6 +162,7 @@ def main(argv: list[str] | None = None) -> None:
     precompute.add_argument("--notes-path", type=Path)
     precompute.add_argument("--annotations-path", type=Path)
     precompute.add_argument("--cfg", help="JSON overrides or path to JSON file")
+    precompute.add_argument("--llm-cfg", help="LLM-only overrides or path to JSON file")
     precompute.add_argument("--experiment-name", help="Name from experiments manifest")
     precompute.add_argument("--experiments-dir", type=Path, help="Override experiments manifest dir")
 
@@ -183,6 +186,7 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "precompute":
         overrides = _parse_json_arg(args.cfg)
+        llm_overrides = _parse_json_arg(args.llm_cfg)
         create_prompt_precompute_job(
             project_root=args.project_root,
             pheno_id=args.pheno_id,
@@ -191,6 +195,7 @@ def main(argv: list[str] | None = None) -> None:
             labeling_mode=args.labeling_mode,
             batch_size=args.batch_size,
             cfg_overrides=overrides,
+            llm_overrides=llm_overrides,
             experiment_name=args.experiment_name,
             experiments_dir=args.experiments_dir,
             job_id=args.job_id,


### PR DESCRIPTION
## Summary
- add LLM override handling to prompt precompute jobs and manifests
- expose precompute LLM overrides through CLI and AdminApp
- update documentation and tests for the enhanced configuration flow

## Testing
- python -m pytest tests/test_large_corpus_jobs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941bca206148327a197725e1bbc646a)