### PR TITLE
Avoid loading retrieval embeddings for prompt inference-only jobs

### DIFF
--- a/tests/test_large_corpus_jobs.py
+++ b/tests/test_large_corpus_jobs.py
@@ -216,15 +216,9 @@ def test_prompt_inference_resumes_with_manifest_overrides(monkeypatch, tmp_path:
 
     applied_overrides: list[dict] = []
 
-    class DummySession:
-        models = object()
-        store = object()
-
-    def fake_backend_from_env(*_args, **_kwargs):  # type: ignore[no-untyped-def]
-        return DummySession()
-
-    def fake_build_shared_components(*_args, **_kwargs):  # type: ignore[no-untyped-def]
-        return {"llm_labeler": object()}
+    class DummyLLMLabeler:
+        def __init__(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            self.label_config = {}
 
     def fake_load_label_config_bundle(*_args, **_kwargs):  # type: ignore[no-untyped-def]
         return type(
@@ -240,8 +234,8 @@ def test_prompt_inference_resumes_with_manifest_overrides(monkeypatch, tmp_path:
     def fake_run_batches(manifest, *_args, **_kwargs):  # type: ignore[no-untyped-def]
         return manifest
 
-    monkeypatch.setattr(jobs.BackendSession, "from_env", staticmethod(fake_backend_from_env))
-    monkeypatch.setattr(jobs, "_build_shared_components", fake_build_shared_components)
+    monkeypatch.setattr(jobs, "build_llm_backend", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(jobs, "LLMLabeler", DummyLLMLabeler)
     monkeypatch.setattr(jobs, "_load_label_config_bundle", fake_load_label_config_bundle)
     monkeypatch.setattr(jobs, "_run_prompt_inference_batches", fake_run_batches)
     monkeypatch.setattr(jobs, "_normalize_local_model_overrides", lambda overrides: overrides)

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -14,6 +14,7 @@ from ..adapters import _load_label_config_bundle, export_inputs_from_repo
 from ..config import OrchestratorConfig, Paths
 from ..experiments import _normalize_local_model_overrides
 from ..label_configs import LabelConfigBundle
+from ..llm_backends import build_llm_backend
 from ..orchestration import _build_shared_components, BackendSession
 from ..orchestrator import _apply_overrides
 from ..services import LLMLabeler
@@ -781,23 +782,18 @@ def run_prompt_inference_job(job: PromptInferenceJob) -> None:
         overrides=label_overrides,
     )
 
-    session_paths = Paths(
-        notes_path=str(prompt_job_dir / "notes.parquet"),
-        annotations_path=str(prompt_job_dir / "annotations.parquet"),
-        outdir=str(job_dir / "_session"),
-        cache_dir_override=str(job_dir / "cache"),
-    )
-    session = BackendSession.from_env(session_paths, cfg)
-
-    components = _build_shared_components(
-        session_paths,
-        cfg,
+    llm_labeler = LLMLabeler(
+        build_llm_backend(cfg.llm),
         label_config_bundle,
-        phenotype_level=job.phenotype_level,
-        models=session.models,
-        store=session.store,
+        cfg.llm,
+        sc_cfg=cfg.scjitter,
+        cache_dir=str(job_dir / "cache"),
     )
-    llm_labeler: LLMLabeler = components["llm_labeler"]
+    llm_labeler.label_config = (
+        getattr(label_config_bundle, "current", None)
+        or getattr(label_config_bundle, "current_config", None)
+        or {}
+    )
 
     if not manifest:
         manifest = {


### PR DESCRIPTION
### Motivation
- The prompt inference path was still creating a `BackendSession` and shared retrieval components which eagerly initialize embedding/reranker models and can trigger HuggingFace downloads even for Azure/remote LLM-only runs.
- Inference-only jobs should not need embedding or retrieval models, so constructing them is unnecessary and harmful for large-corpus inference.

### Description
- Reworked `run_prompt_inference_job` to construct only the LLM pieces by calling `build_llm_backend` and creating an `LLMLabeler`, instead of building a `BackendSession` and calling `_build_shared_components` which loads embedding models. 
- Added an explicit assignment for `llm_labeler.label_config` using `label_config_bundle.current`/`current_config` to preserve label wiring.
- Imported `build_llm_backend` at the top of `vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py` and removed the unnecessary session/component initialization in the inference-only path.
- Updated the regression test `tests/test_large_corpus_jobs.py::test_prompt_inference_resumes_with_manifest_overrides` to mock `build_llm_backend`/`LLMLabeler` instead of mocking `BackendSession.from_env` and `_build_shared_components`.

### Testing
- Ran the focused test command `pytest -q tests/test_large_corpus_jobs.py -k 'prompt_inference_resumes_with_manifest_overrides or prompt_precompute_single_doc_full_context_skips_retrieval_index'`, and both targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d416796afc832789950a8cdbd9ad86)