### PR TITLE
Backfill overrides from manifests for prompt jobs

### DIFF
--- a/tests/test_large_corpus_jobs.py
+++ b/tests/test_large_corpus_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import sys
@@ -115,4 +116,151 @@ def test_prompt_precompute_applies_env_overrides(monkeypatch, tmp_path: Path) ->
     assert os.getenv("AZURE_OPENAI_API_KEY") is None
     assert os.getenv("AZURE_OPENAI_API_VERSION") is None
     assert os.getenv("AZURE_OPENAI_ENDPOINT") is None
+
+
+def test_prompt_precompute_resumes_with_manifest_overrides(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    job_dir = project_root / "admin_tools" / "prompt_jobs" / "job-2"
+    job_dir.mkdir(parents=True)
+
+    manifest_overrides = {"label_config": {"foo": "bar"}}
+    manifest_llm_overrides = {"backend": "hf"}
+    (job_dir / "job_manifest.json").write_text(
+        json.dumps({"cfg_overrides": manifest_overrides, "llm_overrides": manifest_llm_overrides})
+    )
+
+    notes_df = pd.DataFrame({"unit_id": ["u1"], "text": ["example"]})
+    ann_df = pd.DataFrame({"unit_id": ["u1"], "label": ["y"]})
+
+    applied_overrides: list[dict] = []
+
+    def fake_export_inputs_from_repo(_project_root, _pheno_id, _rounds):  # type: ignore[no-untyped-def]
+        return notes_df, ann_df
+
+    def fake_backend_from_env(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return object()
+
+    def fake_load_label_config_bundle(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return type(
+            "Bundle",
+            (),
+            {
+                "current_rules_map": staticmethod(lambda *_args, **_kwargs: {}),
+                "current_label_types": staticmethod(lambda *_args, **_kwargs: {}),
+                "current": {},
+            },
+        )()
+
+    def fake_run_batches(manifest, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return manifest
+
+    monkeypatch.setattr(jobs, "export_inputs_from_repo", fake_export_inputs_from_repo)
+    monkeypatch.setattr(jobs.BackendSession, "from_env", staticmethod(fake_backend_from_env))
+    monkeypatch.setattr(jobs, "_load_label_config_bundle", fake_load_label_config_bundle)
+    monkeypatch.setattr(jobs, "_run_prompt_precompute_batches", fake_run_batches)
+    monkeypatch.setattr(jobs, "_normalize_local_model_overrides", lambda overrides: overrides)
+    monkeypatch.setattr(jobs, "_apply_overrides", lambda _cfg, overrides: applied_overrides.append(overrides))
+
+    job = jobs.PromptPrecomputeJob(
+        job_id="job-2",
+        project_root=project_root,
+        pheno_id="p1",
+        labelset_id="ls",
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        llm_overrides=None,
+        notes_path=None,
+        annotations_path=None,
+        job_dir=job_dir,
+        batch_size=1,
+        env_overrides=None,
+    )
+
+    jobs.run_prompt_precompute_job(job)
+
+    assert manifest_overrides in applied_overrides
+    assert {"llm": manifest_llm_overrides} in applied_overrides
+
+    manifest = jobs.read_manifest(job_dir / "job_manifest.json")
+    assert manifest and manifest.get("cfg_overrides") == manifest_overrides
+    assert manifest.get("llm_overrides") == manifest_llm_overrides
+
+
+def test_prompt_inference_resumes_with_manifest_overrides(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    prompt_job_dir = project_root / "admin_tools" / "prompt_jobs" / "prompt-1"
+    prompt_job_dir.mkdir(parents=True)
+    prompt_manifest = {
+        "pheno_id": "p1",
+        "labelset_id": "ls",
+        "phenotype_level": "single_doc",
+        "labeling_mode": "single_prompt",
+        "batches": [],
+    }
+    (prompt_job_dir / "job_manifest.json").write_text(json.dumps(prompt_manifest))
+
+    job_dir = project_root / "admin_tools" / "prompt_inference" / "job-3"
+    job_dir.mkdir(parents=True)
+    inference_manifest = {
+        "cfg_overrides": {"label_config": {"baz": 2}},
+        "llm_overrides": {"backend": "bedrock"},
+        "batches": [],
+    }
+    (job_dir / "job_manifest.json").write_text(json.dumps(inference_manifest))
+
+    applied_overrides: list[dict] = []
+
+    class DummySession:
+        models = object()
+        store = object()
+
+    def fake_backend_from_env(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return DummySession()
+
+    def fake_build_shared_components(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return {"llm_labeler": object()}
+
+    def fake_load_label_config_bundle(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return type(
+            "Bundle",
+            (),
+            {
+                "current_rules_map": staticmethod(lambda *_args, **_kwargs: {}),
+                "current_label_types": staticmethod(lambda *_args, **_kwargs: {}),
+                "current_config": {},
+            },
+        )()
+
+    def fake_run_batches(manifest, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return manifest
+
+    monkeypatch.setattr(jobs.BackendSession, "from_env", staticmethod(fake_backend_from_env))
+    monkeypatch.setattr(jobs, "_build_shared_components", fake_build_shared_components)
+    monkeypatch.setattr(jobs, "_load_label_config_bundle", fake_load_label_config_bundle)
+    monkeypatch.setattr(jobs, "_run_prompt_inference_batches", fake_run_batches)
+    monkeypatch.setattr(jobs, "_normalize_local_model_overrides", lambda overrides: overrides)
+    monkeypatch.setattr(jobs, "_apply_overrides", lambda _cfg, overrides: applied_overrides.append(overrides))
+
+    job = jobs.PromptInferenceJob(
+        job_id="job-3",
+        prompt_job_id="prompt-1",
+        project_root=project_root,
+        prompt_job_dir=prompt_job_dir,
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        llm_overrides=None,
+        job_dir=job_dir,
+        batch_limit=None,
+    )
+
+    jobs.run_prompt_inference_job(job)
+
+    assert inference_manifest["cfg_overrides"] in applied_overrides
+    assert {"llm": inference_manifest["llm_overrides"]} in applied_overrides
+
+    manifest = jobs.read_manifest(job_dir / "job_manifest.json")
+    assert manifest and manifest.get("cfg_overrides") == inference_manifest["cfg_overrides"]
+    assert manifest.get("llm_overrides") == inference_manifest["llm_overrides"]
 


### PR DESCRIPTION
## Summary
- hydrate cfg/llm overrides from existing manifests when resuming prompt precompute or inference jobs
- persist hydrated overrides back to job manifests
- add tests covering resumed runs using manifest overrides

## Testing
- pytest tests/test_large_corpus_jobs.py -k overrides


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941c54b11a08327b8fd4be985643fcd)