### PR TITLE
Support external datasets and persist prompt payloads for large-corpus prompt precompute

### DIFF
--- a/tests/test_large_corpus_jobs.py
+++ b/tests/test_large_corpus_jobs.py
@@ -264,3 +264,158 @@ def test_prompt_inference_resumes_with_manifest_overrides(monkeypatch, tmp_path:
     assert manifest and manifest.get("cfg_overrides") == inference_manifest["cfg_overrides"]
     assert manifest.get("llm_overrides") == inference_manifest["llm_overrides"]
 
+
+def test_prompt_precompute_external_dataset_family_generates_all_labels(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True)
+    dataset_path = tmp_path / "notes.feather"
+    pd.DataFrame(
+        {
+            "person_id": ["p1"],
+            "note_id": ["d1"],
+            "note_text": ["Patient has diabetes documented in the chart."],
+        }
+    ).to_feather(dataset_path)
+
+    class DummyLabelBundle:
+        current = {
+            "root": {"type": "binary", "rule": "Root rule"},
+            "child": {"type": "binary", "rule": "Child rule", "gated_by": "root"},
+        }
+
+        @staticmethod
+        def current_rules_map(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"root": "Root rule", "child": "Child rule"}
+
+        @staticmethod
+        def current_label_types(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"root": "binary", "child": "binary"}
+
+    class DummyStore:
+        def build_chunk_index(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return None
+
+        def _compute_corpus_fingerprint(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return "fp-1"
+
+    class DummySession:
+        models = object()
+        store = DummyStore()
+
+    class DummyContextBuilder:
+        def build_context_for_label(self, unit_id, label_id, label_rules):  # type: ignore[no-untyped-def]
+            return [{"doc_id": unit_id, "chunk_id": label_id, "text": label_rules, "score": 1.0, "metadata": {}}]
+
+        def build_context_for_family(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return [{"doc_id": "d1", "chunk_id": "all", "text": "context", "score": 1.0, "metadata": {}}]
+
+    class DummyLLMLabeler:
+        def build_single_label_prompt_payload(self, **kwargs):  # type: ignore[no-untyped-def]
+            return {"prompt": {"system": kwargs["label_id"], "user": "ctx"}, "messages": [], "response_format": {}}
+
+        def build_multi_label_prompt_payload(self, **kwargs):  # type: ignore[no-untyped-def]
+            return {"prompt": {"system": ",".join(kwargs["label_ids"]), "user": "ctx"}, "messages": [], "response_format": {}}
+
+    def fake_backend_from_env(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return DummySession()
+
+    def fake_load_label_config_bundle(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return DummyLabelBundle()
+
+    def fake_build_shared_components(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        notes_df = pd.read_parquet(project_root / "admin_tools" / "prompt_jobs" / "job-ext" / "notes.parquet")
+        return {
+            "repo": type("R", (), {"notes": notes_df})(),
+            "store": DummyStore(),
+            "context_builder": DummyContextBuilder(),
+            "llm_labeler": DummyLLMLabeler(),
+        }
+
+    monkeypatch.setattr(jobs.BackendSession, "from_env", staticmethod(fake_backend_from_env))
+    monkeypatch.setattr(jobs, "_load_label_config_bundle", fake_load_label_config_bundle)
+    monkeypatch.setattr(jobs, "_build_shared_components", fake_build_shared_components)
+
+    job = jobs.PromptPrecomputeJob(
+        job_id="job-ext",
+        project_root=project_root,
+        pheno_id="p1",
+        labelset_id="ls",
+        phenotype_level="multi_doc",
+        labeling_mode="family",
+        cfg_overrides={},
+        dataset_path=dataset_path,
+        dataset_column_map={"patient_icn": "person_id", "doc_id": "note_id", "text": "note_text"},
+        batch_size=10,
+    )
+
+    jobs.run_prompt_precompute_job(job)
+
+    out_path = project_root / "admin_tools" / "prompt_jobs" / "job-ext" / "prompts_family" / "prompts_batch_00000.parquet"
+    df = pd.read_parquet(out_path)
+    assert set(df["label_id"]) == {"root", "child"}
+    assert "prompt_payload" in df.columns
+    assert (project_root / "admin_tools" / "prompt_jobs" / "job-ext" / "notes.parquet").exists()
+
+
+def test_prompt_precompute_single_prompt_stores_prompt_payload(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True)
+    notes_df = pd.DataFrame({"unit_id": ["u1"], "patient_icn": ["p1"], "doc_id": ["d1"], "text": ["example"]})
+    ann_df = pd.DataFrame({"unit_id": ["u1"], "label": ["y"]})
+
+    class DummyStore:
+        def build_chunk_index(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return None
+
+        def _compute_corpus_fingerprint(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return "fp-2"
+
+    class DummySession:
+        models = object()
+        store = DummyStore()
+
+    class DummyBundle:
+        current = {"a": {"type": "binary", "rule": "Rule A"}, "b": {"type": "binary", "rule": "Rule B"}}
+
+        @staticmethod
+        def current_rules_map(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"a": "Rule A", "b": "Rule B"}
+
+        @staticmethod
+        def current_label_types(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"a": "binary", "b": "binary"}
+
+    class DummyContextBuilder:
+        def build_context_for_family(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return [{"doc_id": "d1", "chunk_id": "all", "text": "family ctx", "score": 1.0, "metadata": {}}]
+
+    class DummyLLMLabeler:
+        def build_multi_label_prompt_payload(self, **kwargs):  # type: ignore[no-untyped-def]
+            return {"prompt": {"system": "sys", "user": "ctx"}, "messages": [], "response_format": {}, "label_ids": kwargs["label_ids"]}
+
+    monkeypatch.setattr(jobs, "export_inputs_from_repo", lambda *_args, **_kwargs: (notes_df, ann_df))
+    monkeypatch.setattr(jobs.BackendSession, "from_env", staticmethod(lambda *_args, **_kwargs: DummySession()))
+    monkeypatch.setattr(jobs, "_load_label_config_bundle", lambda *_args, **_kwargs: DummyBundle())
+    monkeypatch.setattr(
+        jobs,
+        "_build_shared_components",
+        lambda *_args, **_kwargs: {"repo": type("R", (), {"notes": notes_df})(), "store": DummyStore(), "context_builder": DummyContextBuilder(), "llm_labeler": DummyLLMLabeler()},
+    )
+
+    job = jobs.PromptPrecomputeJob(
+        job_id="job-single",
+        project_root=project_root,
+        pheno_id="p1",
+        labelset_id="ls",
+        phenotype_level="multi_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        batch_size=10,
+    )
+
+    jobs.run_prompt_precompute_job(job)
+
+    out_path = project_root / "admin_tools" / "prompt_jobs" / "job-single" / "prompts_single" / "prompts_batch_00000.parquet"
+    df = pd.read_parquet(out_path)
+    assert "prompt_payload" in df.columns
+    assert "a" in str(df.iloc[0]["prompt_payload"])

--- a/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
+++ b/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
@@ -68,6 +68,8 @@ def create_prompt_precompute_job(
     job_id: str | None = None,
     notes_path: str | Path | None = None,
     annotations_path: str | Path | None = None,
+    dataset_path: str | Path | None = None,
+    dataset_column_map: dict[str, str] | None = None,
     job_dir: str | Path | None = None,
     env_overrides: dict[str, str] | None = None,
 ) -> PromptPrecomputeJob:
@@ -89,6 +91,8 @@ def create_prompt_precompute_job(
         llm_overrides=llm_overrides,
         notes_path=Path(notes_path) if notes_path else None,
         annotations_path=Path(annotations_path) if annotations_path else None,
+        dataset_path=Path(dataset_path) if dataset_path else None,
+        dataset_column_map=dataset_column_map,
         job_dir=Path(job_dir) if job_dir else None,
         batch_size=batch_size,
         env_overrides={str(k): str(v) for k, v in (env_overrides or {}).items() if str(v)},
@@ -161,6 +165,8 @@ def main(argv: list[str] | None = None) -> None:
     precompute.add_argument("--job-dir", type=Path)
     precompute.add_argument("--notes-path", type=Path)
     precompute.add_argument("--annotations-path", type=Path)
+    precompute.add_argument("--dataset-path", type=Path, help="External corpus table for prompt generation.")
+    precompute.add_argument("--dataset-columns", help="JSON mapping from canonical columns to source columns.")
     precompute.add_argument("--cfg", help="JSON overrides or path to JSON file")
     precompute.add_argument("--llm-cfg", help="LLM-only overrides or path to JSON file")
     precompute.add_argument("--experiment-name", help="Name from experiments manifest")
@@ -201,6 +207,8 @@ def main(argv: list[str] | None = None) -> None:
             job_id=args.job_id,
             notes_path=args.notes_path,
             annotations_path=args.annotations_path,
+            dataset_path=args.dataset_path,
+            dataset_column_map=_parse_json_arg(args.dataset_columns),
             job_dir=args.job_dir,
         )
     elif args.command == "infer":

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -42,6 +42,8 @@ class PromptPrecomputeJob:
     llm_overrides: dict[str, Any] | None = None
     notes_path: Path | None = None
     annotations_path: Path | None = None
+    dataset_path: Path | None = None
+    dataset_column_map: dict[str, str] | None = None
     job_dir: Path | None = None
     batch_size: int = 128
     env_overrides: dict[str, str] | None = None
@@ -59,6 +61,75 @@ class PromptInferenceJob:
     llm_overrides: dict[str, Any] | None
     job_dir: Path | None = None
     batch_limit: int | None = None
+
+
+def _empty_annotations_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        columns=[
+            "round_id",
+            "unit_id",
+            "doc_id",
+            "label_id",
+            "reviewer_id",
+            "label_value",
+            "label_value_num",
+            "label_value_date",
+            "labelset_id",
+            "document_text",
+            "rationales_json",
+            "document_metadata_json",
+            "label_rules",
+            "reviewer_notes",
+        ]
+    )
+
+
+def _prepare_notes_from_external_dataset(
+    dataset_path: Path,
+    phenotype_level: str,
+    dataset_column_map: dict[str, str] | None,
+) -> pd.DataFrame:
+    df = read_table(str(dataset_path)).copy()
+    colmap = {str(k): str(v) for k, v in (dataset_column_map or {}).items() if str(k) and str(v)}
+    rename_map = {src: dest for dest, src in colmap.items() if src in df.columns}
+    if rename_map:
+        df = df.rename(columns=rename_map)
+
+    if "text" not in df.columns:
+        raise ValueError("External inference dataset must provide a 'text' column or map one via dataset_column_map.")
+
+    if "doc_id" not in df.columns:
+        if phenotype_level == "single_doc":
+            raise ValueError("single_doc prompt precompute requires a 'doc_id' column in the external dataset.")
+        df["doc_id"] = df["unit_id"].astype(str) if "unit_id" in df.columns else df.index.astype(str)
+
+    if "patient_icn" not in df.columns:
+        fallback = "unit_id" if "unit_id" in df.columns else "doc_id"
+        df["patient_icn"] = df[fallback].astype(str)
+
+    if "unit_id" not in df.columns:
+        df["unit_id"] = _infer_unit_id_column(df, phenotype_level)
+    else:
+        df["unit_id"] = df["unit_id"].astype(str)
+
+    df["doc_id"] = df["doc_id"].astype(str)
+    df["patient_icn"] = df["patient_icn"].astype(str)
+    df["text"] = df["text"].astype(str)
+    if "notetype" not in df.columns:
+        df["notetype"] = ""
+    return df
+
+
+def _ordered_label_ids(label_config: dict[str, Any], label_types: dict[str, str]) -> list[str]:
+    _parent_to_children, child_to_parents, roots = build_label_dependencies(label_config or {})
+    ordered = list(roots)
+    for lid in sorted(label_types.keys()):
+        if lid not in ordered:
+            ordered.append(lid)
+    for lid in sorted(child_to_parents.keys()):
+        if lid not in ordered:
+            ordered.append(lid)
+    return ordered
 
 
 def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
@@ -106,9 +177,21 @@ def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
             if not job.llm_overrides and isinstance(manifest_llm, dict):
                 job.llm_overrides = manifest_llm
 
-        if job.notes_path is not None and job.annotations_path is not None:
+        if job.notes_path is not None:
             notes_path = job.notes_path
-            ann_path = job.annotations_path
+            ann_path = job.annotations_path or (job_dir / "annotations.parquet")
+            if job.annotations_path is None:
+                _empty_annotations_frame().to_parquet(ann_path, index=False)
+        elif job.dataset_path is not None:
+            notes_df = _prepare_notes_from_external_dataset(
+                job.dataset_path,
+                job.phenotype_level,
+                job.dataset_column_map,
+            )
+            notes_path = job_dir / "notes.parquet"
+            ann_path = job_dir / "annotations.parquet"
+            notes_df.to_parquet(notes_path, index=False)
+            _empty_annotations_frame().to_parquet(ann_path, index=False)
         else:
             notes_df, ann_df = export_inputs_from_repo(job.project_root, job.pheno_id, [])
             notes_df = notes_df.copy()
@@ -157,13 +240,17 @@ def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
                 "cfg_overrides": job.cfg_overrides,
                 "llm_overrides": job.llm_overrides or {},
                 "batch_size": job.batch_size,
+                "dataset_path": str(job.dataset_path) if job.dataset_path else None,
+                "dataset_column_map": job.dataset_column_map or {},
                 "batches": [],
             }
         elif isinstance(manifest, dict):
             manifest["cfg_overrides"] = job.cfg_overrides
             manifest["llm_overrides"] = job.llm_overrides or {}
+            manifest["dataset_path"] = str(job.dataset_path) if job.dataset_path else manifest.get("dataset_path")
+            manifest["dataset_column_map"] = job.dataset_column_map or manifest.get("dataset_column_map") or {}
 
-        repo_notes = notes_df if job.notes_path is None else read_table(str(notes_path))
+        repo_notes = notes_df if (job.notes_path is None or job.dataset_path is not None) else read_table(str(notes_path))
         manifest = _initialize_and_update_batches_for_prompt_precompute(manifest, job, repo_notes)
         write_manifest_atomic(manifest_path, manifest)
 
@@ -253,6 +340,7 @@ def _run_prompt_precompute_batches(
     repo = components["repo"]
     store = components["store"]
     context_builder = components["context_builder"]
+    llm_labeler = components["llm_labeler"]
 
     store.build_chunk_index(repo.notes, cfg.rag, cfg.index)
 
@@ -268,7 +356,8 @@ def _run_prompt_precompute_batches(
 
     rules_map = rules_map or {}
     label_types = label_types or {}
-    label_ids = sorted(label_types.keys())
+    label_config = (label_config_bundle.current or {}).copy()
+    label_ids = _ordered_label_ids(label_config, label_types)
 
     rag_fingerprint = store._compute_corpus_fingerprint(repo.notes, cfg.rag)
 
@@ -311,10 +400,17 @@ def _run_prompt_precompute_batches(
                         rules_map=rules_subset,
                         label_types=label_type_subset,
                         rag_fingerprint=rag_fingerprint,
+                        prompt_payload=llm_labeler.build_multi_label_prompt_payload(
+                            label_ids=label_ids,
+                            label_types=label_type_subset,
+                            rules_map=rules_subset,
+                            ctx_snippets=ctx_snippets,
+                        ),
                         meta={
                             "pheno_id": job.pheno_id,
                             "labelset_id": job.labelset_id,
                             "phenotype_level": job.phenotype_level,
+                            "label_order": label_ids,
                         },
                     )
                 )
@@ -328,12 +424,7 @@ def _run_prompt_precompute_batches(
 
         elif job.labeling_mode == "family":
             log.info("Building family-prompt batch %s with %d units", batch_id, len(unit_ids))
-            label_config = label_config_bundle.current or {}
-            _parent_to_children, _child_to_parents, roots = build_label_dependencies(label_config)
-            ordered_labels = list(roots)
-            for lid in sorted(label_types.keys()):
-                if lid not in ordered_labels:
-                    ordered_labels.append(lid)
+            ordered_labels = label_ids
 
             for unit_id in unit_ids:
                 for label_id in ordered_labels:
@@ -353,10 +444,22 @@ def _run_prompt_precompute_batches(
                             label_rules=rules_map.get(label_id, ""),
                             ctx_snippets=ctx_snippets,
                             rag_fingerprint=rag_fingerprint,
+                            prompt_payload=llm_labeler.build_single_label_prompt_payload(
+                                label_id=label_id,
+                                label_type=label_types.get(label_id, ""),
+                                label_rules=rules_map.get(label_id, ""),
+                                snippets=ctx_snippets,
+                            ),
                             meta={
                                 "pheno_id": job.pheno_id,
                                 "labelset_id": job.labelset_id,
                                 "phenotype_level": job.phenotype_level,
+                                "label_order": ordered_labels,
+                                "gated_by": list((label_config.get(label_id, {}) or {}).get("gated_by", []))
+                                if isinstance((label_config.get(label_id, {}) or {}).get("gated_by", []), list)
+                                else ([str((label_config.get(label_id, {}) or {}).get("gated_by"))]
+                                      if (label_config.get(label_id, {}) or {}).get("gated_by")
+                                      else []),
                             },
                         )
                     )

--- a/vaannotate/vaannotate_ai_backend/pipelines/prompt_tasks.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/prompt_tasks.py
@@ -18,6 +18,7 @@ class SinglePromptTask:
     rules_map: dict[str, str]  # label_id -> rule text
     label_types: dict[str, str]  # label_id -> type ("binary", "categorical", "date", etc.)
     rag_fingerprint: str
+    prompt_payload: dict
     meta: dict  # pheno_id, labelset_id, phenotype_level, etc.
 
 
@@ -31,6 +32,7 @@ class FamilyPromptTask:
     label_rules: str
     ctx_snippets: list[dict]  # RAG snippets for this (unit,label) only
     rag_fingerprint: str
+    prompt_payload: dict
     meta: dict
 
 
@@ -41,7 +43,7 @@ def single_prompt_tasks_to_df(tasks: list[SinglePromptTask]) -> pd.DataFrame:
     if df.empty:
         return df
 
-    return _jsonify_cols(df, ["ctx_snippets", "rules_map", "label_types", "meta"])
+    return _jsonify_cols(df, ["ctx_snippets", "rules_map", "label_types", "prompt_payload", "meta"])
 
 
 def family_prompt_tasks_to_df(tasks: list[FamilyPromptTask]) -> pd.DataFrame:
@@ -51,7 +53,7 @@ def family_prompt_tasks_to_df(tasks: list[FamilyPromptTask]) -> pd.DataFrame:
     if df.empty:
         return df
 
-    return _jsonify_cols(df, ["ctx_snippets", "meta"])
+    return _jsonify_cols(df, ["ctx_snippets", "prompt_payload", "meta"])
 
 
 def _parse_jsonish(value, default):
@@ -83,6 +85,7 @@ def df_to_single_prompt_tasks(df: pd.DataFrame) -> List[SinglePromptTask]:
                 rules_map=_parse_jsonish(row.get("rules_map"), {}),
                 label_types=_parse_jsonish(row.get("label_types"), {}),
                 rag_fingerprint=row.get("rag_fingerprint"),
+                prompt_payload=_parse_jsonish(row.get("prompt_payload"), {}),
                 meta=_parse_jsonish(row.get("meta"), {}),
             )
         )
@@ -108,6 +111,7 @@ def df_to_family_prompt_tasks(df: pd.DataFrame) -> List[FamilyPromptTask]:
                 label_rules=str(row.get("label_rules")),
                 ctx_snippets=_parse_jsonish(row.get("ctx_snippets"), []),
                 rag_fingerprint=row.get("rag_fingerprint"),
+                prompt_payload=_parse_jsonish(row.get("prompt_payload"), {}),
                 meta=_parse_jsonish(row.get("meta"), {}),
             )
         )

--- a/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
+++ b/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
@@ -148,6 +148,138 @@ class LLMLabeler:
             used += len(frag)
         return "\n\n".join(ctx)
 
+    def build_single_label_prompt_payload(
+        self,
+        *,
+        label_id: str,
+        label_type: str,
+        label_rules: str,
+        snippets: List[dict],
+        temperature: float | None = None,
+        system_suffix: str = "",
+    ) -> dict[str, Any]:
+        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
+        ordered_snippets = self._ordered_snippets(snippets)
+        ctx_text = self._build_context_text(ordered_snippets)
+        opts = _options_for_label(label_id, label_type, self.label_config)
+        lt_norm = (label_type or "").strip().lower()
+        categorical_types = self.CATEGORICAL_TYPES
+        use_options = bool(opts) and lt_norm in categorical_types
+        option_values = [str(opt) for opt in (opts or [])]
+        is_multi_select = lt_norm == "categorical_multi"
+        unknown_option_configured = any(_canon_str(o).lower() == "unknown" for o in option_values)
+
+        guideline_text = label_rules if label_rules else "(no additional guidelines)"
+        response_keys = "reasoning, prediction" if include_reasoning else "prediction"
+        system_segments: list[str] = [
+            "You are a meticulous clinical annotator for EHR data.",
+            f"Your task: label '{label_id}' (type: {label_type}). Use the evidence snippets from this patient's notes.",
+            f"Label rules:\n{guideline_text}",
+        ]
+        if use_options:
+            if is_multi_select:
+                system_segments.append("Select every option that is supported by the evidence from the list below.")
+                system_segments.append("Options:")
+                system_segments.extend(f"- {opt}" for opt in option_values)
+                deny_unknown = " Do NOT answer 'unknown' unless it appears in the options above." if not unknown_option_configured else ""
+                system_segments.append(
+                    "Return a compact JSON object where each included option key is set to 'Yes' if it applies (omit or set to 'No' when it does not)." + deny_unknown
+                )
+            else:
+                system_segments.append("Choose the single best option from the list below based on the evidence.")
+                system_segments.append("Options:")
+                system_segments.extend(f"- {opt}" for opt in option_values)
+                system_segments.append(
+                    f"Set prediction to exactly one of: {', '.join(option_values)}. Do not invent new options."
+                )
+        else:
+            system_segments.append("If insufficient evidence, reply with 'unknown'.")
+        if include_reasoning:
+            system_segments.append("Think step-by-step citing specific evidence, and keep the reasoning concise.")
+        system_segments.append(f"Return strict JSON only with keys: {response_keys}.")
+        system_segments.append("No additional keys or text.")
+
+        system = "\n\n".join(system_segments)
+        if system_suffix:
+            system = system + "\n" + str(system_suffix)
+        few_shot_msgs = self._few_shot_messages(label_id)
+        schema = {
+            "type": "object",
+            "properties": {"prediction": self._prediction_schema(label_type, option_values, categorical_types)},
+            "required": ["prediction"],
+            "additionalProperties": include_reasoning,
+        }
+        if include_reasoning:
+            schema["properties"]["reasoning"] = {"type": "string"}
+        return {
+            "messages": [{"role": "system", "content": system}, *few_shot_msgs, {"role": "user", "content": ctx_text}],
+            "prompt": {"system": system, "messages": few_shot_msgs, "user": ctx_text},
+            "response_format": {"type": "json_object", "json_schema": schema},
+            "params": {"temperature": self.cfg.temperature if temperature is None else temperature},
+        }
+
+    def build_multi_label_prompt_payload(
+        self,
+        *,
+        label_ids: list[str],
+        label_types: Mapping[str, str],
+        rules_map: Mapping[str, str],
+        ctx_snippets: list[dict],
+    ) -> dict[str, Any]:
+        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
+        ordered_snippets = self._ordered_snippets(ctx_snippets)
+        ctx_text = self._build_context_text(ordered_snippets)
+
+        label_summaries: list[str] = []
+        schema = {"type": "object", "properties": {}, "additionalProperties": False, "required": []}
+        for lid in label_ids:
+            ltype = label_types.get(lid, "categorical") if isinstance(label_types, Mapping) else "categorical"
+            rules = rules_map.get(lid, "") if isinstance(rules_map, Mapping) else ""
+            opts = _options_for_label(lid, ltype, self.label_config)
+            option_values = [str(o) for o in (opts or [])]
+            is_multi = (ltype or "").strip().lower() == "categorical_multi"
+            label_lines = [f"Label '{lid}' (type: {ltype})"]
+            if option_values:
+                label_lines.append("Options:")
+                label_lines.extend(f"- {opt}" for opt in option_values)
+            if rules:
+                label_lines.append(f"Guidelines:\n{rules}")
+            label_lines.append("If no evidence, respond with 'no' or 'unknown'.")
+            if is_multi:
+                label_lines.append("Select all supported options; omit unsupported ones.")
+                label_lines.append(
+                    "Set prediction to a JSON object with each selected option key set to 'Yes' (omit or set to 'No' when unsupported)."
+                )
+            label_summaries.append("\n".join(label_lines))
+            label_schema = {
+                "type": "object",
+                "properties": {"prediction": self._prediction_schema(ltype, option_values, self.CATEGORICAL_TYPES)},
+                "required": ["prediction"],
+                "additionalProperties": include_reasoning,
+            }
+            if include_reasoning:
+                label_schema["properties"]["reasoning"] = {"type": "string"}
+            schema["properties"][lid] = label_schema
+            schema["required"].append(lid)
+
+        system_prompt = "\n\n".join(
+            [
+                "You are a meticulous clinical annotator for EHR data.",
+                "Given the patient context, extract all requested labels in one pass.",
+                "Use 'no' or 'unknown' when evidence is missing or insufficient.",
+                "Each label must return JSON with keys: prediction (required) and reasoning (optional).",
+                "Label details:",
+                "\n\n".join(label_summaries),
+            ]
+        )
+        few_shot_msgs = self._few_shot_messages_for_labels(label_ids)
+        return {
+            "messages": [{"role": "system", "content": system_prompt}, *few_shot_msgs, {"role": "user", "content": ctx_text}],
+            "prompt": {"system": system_prompt, "messages": few_shot_msgs, "user": ctx_text},
+            "response_format": {"type": "json_object", "json_schema": schema},
+            "params": {"temperature": self.cfg.temperature},
+        }
+
     @staticmethod
     def _norm_token(x) -> str:
         if x is None:
@@ -416,10 +548,7 @@ class LLMLabeler:
         snippets = self._ordered_snippets(snippets)
 
         rng = random.Random()
-        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
-
         preds, runs = [], []
-        system_intro = "You are a meticulous clinical annotator for EHR data."
 
         for i in range(n_consistency):
             sc_meta = ""
@@ -437,69 +566,28 @@ class LLMLabeler:
                 t_lo, t_hi = temp_range
                 t = rng.uniform(float(t_lo), float(t_hi))
                 sc_meta = f"<!-- sc:vote={i};k={k};drop={drop_p:.2f};shuf={int(shuffle_context)};temp={t:.2f} -->"
-                ctx_text = self._build_context_text(cand)
                 temperature_this_vote = t
             else:
                 sc_meta = ""
-                ctx_text = self._build_context_text(snippets)
+                cand = list(snippets)
                 temperature_this_vote = self.cfg.temperature
 
+            prompt_payload = self.build_single_label_prompt_payload(
+                label_id=label_id,
+                label_type=label_type,
+                label_rules=label_rules,
+                snippets=cand,
+                temperature=temperature_this_vote,
+                system_suffix=sc_meta,
+            )
+            messages = prompt_payload["messages"]
+            schema = prompt_payload["response_format"]["json_schema"]
             opts = _options_for_label(label_id, label_type, self.label_config)
             lt_norm = (label_type or "").strip().lower()
             categorical_types = self.CATEGORICAL_TYPES
             use_options = bool(opts) and lt_norm in categorical_types
             option_values = [str(opt) for opt in (opts or [])]
             is_multi_select = lt_norm == "categorical_multi"
-            unknown_option_configured = any(_canon_str(o).lower() == "unknown" for o in option_values)
-
-            guideline_text = label_rules if label_rules else "(no additional guidelines)"
-            response_keys = "reasoning, prediction" if include_reasoning else "prediction"
-
-            system_segments: list[str] = [
-                system_intro,
-                f"Your task: label '{label_id}' (type: {label_type}). Use the evidence snippets from this patient's notes.",
-                f"Label rules:\n{guideline_text}",
-            ]
-            if use_options:
-                if is_multi_select:
-                    system_segments.append("Select every option that is supported by the evidence from the list below.")
-                    system_segments.append("Options:")
-                    system_segments.extend(f"- {opt}" for opt in option_values)
-                    deny_unknown = " Do NOT answer 'unknown' unless it appears in the options above." if not unknown_option_configured else ""
-                    system_segments.append(
-                        "Return a compact JSON object where each included option key is set to 'Yes' if it applies (omit or set to 'No' when it does not)." + deny_unknown
-                    )
-                else:
-                    system_segments.append("Choose the single best option from the list below based on the evidence.")
-                    system_segments.append("Options:")
-                    system_segments.extend(f"- {opt}" for opt in option_values)
-                    system_segments.append(
-                        f"Set prediction to exactly one of: {', '.join(option_values)}. Do not invent new options."
-                    )
-            else:
-                system_segments.append("If insufficient evidence, reply with 'unknown'.")
-
-            if include_reasoning:
-                system_segments.append(
-                    "Think step-by-step citing specific evidence, and keep the reasoning concise."
-                )
-            system_segments.append(f"Return strict JSON only with keys: {response_keys}.")
-            system_segments.append("No additional keys or text.")
-
-            system_body = "\n\n".join(system_segments)
-            system = system_body + ("\n" + sc_meta if sc_meta else "")
-
-            few_shot_msgs = self._few_shot_messages(label_id)
-            messages = ([{"role": "system", "content": system}] + few_shot_msgs + [{"role": "user", "content": ctx_text}])
-            prediction_schema = self._prediction_schema(label_type, option_values, categorical_types)
-            schema = {
-                "type": "object",
-                "properties": {"prediction": prediction_schema},
-                "required": ["prediction"],
-                "additionalProperties": include_reasoning,
-            }
-            if include_reasoning:
-                schema["properties"]["reasoning"] = {"type": "string"}
             try:
                 result = self.backend.json_call(
                     messages,
@@ -518,7 +606,7 @@ class LLMLabeler:
                         "unit_id": unit_id,
                         "label_id": label_id,
                         "label_type": label_type,
-                        "prompt": {"system": system, "messages": few_shot_msgs, "user": ctx_text},
+                        "prompt": prompt_payload["prompt"],
                         "params": {"temperature": temperature_this_vote},
                         "output": content,
                         "rag_diagnostics": rag_diagnostics or {},
@@ -537,7 +625,7 @@ class LLMLabeler:
                 obj = content if isinstance(content, Mapping) else None
 
             pred_raw = (obj or {}).get("prediction")
-            reasoning = (obj or {}).get("reasoning") if include_reasoning else None
+            reasoning = (obj or {}).get("reasoning") if bool(getattr(self.cfg, "include_reasoning", True)) else None
             pred_norm = None
             if use_options:
                 if is_multi_select:
@@ -626,65 +714,14 @@ class LLMLabeler:
             }
         """
 
-        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
-        ordered_snippets = self._ordered_snippets(ctx_snippets)
-        ctx_text = self._build_context_text(ordered_snippets)
-        categorical_types = self.CATEGORICAL_TYPES
-
-        label_summaries: list[str] = []
-        schema = {"type": "object", "properties": {}, "additionalProperties": False, "required": []}
-        for lid in label_ids:
-            ltype = label_types.get(lid, "categorical") if isinstance(label_types, Mapping) else "categorical"
-            rules = rules_map.get(lid, "") if isinstance(rules_map, Mapping) else ""
-            opts = _options_for_label(lid, ltype, self.label_config)
-            option_values = [str(o) for o in (opts or [])]
-            is_multi = (ltype or "").strip().lower() == "categorical_multi"
-
-            label_lines = [f"Label '{lid}' (type: {ltype})"]
-            if option_values:
-                label_lines.append("Options:")
-                label_lines.extend(f"- {opt}" for opt in option_values)
-            if rules:
-                label_lines.append(f"Guidelines:\n{rules}")
-            label_lines.append("If no evidence, respond with 'no' or 'unknown'.")
-            if is_multi:
-                label_lines.append(
-                    "Select all supported options; omit unsupported ones."
-                )
-                label_lines.append(
-                    "Set prediction to a JSON object with each selected option key set to 'Yes' (omit or set to 'No' when unsupported)."
-                )
-            label_summaries.append("\n".join(label_lines))
-
-            label_schema = {
-                "type": "object",
-                "properties": {
-                    "prediction": self._prediction_schema(ltype, option_values, self.CATEGORICAL_TYPES)
-                },
-                "required": ["prediction"],
-                "additionalProperties": include_reasoning,
-            }
-            if include_reasoning:
-                label_schema["properties"]["reasoning"] = {"type": "string"}
-            schema["properties"][lid] = label_schema
-            schema["required"].append(lid)
-
-        system_segments = [
-            "You are a meticulous clinical annotator for EHR data.",
-            "Given the patient context, extract all requested labels in one pass.",
-            "Use 'no' or 'unknown' when evidence is missing or insufficient.",
-            "Each label must return JSON with keys: prediction (required) and reasoning (optional).",
-            "Label details:",
-            "\n\n".join(label_summaries),
-        ]
-        system_prompt = "\n\n".join(system_segments)
-
-        few_shot_msgs = self._few_shot_messages_for_labels(label_ids)
-        messages = [
-            {"role": "system", "content": system_prompt},
-            *few_shot_msgs,
-            {"role": "user", "content": ctx_text},
-        ]
+        prompt_payload = self.build_multi_label_prompt_payload(
+            label_ids=label_ids,
+            label_types=label_types,
+            rules_map=rules_map,
+            ctx_snippets=ctx_snippets,
+        )
+        messages = prompt_payload["messages"]
+        schema = prompt_payload["response_format"]["json_schema"]
 
         try:
             result = self.backend.json_call(
@@ -703,7 +740,7 @@ class LLMLabeler:
                 {
                     "unit_id": unit_id,
                     "label_ids": label_ids,
-                    "prompt": {"system": system_prompt, "messages": few_shot_msgs, "user": ctx_text},
+                    "prompt": prompt_payload["prompt"],
                     "output": content,
                 },
             )

--- a/vaannotate/vaannotate_ai_backend/utils/io.py
+++ b/vaannotate/vaannotate_ai_backend/utils/io.py
@@ -14,6 +14,8 @@ def read_table(path: str) -> pd.DataFrame:
         return pd.read_csv(path)
     if ext == "tsv":
         return pd.read_csv(path, sep="\t")
+    if ext == "feather":
+        return pd.read_feather(path)
     if ext in ("parquet", "pq"):
         return pd.read_parquet(path)
     if ext == "jsonl":
@@ -32,6 +34,8 @@ def write_table(df: pd.DataFrame, path: str):
     ext = path.lower().split(".")[-1]
     if ext == "csv":
         df.to_csv(path, index=False)
+    elif ext == "feather":
+        df.to_feather(path)
     elif ext in ("parquet", "pq"):
         df.to_parquet(path, index=False)
     elif ext == "jsonl":


### PR DESCRIPTION
### Motivation
- Enable prompt precompute to run directly from very large external corpora (parquet/feather/csv/etc.) without importing into a project so inference can scale to huge datasets.
- Make prompt generation inspectable and restart-safe by materializing normalized notes/annotations and recording rendered prompt payloads alongside task rows. 
- Ensure prompt generation respects family vs single-prompt labeling semantics (including gated children) and preserves a stable label ordering for reproducible runs.

### Description
- Added `dataset_path` and `dataset_column_map` to `PromptPrecomputeJob` and CLI flags (`--dataset-path`, `--dataset-columns`), plus `read_table`/`write_table` support for Feather files so external tables can be ingested. 
- Implemented `_prepare_notes_from_external_dataset` to normalize external tables (map columns, infer `unit_id`/`patient_icn`/`doc_id`, materialize `notes.parquet` and an empty `annotations.parquet`) and record the dataset source in the job manifest. 
- Persisted fully rendered prompt payloads on task generation by adding `prompt_payload` to `SinglePromptTask` and `FamilyPromptTask` (and JSONification/parsing helpers), and wrote those payloads into batch parquet files for both `single_prompt` and `family` modes. 
- Refactored `LLMLabeler` to expose `build_single_label_prompt_payload` and `build_multi_label_prompt_payload` and reused those helpers in the runtime inference paths so precomputed payloads match actual runtime prompts. 
- Added `_ordered_label_ids` to compute family-aware label ordering (using `build_label_dependencies`) and used it to ensure all family members (including gated children) are generated in the correct order and metadata. 
- Updated large-corpus precompute batching logic to handle the new dataset path, to materialize notes/annotations into the job directory, and to include `label_order`/gating metadata in prompt `meta` for diagnostics. 
- Test coverage: added tests to cover external feather-backed datasets with column remapping, family prompt generation for gated labels, and persisted prompt payloads in single-prompt mode; adjusted existing resume/manifest tests to include LLM overrides handling.

### Testing
- Ran `pytest -q tests/test_large_corpus_jobs.py`, which passed (all tests in that file succeeded).
- Ran `python -m compileall vaannotate/vaannotate_ai_backend` to verify byte-compilation, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc71ccc68883278f13db270e1c9d52)