### PR TITLE
Always populate round config metadata

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -7596,31 +7596,31 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                     "enabled": True,
                     "top_snippets": assisted_top_n,
                 }
-                if corpus_record:
-                    config_payload["corpus_name"] = corpus_record["name"]
-                    config_payload["corpus_path"] = corpus_record["relative_path"]
-                if sampling_metadata:
-                    config_payload["sampling"] = sampling_metadata
-                if filters.metadata_filters:
-                    metadata_payload: Dict[str, object] = {
-                        "conditions": [
-                            condition.to_payload() for condition in filters.metadata_filters
-                        ]
-                    }
-                    metadata_payload["logic"] = "any" if filters.match_any else "all"
-                    config_payload["filters"] = {"metadata": metadata_payload}
-                if strat_field_keys:
-                    config_payload["stratification"] = {
-                        "fields": strat_field_keys,
-                        "labels": [
-                            self._metadata_lookup[key].label
-                            for key in strat_field_keys
-                            if key in self._metadata_lookup
-                        ],
-                        "aliases": strat_aliases,
-                    }
-                if label_schema:
-                    config_payload["label_schema"] = label_schema
+            if corpus_record:
+                config_payload["corpus_name"] = corpus_record["name"]
+                config_payload["corpus_path"] = corpus_record["relative_path"]
+            if sampling_metadata:
+                config_payload["sampling"] = sampling_metadata
+            if filters.metadata_filters:
+                metadata_payload: Dict[str, object] = {
+                    "conditions": [
+                        condition.to_payload() for condition in filters.metadata_filters
+                    ]
+                }
+                metadata_payload["logic"] = "any" if filters.match_any else "all"
+                config_payload["filters"] = {"metadata": metadata_payload}
+            if strat_field_keys:
+                config_payload["stratification"] = {
+                    "fields": strat_field_keys,
+                    "labels": [
+                        self._metadata_lookup[key].label
+                        for key in strat_field_keys
+                        if key in self._metadata_lookup
+                    ],
+                    "aliases": strat_aliases,
+                }
+            if label_schema:
+                config_payload["label_schema"] = label_schema
             config = models.RoundConfig(
                 round_id=round_id,
                 config_json=json.dumps(config_payload, indent=2),


### PR DESCRIPTION
### Motivation
- Ensure round configuration JSON always includes corpus, sampling, filter, stratification, and label schema metadata so downstream tools and exports can rely on those fields even when assisted review is disabled. 
- Preserve `assisted_review` behavior as an optional feature while decoupling other config population from the assisted-review gating.

### Description
- Move population of `corpus_name`/`corpus_path`, `sampling`, `filters`, `stratification`, and `label_schema` out of the `if assisted_enabled:` block in `RoundBuilderDialog._create_round` so they are set unconditionally on the created `config_payload`.
- Keep the `assisted_review` block and its `enabled`/`top_snippets` settings conditional on `assisted_enabled` so assisted-review-specific settings remain optional.
- No other behavior for AI backend, final LLM, or reviewer/assignment persistence logic was changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697520e9b4e48327a0249500e13c5f8c)