### PR TITLE
Register reviewers during round creation

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, Set
 
-from .project import build_label_config, fetch_labelset
+from .project import build_label_config, fetch_labelset, register_reviewer
 from .schema import initialize_assignment_db, initialize_round_aggregate_db
 from .shared.metadata import (
     MetadataFilterCondition,
@@ -411,6 +411,22 @@ class RoundBuilder:
                 if csv_override:
                     config["preselected_units_csv"] = str(csv_override)
                 config["status"] = status
+                for reviewer in config["reviewers"]:
+                    reviewer_id = str(
+                        reviewer.get("id") or reviewer.get("reviewer_id") or ""
+                    ).strip()
+                    if not reviewer_id:
+                        continue
+                    name = str(reviewer.get("name") or reviewer_id).strip()
+                    email = reviewer.get("email")
+                    windows_account = reviewer.get("windows_account")
+                    register_reviewer(
+                        project_conn,
+                        reviewer_id,
+                        name,
+                        email=email,
+                        windows_account=windows_account,
+                    )
     
                 manifest_path = round_dir / "manifest.csv"
                 with manifest_path.open("w", encoding="utf-8", newline="") as fh:


### PR DESCRIPTION
### Motivation
- Ensure reviewers declared in `config["reviewers"]` are persisted to the project database during round creation so `ClientApp.list_reviewers` can find them without an extra admin CLI step.

### Description
- Import `register_reviewer` from `vaannotate.project` and call it for each entry in `config["reviewers"]` during the round creation flow in `vaannotate/rounds.py`.
- Persist each reviewer’s `id`, `name`, and optional `email`/`windows_account`, skipping entries missing a reviewer id.
- The registration is performed before assignment files and `assignments` rows are created so the project `reviewers` table is always populated for subsequent client access.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751c5dbe4083279047bb116b47475e)