### PR TITLE
Fix large-corpus inference label config lookup and expose Azure API key in inference settings

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -2542,6 +2542,7 @@ AI_CONFIG_TOOLTIPS: Dict[str, Dict[str, str]] = {
         "rpm_limit": "Requests-per-minute throttle; leave 0 to disable.",
         "include_reasoning": "Ask the LLM to return reasoning/rationale text.",
         "few_shot_examples": "Optional JSON mapping of label_id → examples, each with 'context' and JSON 'answer'.",
+        "azure_api_key": "Azure OpenAI API key used when backend=azure.",
         "azure_api_version": "Azure OpenAI API version to target.",
         "azure_endpoint": "Custom Azure OpenAI endpoint URL.",
         "local_model_dir": "Path to the local ExLlamaV2 model directory.",
@@ -2974,6 +2975,7 @@ class AIAdvancedConfigDialog(QtWidgets.QDialog):
                 "max_context_chars",
                 "rpm_limit",
                 "include_reasoning",
+                "azure_api_key",
                 "azure_api_version",
                 "azure_endpoint",
                 "local_model_dir",
@@ -3002,6 +3004,7 @@ class AIAdvancedConfigDialog(QtWidgets.QDialog):
                 "max_context_chars",
                 "rpm_limit",
                 "include_reasoning",
+                "azure_api_key",
                 "azure_api_version",
                 "azure_endpoint",
                 "local_model_dir",
@@ -3293,6 +3296,9 @@ class AIAdvancedConfigDialog(QtWidgets.QDialog):
         else:
             edit = QtWidgets.QLineEdit()
             edit.setText("" if value is None else str(value))
+            if section == "llm" and name == "azure_api_key":
+                edit.setEchoMode(QtWidgets.QLineEdit.EchoMode.Password)
+                edit.setPlaceholderText("Enter Azure OpenAI API key")
             widget = edit
         if tooltip:
             widget.setToolTip(tooltip)

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -962,9 +962,14 @@ def _run_single_prompt_batch(
     label_types: dict[str, str],
 ) -> pd.DataFrame:
     tasks = df_to_single_prompt_tasks(df_prompts)
+    current_label_config = (
+        getattr(label_config_bundle, "current", None)
+        or getattr(label_config_bundle, "current_config", None)
+        or {}
+    )
 
     parent_to_children, child_to_parents, roots = build_label_dependencies(
-        label_config_bundle.current_config
+        current_label_config
     )
 
     rows: list[dict] = []
@@ -997,7 +1002,7 @@ def _run_single_prompt_batch(
                 unit_id=unit_id,
                 parent_preds=parent_preds,
                 label_types=task.label_types,
-                label_config=label_config_bundle.current_config,
+                label_config=current_label_config,
             )
             if not gated_ok:
                 value = None
@@ -1030,11 +1035,16 @@ def _run_family_prompt_batch(
     label_types: dict[str, str],
 ) -> pd.DataFrame:
     tasks = df_to_family_prompt_tasks(df_prompts)
+    current_label_config = (
+        getattr(label_config_bundle, "current", None)
+        or getattr(label_config_bundle, "current_config", None)
+        or {}
+    )
 
     ctx_by_pair = {(t.unit_id, t.label_id): t for t in tasks}
 
     parent_to_children, child_to_parents, roots = build_label_dependencies(
-        label_config_bundle.current_config
+        current_label_config
     )
 
     all_label_ids = sorted(label_types.keys())
@@ -1056,7 +1066,7 @@ def _run_family_prompt_batch(
                 unit_id=unit_id,
                 parent_preds=parent_preds,
                 label_types=label_types,
-                label_config=label_config_bundle.current_config,
+                label_config=current_label_config,
             )
             if not allowed:
                 continue


### PR DESCRIPTION
### Motivation
- Large-corpus prompt inference crashed when consumers expected `LabelConfigBundle.current_config` to exist, causing errors like `"'labelConfigBundle' object has no attribute 'current_config'"`. 
- Inference job settings did not expose the Azure API key as a configurable field in the advanced UI.

### Description
- Updated prompt-inference batch code in `_run_single_prompt_batch` and `_run_family_prompt_batch` to resolve the active label configuration via `getattr(label_config_bundle, "current", None) or getattr(label_config_bundle, "current_config", None) or {}` and use that value for dependency/gating lookups. 
- Replaced direct uses of `label_config_bundle.current_config` with the resolved `current_label_config` in both single-prompt and family inference paths to ensure compatibility with both the new and legacy/mocked bundle shapes. 
- Added `azure_api_key` to the inference advanced-settings allowlist and `AI_CONFIG_TOOLTIPS` with a tooltip describing the key. 
- Made the `azure_api_key` widget masked (password echo) and added a placeholder to the advanced dialog so the key is not shown in plain text.

### Testing
- Ran `pytest -q tests/test_large_corpus_jobs.py` which completed successfully (`7 passed`) with the change applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d411ff374c832798da5b7767d1a619)