### PR TITLE
Skip unnecessary retrieval indexing during prompt precompute

### DIFF
--- a/tests/test_large_corpus_jobs.py
+++ b/tests/test_large_corpus_jobs.py
@@ -41,7 +41,7 @@ def test_prompt_precompute_applies_env_overrides(monkeypatch, tmp_path: Path) ->
         models = object()
         store = object()
 
-    def fake_export_inputs_from_repo(_project_root, _pheno_id, _rounds):  # type: ignore[no-untyped-def]
+    def fake_export_inputs_from_repo(_project_root, _pheno_id, _rounds, **_kwargs):  # type: ignore[no-untyped-def]
         return notes_df, ann_df
 
     def fake_backend_from_env(*_args, **_kwargs):  # type: ignore[no-untyped-def]
@@ -134,7 +134,7 @@ def test_prompt_precompute_resumes_with_manifest_overrides(monkeypatch, tmp_path
 
     applied_overrides: list[dict] = []
 
-    def fake_export_inputs_from_repo(_project_root, _pheno_id, _rounds):  # type: ignore[no-untyped-def]
+    def fake_export_inputs_from_repo(_project_root, _pheno_id, _rounds, **_kwargs):  # type: ignore[no-untyped-def]
         return notes_df, ann_df
 
     def fake_backend_from_env(*_args, **_kwargs):  # type: ignore[no-untyped-def]
@@ -419,3 +419,69 @@ def test_prompt_precompute_single_prompt_stores_prompt_payload(monkeypatch, tmp_
     df = pd.read_parquet(out_path)
     assert "prompt_payload" in df.columns
     assert "a" in str(df.iloc[0]["prompt_payload"])
+
+
+def test_prompt_precompute_single_doc_full_context_skips_retrieval_index(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True)
+    notes_df = pd.DataFrame({"unit_id": ["u1"], "patient_icn": ["p1"], "doc_id": ["d1"], "text": ["example"]})
+    ann_df = pd.DataFrame({"unit_id": ["u1"], "label": ["y"]})
+
+    build_calls: list[str] = []
+    family_kwargs: list[dict[str, object]] = []
+    statuses: list[str] = []
+
+    class DummyStore:
+        def build_chunk_index(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            build_calls.append("called")
+
+        def _compute_corpus_fingerprint(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return "fp-full"
+
+    class DummySession:
+        models = object()
+        store = DummyStore()
+
+    class DummyBundle:
+        current = {"a": {"type": "binary", "rule": "Rule A"}}
+
+        @staticmethod
+        def current_rules_map(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"a": "Rule A"}
+
+        @staticmethod
+        def current_label_types(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"a": "binary"}
+
+    class DummyContextBuilder:
+        def build_context_for_family(self, *_args, **kwargs):  # type: ignore[no-untyped-def]
+            family_kwargs.append(kwargs)
+            return [{"doc_id": "d1", "chunk_id": "__full__", "text": "full ctx", "score": 1.0, "metadata": {}}]
+
+    monkeypatch.setattr(jobs, "export_inputs_from_repo", lambda *_args, **_kwargs: (notes_df, ann_df))
+    monkeypatch.setattr(jobs.BackendSession, "from_env", staticmethod(lambda *_args, **_kwargs: DummySession()))
+    monkeypatch.setattr(jobs, "_load_label_config_bundle", lambda *_args, **_kwargs: DummyBundle())
+    monkeypatch.setattr(
+        jobs,
+        "_build_shared_components",
+        lambda *_args, **_kwargs: {"repo": type("R", (), {"notes": notes_df})(), "store": DummyStore(), "context_builder": DummyContextBuilder()},
+    )
+
+    job = jobs.PromptPrecomputeJob(
+        job_id="job-full",
+        project_root=project_root,
+        pheno_id="p1",
+        labelset_id="ls",
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={"llmfirst": {"single_doc_context": "full", "single_doc_full_context_max_chars": 321}},
+        batch_size=10,
+        status_callback=statuses.append,
+    )
+
+    jobs.run_prompt_precompute_job(job)
+
+    assert not build_calls
+    assert family_kwargs and family_kwargs[0]["single_doc_context_mode"] == "full"
+    assert family_kwargs[0]["full_doc_char_limit"] == 321
+    assert any("skipping retrieval index build" in status.lower() for status in statuses)

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -159,6 +159,15 @@ def _format_eta(seconds: float | None) -> str:
     return f"ETA {secs}s"
 
 
+def _prompt_precompute_requires_retrieval_index(
+    cfg: OrchestratorConfig,
+    phenotype_level: str,
+) -> bool:
+    level = str(phenotype_level or "").strip().lower()
+    context_mode = str(getattr(cfg.llmfirst, "single_doc_context", "rag") or "rag").strip().lower()
+    return not (level == "single_doc" and context_mode == "full")
+
+
 def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
     """
     Build RAG contexts and prompt tasks for a large unlabeled corpus.
@@ -311,11 +320,19 @@ def run_prompt_precompute_job(job: PromptPrecomputeJob) -> None:
         )
         total_batches = len(manifest.get("batches", []))
         total_units = sum(len(batch.get("unit_ids", []) or []) for batch in manifest.get("batches", []))
-        _emit_precompute_status(
-            job,
-            f"Prepared prompt precompute for {total_units} units across {total_batches} batches "
-            f"({completed_batches} already completed). Building retrieval index…",
+        needs_retrieval_index = _prompt_precompute_requires_retrieval_index(
+            cfg,
+            job.phenotype_level,
         )
+        prep_message = (
+            f"Prepared prompt precompute for {total_units} units across {total_batches} batches "
+            f"({completed_batches} already completed). "
+        )
+        if needs_retrieval_index:
+            prep_message += "Building retrieval index…"
+        else:
+            prep_message += "Using full-document single-doc context; skipping retrieval index build."
+        _emit_precompute_status(job, prep_message)
 
         manifest = _run_prompt_precompute_batches(
             manifest,
@@ -410,7 +427,12 @@ def _run_prompt_precompute_batches(
         cache_dir=str(job_dir / "cache"),
     )
 
-    store.build_chunk_index(repo.notes, cfg.rag, cfg.index)
+    needs_retrieval_index = _prompt_precompute_requires_retrieval_index(
+        cfg,
+        job.phenotype_level,
+    )
+    if needs_retrieval_index:
+        store.build_chunk_index(repo.notes, cfg.rag, cfg.index)
 
     try:
         rules_map = label_config_bundle.current_rules_map(components.get("label_config"))
@@ -475,6 +497,8 @@ def _run_prompt_precompute_batches(
                     topk_per_label=cfg.rag.top_k_final,
                     max_snippets=None,
                     max_chars=getattr(cfg.llmfirst, "single_prompt_max_chars", None),
+                    single_doc_context_mode=getattr(cfg.llmfirst, "single_doc_context", "rag"),
+                    full_doc_char_limit=getattr(cfg.llmfirst, "single_doc_full_context_max_chars", None),
                 )
 
                 rules_subset = {lid: rules_map.get(lid, "") for lid in label_ids}

--- a/vaannotate/vaannotate_ai_backend/services/context_builder.py
+++ b/vaannotate/vaannotate_ai_backend/services/context_builder.py
@@ -138,6 +138,8 @@ class ContextBuilder:
         topk_per_label: int | None = None,
         max_snippets: int | None = None,
         max_chars: int | None = None,
+        single_doc_context_mode: str = "rag",
+        full_doc_char_limit: int | None = None,
     ) -> list[dict]:
         """
         Build a single merged context for a unit across many labels.
@@ -162,7 +164,13 @@ class ContextBuilder:
                 topk = None
 
         for label_id in label_ids:
-            snippets = self.build_context_for_label(unit_id, label_id, rules_map.get(label_id, ""))
+            snippets = self.build_context_for_label(
+                unit_id,
+                label_id,
+                rules_map.get(label_id, ""),
+                single_doc_context_mode=single_doc_context_mode,
+                full_doc_char_limit=full_doc_char_limit,
+            )
             if topk is not None:
                 snippets = snippets[:topk]
             collected.extend(snippets)


### PR DESCRIPTION
### Motivation
- Avoid building a retrieval (RAG) index for simple prompt precompute jobs that use single-document full-context mode, since those jobs do not need chunk-level retrieval and the index build is unnecessary and misleading.

### Description
- Add `_prompt_precompute_requires_retrieval_index(cfg, phenotype_level)` to decide whether an index is required based on `phenotype_level` and `cfg.llmfirst.single_doc_context`.
- Use the new predicate to conditionally call `store.build_chunk_index(...)` in `run_prompt_precompute_job`/`_run_prompt_precompute_batches` and to emit a clearer status message when the index is skipped in `vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py`.
- Propagate single-document context settings (`single_doc_context` and `single_doc_full_context_max_chars`) into `ContextBuilder.build_context_for_family(...)` so `single_doc_context="full"` is respected during single-prompt precompute in `vaannotate/vaannotate_ai_backend/services/context_builder.py`.
- Update test doubles to match the current `export_inputs_from_repo(..., corpus_id=..., corpus_path=...)` signature and add a regression test `test_prompt_precompute_single_doc_full_context_skips_retrieval_index` in `tests/test_large_corpus_jobs.py` to assert no index build and that full-context parameters are forwarded.

### Testing
- Ran `pytest -q tests/test_large_corpus_jobs.py` which passed (6 passed, 0 failed) after the changes. 
- Changes committed with message `"Skip unnecessary prompt precompute indexes"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc8960cadc832788b4441e30d5327c)