### PR TITLE
Large-corpus precompute: support multiple input sources, corpus DB selection, and precompute progress reporting

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -1172,6 +1172,7 @@ class _LargeCorpusJobWorker(QtCore.QObject):
                 os.environ[key] = value
 
             if self.precompute_job is not None:
+                self.precompute_job.status_callback = self.log_message.emit
                 self.log_message.emit(
                     f"Starting prompt precompute job {self.precompute_job.job_id}…"
                 )
@@ -1199,6 +1200,10 @@ class _LargeCorpusJobWorker(QtCore.QObject):
 
 
 class LargeCorpusJobDialog(QtWidgets.QDialog):
+    _PRECOMPUTE_SOURCE_PROJECT_CORPUS = "project_corpus"
+    _PRECOMPUTE_SOURCE_EXTERNAL_DATASET = "external_dataset"
+    _PRECOMPUTE_SOURCE_EXPORTED_TABLES = "exported_tables"
+
     def __init__(
         self,
         parent: Optional[QtWidgets.QWidget],
@@ -1213,6 +1218,7 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         self._default_inference_id = self._build_default_job_id("inference")
         self._running_workers: list[tuple[QtCore.QThread, _LargeCorpusJobWorker, AIRoundLogDialog]] = []
         self._rounds = self._load_rounds()
+        self._precompute_corpus_path: str | None = None
         self._setup_ui()
 
     def _build_default_job_id(self, suffix: str) -> str:
@@ -1261,6 +1267,19 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         self.precompute_batch_spin.setValue(128)
         form.addRow("Batch size", self.precompute_batch_spin)
 
+        self.precompute_source_combo = QtWidgets.QComboBox()
+        self.precompute_source_combo.addItem("Project corpus", self._PRECOMPUTE_SOURCE_PROJECT_CORPUS)
+        self.precompute_source_combo.addItem("External dataset file", self._PRECOMPUTE_SOURCE_EXTERNAL_DATASET)
+        self.precompute_source_combo.addItem("Pre-exported notes/annotations", self._PRECOMPUTE_SOURCE_EXPORTED_TABLES)
+        self.precompute_source_combo.currentIndexChanged.connect(self._on_precompute_source_changed)
+        form.addRow("Input source", self.precompute_source_combo)
+
+        self.precompute_source_stack = QtWidgets.QStackedWidget()
+        self.precompute_source_stack.addWidget(self._build_precompute_project_corpus_source())
+        self.precompute_source_stack.addWidget(self._build_precompute_external_dataset_source())
+        self.precompute_source_stack.addWidget(self._build_precompute_exported_tables_source())
+        form.addRow("Source details", self.precompute_source_stack)
+
         prompt_dir_placeholder = str(self._default_prompt_dir(self._default_precompute_id))
         precompute_dir_row, self.precompute_dir_edit = self._path_selector(prompt_dir_placeholder)
         form.addRow("Prompt job directory", precompute_dir_row)
@@ -1286,6 +1305,65 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         note_label.setWordWrap(True)
         form.addRow(note_label)
 
+        return widget
+
+    def _build_precompute_project_corpus_source(self) -> QtWidgets.QWidget:
+        widget = QtWidgets.QWidget()
+        form = QtWidgets.QFormLayout(widget)
+
+        corpus_row = QtWidgets.QHBoxLayout()
+        self.precompute_corpus_combo = QtWidgets.QComboBox()
+        self._populate_precompute_corpus_combo()
+        corpus_row.addWidget(self.precompute_corpus_combo)
+        browse_button = QtWidgets.QPushButton("Browse DB…")
+        browse_button.clicked.connect(self._browse_precompute_corpus_path)
+        corpus_row.addWidget(browse_button)
+        form.addRow("Corpus", corpus_row)
+
+        self.precompute_corpus_path_label = QtWidgets.QLabel("Using selected project corpus")
+        self.precompute_corpus_path_label.setWordWrap(True)
+        form.addRow("External DB override", self.precompute_corpus_path_label)
+        return widget
+
+    def _build_precompute_external_dataset_source(self) -> QtWidgets.QWidget:
+        widget = QtWidgets.QWidget()
+        form = QtWidgets.QFormLayout(widget)
+        dataset_row, self.precompute_dataset_path_edit = self._file_selector(
+            "Select external dataset file",
+            "Dataset files (*.parquet *.pq *.csv *.tsv *.json *.jsonl *.db *.sqlite *.sqlite3);;All files (*)",
+        )
+        form.addRow("Dataset path", dataset_row)
+        self.precompute_dataset_columns_edit = QtWidgets.QPlainTextEdit()
+        self.precompute_dataset_columns_edit.setPlaceholderText(
+            'Optional JSON column map, e.g. {"text": "note_text", "doc_id": "document_id"}'
+        )
+        form.addRow("Column mapping", self.precompute_dataset_columns_edit)
+        help_label = QtWidgets.QLabel(
+            "The dataset must provide a text column, either directly or via the column mapping. "
+            "For single_doc jobs, doc_id is also required."
+        )
+        help_label.setWordWrap(True)
+        form.addRow(help_label)
+        return widget
+
+    def _build_precompute_exported_tables_source(self) -> QtWidgets.QWidget:
+        widget = QtWidgets.QWidget()
+        form = QtWidgets.QFormLayout(widget)
+        notes_row, self.precompute_notes_path_edit = self._file_selector(
+            "Select notes table",
+            "Table files (*.parquet *.pq *.csv *.tsv);;All files (*)",
+        )
+        form.addRow("Notes path", notes_row)
+        ann_row, self.precompute_annotations_path_edit = self._file_selector(
+            "Select annotations table",
+            "Table files (*.parquet *.pq *.csv *.tsv);;All files (*)",
+        )
+        form.addRow("Annotations path", ann_row)
+        help_label = QtWidgets.QLabel(
+            "Use this when you already have exported notes and optional prior annotations prepared outside the project corpus."
+        )
+        help_label.setWordWrap(True)
+        form.addRow(help_label)
         return widget
 
     def _build_inference_tab(self) -> QtWidgets.QWidget:
@@ -1365,6 +1443,27 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         layout.addWidget(browse_button)
         return container, line_edit
 
+    def _file_selector(
+        self,
+        title: str,
+        file_filter: str,
+        *,
+        placeholder: str = "",
+    ) -> tuple[QtWidgets.QWidget, QtWidgets.QLineEdit]:
+        container = QtWidgets.QWidget()
+        layout = QtWidgets.QHBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        line_edit = QtWidgets.QLineEdit()
+        if placeholder:
+            line_edit.setPlaceholderText(placeholder)
+        browse_button = QtWidgets.QPushButton("Browse…")
+        browse_button.clicked.connect(
+            lambda: self._browse_for_file(line_edit, title, file_filter)
+        )
+        layout.addWidget(line_edit)
+        layout.addWidget(browse_button)
+        return container, line_edit
+
     def _browse_for_dir(self, line_edit: QtWidgets.QLineEdit) -> None:
         start_dir = line_edit.text().strip() or str(self.project_root)
         directory = QtWidgets.QFileDialog.getExistingDirectory(
@@ -1374,6 +1473,58 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         )
         if directory:
             line_edit.setText(directory)
+
+    def _browse_for_file(
+        self,
+        line_edit: QtWidgets.QLineEdit,
+        title: str,
+        file_filter: str,
+    ) -> None:
+        start_dir = line_edit.text().strip() or str(self.project_root)
+        path_str, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            title,
+            start_dir,
+            file_filter,
+        )
+        if path_str:
+            line_edit.setText(path_str)
+
+    def _populate_precompute_corpus_combo(self) -> None:
+        self.precompute_corpus_combo.clear()
+        corpora = self.ctx.list_corpora()
+        if not corpora:
+            self.precompute_corpus_combo.addItem("Select corpus…", None)
+            self.precompute_corpus_combo.setEnabled(False)
+            return
+        self.precompute_corpus_combo.setEnabled(True)
+        for corpus in corpora:
+            corpus_id = str(corpus.get("corpus_id") or "")
+            name = str(corpus.get("name") or corpus_id)
+            self.precompute_corpus_combo.addItem(f"{name} ({corpus_id})", corpus_id)
+        self.precompute_corpus_combo.setCurrentIndex(0)
+
+    def _browse_precompute_corpus_path(self) -> None:
+        start_dir = str(self.project_root)
+        path_str, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select corpus database",
+            start_dir,
+            "SQLite databases (*.db *.sqlite *.sqlite3);;All files (*)",
+        )
+        if path_str:
+            self._precompute_corpus_path = path_str
+            if hasattr(self, "precompute_corpus_path_label"):
+                self.precompute_corpus_path_label.setText(path_str)
+
+    def _on_precompute_source_changed(self) -> None:
+        source = self.precompute_source_combo.currentData()
+        if source == self._PRECOMPUTE_SOURCE_EXTERNAL_DATASET:
+            self.precompute_source_stack.setCurrentIndex(1)
+        elif source == self._PRECOMPUTE_SOURCE_EXPORTED_TABLES:
+            self.precompute_source_stack.setCurrentIndex(2)
+        else:
+            self.precompute_source_stack.setCurrentIndex(0)
 
     def _default_prompt_dir(self, job_id: str) -> Path:
         return self.project_root / "admin_tools" / "prompt_jobs" / job_id
@@ -1430,6 +1581,10 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         manifest_labelset: str | None = None
         manifest_mode: str | None = None
         manifest_batch: int | None = None
+        manifest_corpus_id: str | None = None
+        manifest_corpus_path: str | None = None
+        manifest_dataset_path: str | None = None
+        manifest_dataset_columns: dict[str, str] = {}
         manifest = read_manifest(job_dir / "job_manifest.json")
         if isinstance(manifest, Mapping):
             manifest_overrides = (
@@ -1451,6 +1606,28 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
                 manifest_batch = int(manifest_batch_raw) if manifest_batch_raw is not None else None
             except Exception:  # noqa: BLE001
                 manifest_batch = None
+            manifest_corpus_raw = manifest.get("corpus_id")
+            manifest_corpus_id = str(manifest_corpus_raw) if manifest_corpus_raw is not None else None
+            manifest_corpus_path_raw = manifest.get("corpus_path")
+            manifest_corpus_path = (
+                str(manifest_corpus_path_raw)
+                if manifest_corpus_path_raw is not None
+                else None
+            )
+            manifest_dataset_path_raw = manifest.get("dataset_path")
+            manifest_dataset_path = (
+                str(manifest_dataset_path_raw)
+                if manifest_dataset_path_raw is not None
+                else None
+            )
+            manifest_dataset_columns = (
+                {
+                    str(key): str(value)
+                    for key, value in manifest.get("dataset_column_map", {}).items()
+                }
+                if isinstance(manifest.get("dataset_column_map"), Mapping)
+                else {}
+            )
 
         if not cfg_overrides and manifest_overrides:
             cfg_overrides = manifest_overrides
@@ -1477,6 +1654,71 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         level = str(self.pheno_row.get("level") or "single_doc")
         labeling_mode = manifest_mode or str(self.precompute_mode_combo.currentText())
         batch_size = manifest_batch or int(self.precompute_batch_spin.value()) or 1
+        source_type = self.precompute_source_combo.currentData()
+        corpus_id: str | None = None
+        corpus_path: Path | None = None
+        notes_path: Path | None = None
+        annotations_path: Path | None = None
+        dataset_path: Path | None = None
+        dataset_column_map: dict[str, str] | None = None
+
+        if manifest_dataset_path and not self.precompute_dataset_path_edit.text().strip():
+            self.precompute_dataset_path_edit.setText(manifest_dataset_path)
+        if manifest_dataset_columns and not self.precompute_dataset_columns_edit.toPlainText().strip():
+            self.precompute_dataset_columns_edit.setPlainText(
+                json.dumps(manifest_dataset_columns, indent=2)
+            )
+        if manifest_corpus_path and not self._precompute_corpus_path:
+            self._precompute_corpus_path = manifest_corpus_path
+            self.precompute_corpus_path_label.setText(manifest_corpus_path)
+        if manifest_corpus_id:
+            idx = self.precompute_corpus_combo.findData(manifest_corpus_id)
+            if idx >= 0:
+                self.precompute_corpus_combo.setCurrentIndex(idx)
+
+        if source_type == self._PRECOMPUTE_SOURCE_EXTERNAL_DATASET:
+            dataset_path_text = self.precompute_dataset_path_edit.text().strip() or manifest_dataset_path or ""
+            if not dataset_path_text:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Large corpus inference",
+                    "Please choose an external dataset file for prompt precompute.",
+                )
+                return None
+            dataset_columns = self._parse_json_overrides(
+                self.precompute_dataset_columns_edit,
+                "dataset column mapping",
+            )
+            if dataset_columns is None:
+                return None
+            dataset_path = Path(dataset_path_text)
+            dataset_column_map = {str(key): str(value) for key, value in (dataset_columns or {}).items()}
+        elif source_type == self._PRECOMPUTE_SOURCE_EXPORTED_TABLES:
+            notes_path_text = self.precompute_notes_path_edit.text().strip()
+            annotations_path_text = self.precompute_annotations_path_edit.text().strip()
+            if not notes_path_text:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Large corpus inference",
+                    "Please choose a notes table for prompt precompute.",
+                )
+                return None
+            notes_path = Path(notes_path_text)
+            annotations_path = Path(annotations_path_text) if annotations_path_text else None
+        else:
+            corpus_id_data = self.precompute_corpus_combo.currentData()
+            corpus_id = str(corpus_id_data) if corpus_id_data else None
+            if manifest_corpus_id and not corpus_id:
+                corpus_id = manifest_corpus_id
+            corpus_path_text = self._precompute_corpus_path or manifest_corpus_path or ""
+            corpus_path = Path(corpus_path_text) if corpus_path_text else None
+            if not corpus_id and corpus_path is None:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Large corpus inference",
+                    "Please select a project corpus or browse to a corpus database.",
+                )
+                return None
 
         return PromptPrecomputeJob(
             job_id=job_id,
@@ -1487,8 +1729,12 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
             labeling_mode=labeling_mode,
             cfg_overrides=cfg_overrides,
             llm_overrides=llm_overrides,
-            notes_path=None,
-            annotations_path=None,
+            corpus_id=corpus_id,
+            corpus_path=corpus_path,
+            notes_path=notes_path,
+            annotations_path=annotations_path,
+            dataset_path=dataset_path,
+            dataset_column_map=dataset_column_map,
             job_dir=job_dir,
             batch_size=batch_size,
         )
@@ -1808,6 +2054,51 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
                 if level and isinstance(level, str):
                     self.pheno_row = dict(self.pheno_row)
                     self.pheno_row["level"] = level
+                dataset_path = prompt_manifest.get("dataset_path")
+                notes_path = prompt_manifest.get("notes_path")
+                annotations_path = prompt_manifest.get("annotations_path")
+                corpus_id = prompt_manifest.get("corpus_id")
+                corpus_path = prompt_manifest.get("corpus_path")
+                dataset_columns = (
+                    prompt_manifest.get("dataset_column_map")
+                    if isinstance(prompt_manifest.get("dataset_column_map"), Mapping)
+                    else {}
+                )
+                if dataset_path:
+                    idx = self.precompute_source_combo.findData(
+                        self._PRECOMPUTE_SOURCE_EXTERNAL_DATASET
+                    )
+                    if idx >= 0:
+                        self.precompute_source_combo.setCurrentIndex(idx)
+                    if not self.precompute_dataset_path_edit.text().strip():
+                        self.precompute_dataset_path_edit.setText(str(dataset_path))
+                    if dataset_columns and not self.precompute_dataset_columns_edit.toPlainText().strip():
+                        self.precompute_dataset_columns_edit.setPlainText(
+                            json.dumps(dataset_columns, indent=2)
+                        )
+                elif notes_path:
+                    idx = self.precompute_source_combo.findData(
+                        self._PRECOMPUTE_SOURCE_EXPORTED_TABLES
+                    )
+                    if idx >= 0:
+                        self.precompute_source_combo.setCurrentIndex(idx)
+                    if not self.precompute_notes_path_edit.text().strip():
+                        self.precompute_notes_path_edit.setText(str(notes_path))
+                    if annotations_path and not self.precompute_annotations_path_edit.text().strip():
+                        self.precompute_annotations_path_edit.setText(str(annotations_path))
+                else:
+                    idx = self.precompute_source_combo.findData(
+                        self._PRECOMPUTE_SOURCE_PROJECT_CORPUS
+                    )
+                    if idx >= 0:
+                        self.precompute_source_combo.setCurrentIndex(idx)
+                    if corpus_id:
+                        corpus_idx = self.precompute_corpus_combo.findData(str(corpus_id))
+                        if corpus_idx >= 0:
+                            self.precompute_corpus_combo.setCurrentIndex(corpus_idx)
+                    if corpus_path and not self._precompute_corpus_path:
+                        self._precompute_corpus_path = str(corpus_path)
+                        self.precompute_corpus_path_label.setText(str(corpus_path))
 
         job_id = self.inference_job_id_edit.text().strip() or self._default_inference_id
         inference_dir_text = self.inference_job_dir_edit.text().strip()

--- a/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
+++ b/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
@@ -66,6 +66,8 @@ def create_prompt_precompute_job(
     experiment_name: str | None = None,
     experiments_dir: str | Path | None = None,
     job_id: str | None = None,
+    corpus_id: str | None = None,
+    corpus_path: str | Path | None = None,
     notes_path: str | Path | None = None,
     annotations_path: str | Path | None = None,
     dataset_path: str | Path | None = None,
@@ -89,6 +91,8 @@ def create_prompt_precompute_job(
         labeling_mode=labeling_mode,
         cfg_overrides=overrides,
         llm_overrides=llm_overrides,
+        corpus_id=corpus_id,
+        corpus_path=Path(corpus_path) if corpus_path else None,
         notes_path=Path(notes_path) if notes_path else None,
         annotations_path=Path(annotations_path) if annotations_path else None,
         dataset_path=Path(dataset_path) if dataset_path else None,
@@ -163,6 +167,8 @@ def main(argv: list[str] | None = None) -> None:
     precompute.add_argument("--batch-size", type=int, default=128)
     precompute.add_argument("--job-id")
     precompute.add_argument("--job-dir", type=Path)
+    precompute.add_argument("--corpus-id")
+    precompute.add_argument("--corpus-path", type=Path)
     precompute.add_argument("--notes-path", type=Path)
     precompute.add_argument("--annotations-path", type=Path)
     precompute.add_argument("--dataset-path", type=Path, help="External corpus table for prompt generation.")
@@ -205,6 +211,8 @@ def main(argv: list[str] | None = None) -> None:
             experiment_name=args.experiment_name,
             experiments_dir=args.experiments_dir,
             job_id=args.job_id,
+            corpus_id=args.corpus_id,
+            corpus_path=args.corpus_path,
             notes_path=args.notes_path,
             annotations_path=args.annotations_path,
             dataset_path=args.dataset_path,

--- a/vaannotate/vaannotate_ai_backend/orchestration.py
+++ b/vaannotate/vaannotate_ai_backend/orchestration.py
@@ -36,6 +36,7 @@ def _build_shared_components(
     phenotype_level: str | None = None,
     *,
     include_pooler: bool = False,
+    include_llm: bool = True,
     models: Models | None = None,
     store: EmbeddingStore | None = None,
 ):
@@ -101,15 +102,17 @@ def _build_shared_components(
     except Exception:
         pass
 
-    backend = build_llm_backend(cfg.llm)
-    llm_labeler = LLMLabeler(
-        backend,
-        label_config_bundle,
-        cfg.llm,
-        sc_cfg=cfg.scjitter,
-        cache_dir=paths.cache_dir,
-    )
-    llm_labeler.label_config = label_config_bundle.current or {}
+    llm_labeler = None
+    if include_llm:
+        backend = build_llm_backend(cfg.llm)
+        llm_labeler = LLMLabeler(
+            backend,
+            label_config_bundle,
+            cfg.llm,
+            sc_cfg=cfg.scjitter,
+            cache_dir=paths.cache_dir,
+        )
+        llm_labeler.label_config = label_config_bundle.current or {}
 
     pooler = None
     if include_pooler:

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import pandas as pd
 
@@ -40,6 +41,8 @@ class PromptPrecomputeJob:
     labeling_mode: str  # "family" | "single_prompt"
     cfg_overrides: dict[str, Any]
     llm_overrides: dict[str, Any] | None = None
+    corpus_id: str | None = None
+    corpus_path: Path | None = None
     notes_path: Path | None = None
     annotations_path: Path | None = None
     dataset_path: Path | None = None
@@ -47,6 +50,7 @@ class PromptPrecomputeJob:
     job_dir: Path | None = None
     batch_size: int = 128
     env_overrides: dict[str, str] | None = None
+    status_callback: Callable[[str], None] | None = None
 
 
 @dataclass
@@ -132,6 +136,29 @@ def _ordered_label_ids(label_config: dict[str, Any], label_types: dict[str, str]
     return ordered
 
 
+def _emit_precompute_status(job: PromptPrecomputeJob, message: str) -> None:
+    logger = logging.getLogger(__name__)
+    logger.info(message)
+    if job.status_callback is not None:
+        try:
+            job.status_callback(message)
+        except Exception:
+            logger.debug("Prompt precompute status callback failed", exc_info=True)
+
+
+def _format_eta(seconds: float | None) -> str:
+    if seconds is None or seconds < 0:
+        return "ETA unknown"
+    rounded = int(round(seconds))
+    minutes, secs = divmod(rounded, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"ETA {hours}h {minutes}m {secs}s"
+    if minutes:
+        return f"ETA {minutes}m {secs}s"
+    return f"ETA {secs}s"
+
+
 def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
     """
     Build RAG contexts and prompt tasks for a large unlabeled corpus.
@@ -146,8 +173,7 @@ def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
     - Updates the manifest using write_manifest_atomic.
     """
 
-    log = logging.getLogger(__name__)
-    log.info("Starting prompt precompute job %s", job.job_id)
+    _emit_precompute_status(job, f"Starting prompt precompute job {job.job_id}")
 
     applied_env: dict[str, str] = {
         str(key): str(value)
@@ -193,7 +219,13 @@ def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
             notes_df.to_parquet(notes_path, index=False)
             _empty_annotations_frame().to_parquet(ann_path, index=False)
         else:
-            notes_df, ann_df = export_inputs_from_repo(job.project_root, job.pheno_id, [])
+            notes_df, ann_df = export_inputs_from_repo(
+                job.project_root,
+                job.pheno_id,
+                [],
+                corpus_id=job.corpus_id,
+                corpus_path=str(job.corpus_path) if job.corpus_path else None,
+            )
             notes_df = notes_df.copy()
             notes_df["unit_id"] = _infer_unit_id_column(notes_df, job.phenotype_level)
 
@@ -239,6 +271,10 @@ def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
                 "labeling_mode": job.labeling_mode,
                 "cfg_overrides": job.cfg_overrides,
                 "llm_overrides": job.llm_overrides or {},
+                "corpus_id": job.corpus_id,
+                "corpus_path": str(job.corpus_path) if job.corpus_path else None,
+                "notes_path": str(job.notes_path) if job.notes_path else None,
+                "annotations_path": str(job.annotations_path) if job.annotations_path else None,
                 "batch_size": job.batch_size,
                 "dataset_path": str(job.dataset_path) if job.dataset_path else None,
                 "dataset_column_map": job.dataset_column_map or {},
@@ -247,12 +283,39 @@ def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
         elif isinstance(manifest, dict):
             manifest["cfg_overrides"] = job.cfg_overrides
             manifest["llm_overrides"] = job.llm_overrides or {}
+            manifest["corpus_id"] = job.corpus_id if job.corpus_id else manifest.get("corpus_id")
+            manifest["corpus_path"] = (
+                str(job.corpus_path)
+                if job.corpus_path
+                else manifest.get("corpus_path")
+            )
+            manifest["notes_path"] = (
+                str(job.notes_path)
+                if job.notes_path
+                else manifest.get("notes_path")
+            )
+            manifest["annotations_path"] = (
+                str(job.annotations_path)
+                if job.annotations_path
+                else manifest.get("annotations_path")
+            )
             manifest["dataset_path"] = str(job.dataset_path) if job.dataset_path else manifest.get("dataset_path")
             manifest["dataset_column_map"] = job.dataset_column_map or manifest.get("dataset_column_map") or {}
 
         repo_notes = notes_df if (job.notes_path is None or job.dataset_path is not None) else read_table(str(notes_path))
         manifest = _initialize_and_update_batches_for_prompt_precompute(manifest, job, repo_notes)
         write_manifest_atomic(manifest_path, manifest)
+
+        completed_batches = sum(
+            1 for batch in manifest.get("batches", []) if batch.get("status") == "completed"
+        )
+        total_batches = len(manifest.get("batches", []))
+        total_units = sum(len(batch.get("unit_ids", []) or []) for batch in manifest.get("batches", []))
+        _emit_precompute_status(
+            job,
+            f"Prepared prompt precompute for {total_units} units across {total_batches} batches "
+            f"({completed_batches} already completed). Building retrieval index…",
+        )
 
         manifest = _run_prompt_precompute_batches(
             manifest,
@@ -317,8 +380,6 @@ def _run_prompt_precompute_batches(
     label_config_bundle: LabelConfigBundle,
     manifest_path: Path,
 ) -> dict:
-    log = logging.getLogger(__name__)
-
     job_dir = job.job_dir or job.project_root / "admin_tools" / "prompt_jobs" / job.job_id
 
     paths = Paths(
@@ -333,6 +394,7 @@ def _run_prompt_precompute_batches(
         cfg,
         label_config_bundle,
         phenotype_level=job.phenotype_level,
+        include_llm=False,
         models=session.models,
         store=session.store,
     )
@@ -340,7 +402,13 @@ def _run_prompt_precompute_batches(
     repo = components["repo"]
     store = components["store"]
     context_builder = components["context_builder"]
-    llm_labeler = components["llm_labeler"]
+    llm_labeler = LLMLabeler(
+        object(),
+        label_config_bundle,
+        cfg.llm,
+        sc_cfg=cfg.scjitter,
+        cache_dir=str(job_dir / "cache"),
+    )
 
     store.build_chunk_index(repo.notes, cfg.rag, cfg.index)
 
@@ -360,6 +428,19 @@ def _run_prompt_precompute_batches(
     label_ids = _ordered_label_ids(label_config, label_types)
 
     rag_fingerprint = store._compute_corpus_fingerprint(repo.notes, cfg.rag)
+    prompts_per_unit = max(1, len(label_ids)) if job.labeling_mode == "family" else 1
+    total_batches = len(manifest.get("batches", []))
+    total_prompts = sum(
+        len(batch.get("unit_ids", []) or []) * prompts_per_unit
+        for batch in manifest.get("batches", [])
+    )
+    completed_prompts = sum(
+        int(batch.get("n_tasks") or 0)
+        for batch in manifest.get("batches", [])
+        if batch.get("status") == "completed"
+    )
+    started_at = time.monotonic()
+    processed_this_run = 0
 
     for batch in manifest.get("batches", []):
         batch_id = batch.get("batch_id")
@@ -374,9 +455,18 @@ def _run_prompt_precompute_batches(
 
         unit_ids = [str(u) for u in batch.get("unit_ids", [])]
         tasks: list[SinglePromptTask | FamilyPromptTask] = []
+        remaining_before = max(total_prompts - completed_prompts, 0)
+        elapsed = max(time.monotonic() - started_at, 0.0)
+        rate = (processed_this_run / elapsed) if elapsed > 0 and processed_this_run > 0 else None
+        eta_before = (remaining_before / rate) if rate and rate > 0 else None
+        _emit_precompute_status(
+            job,
+            f"Precompute batch {int(batch_id) + 1}/{total_batches}: "
+            f"{completed_prompts:,} prompts done, {remaining_before:,} prompts to go, "
+            f"{_format_eta(eta_before)}.",
+        )
 
         if job.labeling_mode == "single_prompt":
-            log.info("Building single-prompt batch %s with %d units", batch_id, len(unit_ids))
             for unit_id in unit_ids:
                 ctx_snippets = context_builder.build_context_for_family(
                     unit_id,
@@ -423,7 +513,6 @@ def _run_prompt_precompute_batches(
             batch["path"] = str(out_path.relative_to(job_dir))
 
         elif job.labeling_mode == "family":
-            log.info("Building family-prompt batch %s with %d units", batch_id, len(unit_ids))
             ordered_labels = label_ids
 
             for unit_id in unit_ids:
@@ -472,13 +561,32 @@ def _run_prompt_precompute_batches(
             batch["path"] = str(out_path.relative_to(job_dir))
 
         else:
-            log.warning("Unknown labeling mode %s; skipping batch %s", job.labeling_mode, batch_id)
+            logging.getLogger(__name__).warning(
+                "Unknown labeling mode %s; skipping batch %s", job.labeling_mode, batch_id
+            )
             continue
 
         batch["status"] = "completed"
         batch["n_tasks"] = len(tasks)
+        completed_prompts += len(tasks)
+        processed_this_run += len(tasks)
 
         write_manifest_atomic(manifest_path, manifest)
+        remaining_after = max(total_prompts - completed_prompts, 0)
+        elapsed = max(time.monotonic() - started_at, 0.0)
+        rate = (processed_this_run / elapsed) if elapsed > 0 and processed_this_run > 0 else None
+        eta_after = (remaining_after / rate) if rate and rate > 0 else None
+        _emit_precompute_status(
+            job,
+            f"Completed batch {int(batch_id) + 1}/{total_batches}: "
+            f"{completed_prompts:,}/{total_prompts:,} prompts done, "
+            f"{remaining_after:,} prompts to go, {_format_eta(eta_after)}.",
+        )
+
+    _emit_precompute_status(
+        job,
+        f"Prompt precompute finished: {completed_prompts:,}/{total_prompts:,} prompts completed.",
+    )
 
     return manifest
 


### PR DESCRIPTION
### Motivation
- Allow prompt precompute to consume different input sources (project corpus, external dataset file, or exported notes/annotations) and to override the project corpus DB path for precompute runs.
- Surface precompute progress and ETA back to the UI so users can see ongoing job status.
- Expose corpus selection options via the CLI and UI and persist chosen inputs in the job manifest.

### Description
- UI: added an `Input source` combo to `LargeCorpusJobDialog` with a `QStackedWidget` for three source types, file/dir pickers (`_file_selector`, `_browse_for_file`, `_browse_precompute_corpus_path`), and population of project corpora via `self.ctx.list_corpora()`; stores `_precompute_corpus_path` and loads manifest defaults into the new controls.
- Backend job model and CLI: extended `PromptPrecomputeJob` with `corpus_id`, `corpus_path`, and `status_callback`, and added `--corpus-id` / `--corpus-path` CLI arguments in `large_corpus_cli.py` and plumbing in `create_prompt_precompute_job` to populate the job fields.
- Precompute pipeline: pass `corpus_id`/`corpus_path` into `export_inputs_from_repo`, persist `corpus_id`/`corpus_path`/dataset/notes/annotations into the manifest, and load them back when resuming; added `_emit_precompute_status` and `_format_eta` helpers to log and call the job `status_callback` for UI updates; emit periodic precompute progress/ETA before and after each batch and on completion.
- Resource handling: `orchestration._build_shared_components` gained an `include_llm` parameter (default kept True) and `run_prompt_precompute_batches` calls `_build_shared_components(..., include_llm=False)` to avoid initializing a full LLM backend during batch building; a lightweight `LLMLabeler` instance is constructed locally for payload generation in precompute.
- Worker/UI integration: `_LargeCorpusJobWorker.run` sets `precompute_job.status_callback = self.log_message.emit` so backend progress messages are forwarded to the dialog log.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc784e67bc83279302deec34b813fb)