### PR TITLE
Persist reviewer email and windows_account in round creation

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -7630,8 +7630,8 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 reviewer_record = models.Reviewer(
                     reviewer_id=reviewer["id"],
                     name=reviewer.get("name", reviewer["id"]),
-                    email=reviewer.get("email", ""),
-                    windows_account=None,
+                    email=reviewer.get("email") or "",
+                    windows_account=reviewer.get("windows_account") or None,
                 )
                 reviewer_record.save(conn)
             for reviewer in reviewers:


### PR DESCRIPTION
### Motivation
- Align persisted reviewer records with the round configuration so `ProjectBrowser.list_reviewers` can surface reviewer `email` and `windows_account` values.

### Description
- In `RoundBuilderDialog._create_round` (file `vaannotate/AdminApp/main.py`) pass reviewer contact fields through when constructing `models.Reviewer` by setting `email=reviewer.get("email") or ""` and `windows_account=reviewer.get("windows_account") or None`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697521517f808327a6215c99dc79ff6b)