### PR TITLE
Normalize few-shot examples, compact JSON examples, and make reasoning optional in prompts

### DIFF
--- a/tests/test_llm_reasoning.py
+++ b/tests/test_llm_reasoning.py
@@ -309,3 +309,106 @@ def test_multilabel_prompt_switches_to_multi_select(tmp_path):
 
     assert result["predictions"]["Multi"]["prediction"] == "Option A"
     assert result["predictions"]["Single"]["prediction"] == "Option B"
+
+
+def test_multilabel_prompt_omits_reasoning_when_disabled(tmp_path):
+    calls: dict[str, object] = {}
+
+    class DummyBackend:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def json_call(self, messages, **kwargs):  # noqa: D401
+            calls["messages"] = list(messages)
+            calls["response_format"] = kwargs.get("response_format")
+            payload = {"Flag": {"prediction": "yes", "reasoning": "ignored"}}
+            return JSONCallResult(
+                data=payload,
+                content=json.dumps(payload),
+                raw_response=None,
+                latency_s=0.01,
+                logprobs=None,
+            )
+
+    llm_cfg = ai_config.LLMConfig()
+    llm_cfg.include_reasoning = False
+    annotator = LLMLabeler(
+        DummyBackend(llm_cfg),
+        LabelConfigBundle(),
+        llm_cfg,
+        sc_cfg=ai_config.SCJitterConfig(),
+        cache_dir=str(tmp_path),
+    )
+
+    annotator.annotate_multi(
+        unit_id="unit-reasoning-off",
+        label_ids=["Flag"],
+        label_types={"Flag": "categorical"},
+        rules_map={"Flag": ""},
+        ctx_snippets=[{"doc_id": "doc-1", "chunk_id": 1, "text": "note", "metadata": {}}],
+    )
+
+    system_message = next(msg["content"] for msg in calls["messages"] if msg["role"] == "system")
+    assert "reasoning (optional)" not in system_message
+    assert "prediction (required)" in system_message
+    response_format = calls.get("response_format") or {}
+    schema = (response_format.get("json_schema") if isinstance(response_format, dict) else {}) or {}
+    label_schema = (schema.get("properties") or {}).get("Flag", {}) or {}
+    assert "reasoning" not in ((label_schema.get("properties") or {}))
+
+
+def test_single_label_few_shot_answer_is_normalized_to_json(tmp_path):
+    class DummyBackend:
+        def json_call(self, *_, **__):  # pragma: no cover - not invoked in this test
+            raise AssertionError("json_call should not be reached")
+
+    llm_cfg = ai_config.LLMConfig()
+    llm_cfg.few_shot_examples = {"Flag": [{"context": "c1", "answer": "yes"}]}
+    annotator = LLMLabeler(
+        llm_backend=DummyBackend(),
+        label_config_bundle=LabelConfigBundle(),
+        llm_config=llm_cfg,
+        sc_cfg=ai_config.SCJitterConfig(),
+        cache_dir=str(tmp_path),
+    )
+
+    payload = annotator.build_single_label_prompt_payload(
+        label_id="Flag",
+        label_type="categorical",
+        label_rules="",
+        snippets=[{"doc_id": "doc-1", "chunk_id": 1, "text": "note", "metadata": {}}],
+    )
+    messages = payload["messages"]
+    assistant_example = next(msg["content"] for msg in messages if msg["role"] == "assistant")
+    assert json.loads(assistant_example) == {"prediction": "yes"}
+
+
+def test_multi_label_few_shot_answer_is_wrapped_by_label(tmp_path):
+    class DummyBackend:
+        def json_call(self, *_, **__):  # pragma: no cover - not invoked in this test
+            raise AssertionError("json_call should not be reached")
+
+    llm_cfg = ai_config.LLMConfig()
+    llm_cfg.include_reasoning = False
+    llm_cfg.few_shot_examples = {
+        "Flag": [{"context": "c1", "answer": '{"prediction":"yes","reasoning":"because"}'}]
+    }
+    annotator = LLMLabeler(
+        llm_backend=DummyBackend(),
+        label_config_bundle=LabelConfigBundle(),
+        llm_config=llm_cfg,
+        sc_cfg=ai_config.SCJitterConfig(),
+        cache_dir=str(tmp_path),
+    )
+
+    payload = annotator.build_multi_label_prompt_payload(
+        label_ids=["Flag"],
+        label_types={"Flag": "categorical"},
+        rules_map={"Flag": ""},
+        ctx_snippets=[{"doc_id": "doc-1", "chunk_id": 1, "text": "note", "metadata": {}}],
+    )
+    assistant_example = next(
+        msg["content"] for msg in payload["messages"] if msg["role"] == "assistant"
+    )
+    parsed = json.loads(assistant_example)
+    assert parsed == {"Flag": {"prediction": "yes"}}

--- a/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
+++ b/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
@@ -148,6 +148,54 @@ class LLMLabeler:
             used += len(frag)
         return "\n\n".join(ctx)
 
+    @staticmethod
+    def _response_keys_text(include_reasoning: bool) -> str:
+        return "prediction (required) and reasoning (optional)" if include_reasoning else "prediction (required)"
+
+    @staticmethod
+    def _compact_json(payload: Any) -> str:
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+    def _parse_jsonish_answer(self, raw_answer: Any) -> Any:
+        if isinstance(raw_answer, str):
+            text = raw_answer.strip()
+            if text:
+                try:
+                    return json.loads(text)
+                except Exception:
+                    return raw_answer
+            return raw_answer
+        return raw_answer
+
+    def _normalize_few_shot_answer(self, raw_answer: Any, *, include_reasoning: bool) -> dict[str, Any]:
+        parsed = self._parse_jsonish_answer(raw_answer)
+        normalized: dict[str, Any] = {}
+        if isinstance(parsed, Mapping):
+            if "prediction" in parsed:
+                normalized["prediction"] = parsed.get("prediction")
+            else:
+                # Backward-compat: treat arbitrary object payload as a prediction
+                # object (common for legacy multi-select examples like
+                # {"Option A": "Yes", "Option B": "No"}).
+                normalized["prediction"] = dict(parsed)
+            if include_reasoning and parsed.get("reasoning") is not None:
+                normalized["reasoning"] = parsed.get("reasoning")
+        else:
+            normalized["prediction"] = parsed
+        if "prediction" not in normalized:
+            normalized["prediction"] = "unknown"
+        return normalized
+
+    def _raw_few_shot_examples(self, label_id: str) -> list[Mapping[str, Any]]:
+        examples_cfg = getattr(self.cfg, "few_shot_examples", {}) or {}
+        if not isinstance(examples_cfg, Mapping):
+            return []
+        label_key = str(label_id)
+        label_examples = examples_cfg.get(label_key) or examples_cfg.get(label_key.lower())
+        if not isinstance(label_examples, (list, tuple)):
+            return []
+        return [entry for entry in label_examples if isinstance(entry, Mapping)]
+
     def build_single_label_prompt_payload(
         self,
         *,
@@ -170,7 +218,7 @@ class LLMLabeler:
         unknown_option_configured = any(_canon_str(o).lower() == "unknown" for o in option_values)
 
         guideline_text = label_rules if label_rules else "(no additional guidelines)"
-        response_keys = "reasoning, prediction" if include_reasoning else "prediction"
+        response_keys = self._response_keys_text(include_reasoning)
         system_segments: list[str] = [
             "You are a meticulous clinical annotator for EHR data.",
             f"Your task: label '{label_id}' (type: {label_type}). Use the evidence snippets from this patient's notes.",
@@ -202,7 +250,7 @@ class LLMLabeler:
         system = "\n\n".join(system_segments)
         if system_suffix:
             system = system + "\n" + str(system_suffix)
-        few_shot_msgs = self._few_shot_messages(label_id)
+        few_shot_msgs = self._few_shot_messages(label_id, include_reasoning=include_reasoning)
         schema = {
             "type": "object",
             "properties": {"prediction": self._prediction_schema(label_type, option_values, categorical_types)},
@@ -262,17 +310,18 @@ class LLMLabeler:
             schema["properties"][lid] = label_schema
             schema["required"].append(lid)
 
+        response_keys = self._response_keys_text(include_reasoning)
         system_prompt = "\n\n".join(
             [
                 "You are a meticulous clinical annotator for EHR data.",
                 "Given the patient context, extract all requested labels in one pass.",
                 "Use 'no' or 'unknown' when evidence is missing or insufficient.",
-                "Each label must return JSON with keys: prediction (required) and reasoning (optional).",
+                f"Each label must return JSON with keys: {response_keys}.",
                 "Label details:",
                 "\n\n".join(label_summaries),
             ]
         )
-        few_shot_msgs = self._few_shot_messages_for_labels(label_ids)
+        few_shot_msgs = self._few_shot_messages_for_labels(label_ids, include_reasoning=include_reasoning)
         return {
             "messages": [{"role": "system", "content": system_prompt}, *few_shot_msgs, {"role": "user", "content": ctx_text}],
             "prompt": {"system": system_prompt, "messages": few_shot_msgs, "user": ctx_text},
@@ -467,18 +516,10 @@ class LLMLabeler:
                 pairs += 1
         return float(sim_sum / max(1, pairs))
 
-    def _few_shot_messages(self, label_id: str) -> list[dict[str, str]]:
-        examples_cfg = getattr(self.cfg, "few_shot_examples", {}) or {}
-        if not isinstance(examples_cfg, Mapping):
-            return []
-        label_key = str(label_id)
-        label_examples = examples_cfg.get(label_key) or examples_cfg.get(label_key.lower())
-        if not isinstance(label_examples, (list, tuple)):
-            return []
+    def _few_shot_messages(self, label_id: str, *, include_reasoning: bool) -> list[dict[str, str]]:
+        label_examples = self._raw_few_shot_examples(label_id)
         messages: list[dict[str, str]] = []
         for entry in label_examples:
-            if not isinstance(entry, Mapping):
-                continue
             answer = entry.get("answer")
             context = entry.get("context")
             if context is not None:
@@ -487,19 +528,23 @@ class LLMLabeler:
                     ctx_text = f"EHR context:\n{ctx_text}"
                 messages.append({"role": "user", "content": ctx_text})
             if answer is not None:
-                messages.append({"role": "assistant", "content": str(answer)})
+                normalized = self._normalize_few_shot_answer(answer, include_reasoning=include_reasoning)
+                messages.append({"role": "assistant", "content": self._compact_json(normalized)})
         return messages
 
-    def _few_shot_messages_for_labels(self, label_ids: Iterable[str]) -> list[dict[str, str]]:
+    def _few_shot_messages_for_labels(self, label_ids: Iterable[str], *, include_reasoning: bool) -> list[dict[str, str]]:
         messages: list[dict[str, str]] = []
         for label_id in label_ids:
-            for entry in self._few_shot_messages(label_id):
-                role = entry.get("role") if isinstance(entry, Mapping) else None
-                content = entry.get("content") if isinstance(entry, Mapping) else None
-                if role not in {"user", "assistant"} or not isinstance(content, str):
-                    continue
-                prefix = f"[label {label_id}] "
-                messages.append({"role": role, "content": prefix + content})
+            for entry in self._raw_few_shot_examples(label_id):
+                context = entry.get("context")
+                answer = entry.get("answer")
+                if context is not None:
+                    ctx_text = str(context).strip()
+                    if ctx_text:
+                        messages.append({"role": "user", "content": f"Label: {label_id}\nEHR context:\n{ctx_text}"})
+                if answer is not None:
+                    normalized = self._normalize_few_shot_answer(answer, include_reasoning=include_reasoning)
+                    messages.append({"role": "assistant", "content": self._compact_json({str(label_id): normalized})})
         return messages
 
     def summarize_label_rule_for_rerank(self, label_id: str, label_rules: str, max_sentences: int = 2) -> str:
@@ -764,6 +809,8 @@ class LLMLabeler:
             }
         ]
 
+        categorical_types = self.CATEGORICAL_TYPES
+        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
         predictions: dict[str, dict] = {}
         for lid in label_ids:
             ltype = label_types.get(lid, "categorical") if isinstance(label_types, Mapping) else "categorical"


### PR DESCRIPTION
### Motivation

- Ensure few-shot examples are normalized and inserted as compact JSON so assistants receive consistent example formats.
- Allow toggling of optional reasoning output across single- and multi-label prompts and reflect that in system instructions and response schemas.
- Improve robustness of parsing free-text or JSON-like few-shot answers so legacy example formats and non-JSON answers are handled predictably.

### Description

- Added helpers `_response_keys_text`, `_compact_json`, `_parse_jsonish_answer`, `_normalize_few_shot_answer`, and `_raw_few_shot_examples` to normalize few-shot entries and produce compact JSON strings.  
- Updated `_few_shot_messages` and `_few_shot_messages_for_labels` to accept `include_reasoning` and to emit normalized, compacted assistant examples; label-scoped few-shot messages are now wrapped with the label key for multi-label prompts.  
- Updated `build_single_label_prompt_payload` and `build_multi_label_prompt_payload` to use the `include_reasoning` flag in system text and in the `response_format` JSON schema.  
- Enhanced parsing logic to handle string/JSON-like answers gracefully and maintain backward compatibility for legacy example shapes.

### Testing

- Added unit tests `test_multilabel_prompt_omits_reasoning_when_disabled`, `test_single_label_few_shot_answer_is_normalized_to_json`, and `test_multi_label_few_shot_answer_is_wrapped_by_label` in `tests/test_llm_reasoning.py`.  
- Ran `pytest tests/test_llm_reasoning.py` and the new tests passed.  
- Existing related tests in `tests/test_llm_reasoning.py` were exercised and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40aec873c832799cb58b7b5cd287f)