### PR TITLE
Guard LLM choice access and add batch-limit for prompt inference with tests

### DIFF
--- a/tests/test_large_corpus_jobs.py
+++ b/tests/test_large_corpus_jobs.py
@@ -554,3 +554,74 @@ def test_prompt_precompute_single_doc_single_prompt_defaults_to_full_and_skips_s
     assert job.cfg_overrides.get("llmfirst", {}).get("single_doc_context") == "full"
     assert family_kwargs and family_kwargs[0]["single_doc_context_mode"] == "full"
     assert any("skipping retrieval index build" in status.lower() for status in statuses)
+
+
+def test_prompt_inference_batch_limit_caps_processed_batches(monkeypatch, tmp_path: Path) -> None:
+    prompt_job_dir = tmp_path / "prompt_job"
+    inference_job_dir = tmp_path / "inference_job"
+    prompt_job_dir.mkdir(parents=True)
+    inference_job_dir.mkdir(parents=True)
+    (inference_job_dir / "outputs").mkdir(parents=True)
+
+    for batch_id in range(3):
+        pd.DataFrame({"x": [batch_id]}).to_parquet(prompt_job_dir / f"prompts_{batch_id}.parquet", index=False)
+
+    manifest = {
+        "batches": [
+            {
+                "batch_id": i,
+                "prompt_batch_path": f"prompts_{i}.parquet",
+                "status": "pending",
+                "n_rows": 0,
+                "output_path": None,
+            }
+            for i in range(3)
+        ]
+    }
+
+    job = jobs.PromptInferenceJob(
+        job_id="inf-1",
+        prompt_job_id="prompt-1",
+        project_root=tmp_path,
+        prompt_job_dir=prompt_job_dir,
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        llm_overrides=None,
+        job_dir=inference_job_dir,
+        batch_limit=2,
+    )
+
+    monkeypatch.setattr(
+        jobs,
+        "_run_single_prompt_batch",
+        lambda *_args, **_kwargs: pd.DataFrame([{"unit_id": "u1", "label_id": "l1"}]),
+    )
+
+    class DummyBundle:
+        @staticmethod
+        def current_rules_map(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+        @staticmethod
+        def current_label_types(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+    out = jobs._run_prompt_inference_batches(
+        manifest,
+        job,
+        jobs.OrchestratorConfig(),
+        llm_labeler=object(),
+        label_config_bundle=DummyBundle(),
+        prompt_job_dir=prompt_job_dir,
+        inference_job_dir=inference_job_dir,
+        manifest_path=inference_job_dir / "job_manifest.json",
+    )
+
+    completed_ids = [b["batch_id"] for b in out["batches"] if b["status"] == "completed"]
+    pending_ids = [b["batch_id"] for b in out["batches"] if b["status"] != "completed"]
+    assert completed_ids == [0, 1]
+    assert pending_ids == [2]
+    assert (inference_job_dir / "outputs" / "outputs_batch_00000.parquet").exists()
+    assert (inference_job_dir / "outputs" / "outputs_batch_00001.parquet").exists()
+    assert not (inference_job_dir / "outputs" / "outputs_batch_00002.parquet").exists()

--- a/tests/test_llm_reasoning.py
+++ b/tests/test_llm_reasoning.py
@@ -12,7 +12,7 @@ if str(ROOT) not in sys.path:
 
 from vaannotate.vaannotate_ai_backend import config as ai_config
 from vaannotate.vaannotate_ai_backend.label_configs import LabelConfigBundle
-from vaannotate.vaannotate_ai_backend.llm_backends import JSONCallResult
+from vaannotate.vaannotate_ai_backend.llm_backends import JSONCallResult, _first_choice_or_raise
 from vaannotate.vaannotate_ai_backend.services.llm_labeler import LLMLabeler
 
 
@@ -248,6 +248,21 @@ def test_label_bundle_preserves_multiselect_routing(tmp_path):
     assert calls["fc"] == 0
     assert calls["json"] == 1
     assert rows[0]["prediction"] == "Option A"
+
+
+def test_first_choice_or_raise_returns_first_choice() -> None:
+    resp = types.SimpleNamespace(choices=["first", "second"])
+    assert _first_choice_or_raise(resp, operation="json_call") == "first"
+
+
+def test_first_choice_or_raise_raises_for_empty_choices() -> None:
+    resp = types.SimpleNamespace(choices=[])
+    try:
+        _first_choice_or_raise(resp, operation="forced_choice")
+    except RuntimeError as exc:
+        assert "forced_choice returned no choices" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected RuntimeError for empty choices")
 
 
 def test_multilabel_prompt_switches_to_multi_select(tmp_path):

--- a/vaannotate/vaannotate_ai_backend/llm_backends.py
+++ b/vaannotate/vaannotate_ai_backend/llm_backends.py
@@ -106,6 +106,22 @@ def _reasoning_first(obj: Mapping[str, Any] | Any) -> Mapping[str, Any] | Any:
     return ordered
 
 
+def _first_choice_or_raise(resp: Any, *, operation: str) -> Any:
+    """Return the first completion choice or raise a helpful error."""
+
+    choices = getattr(resp, "choices", None)
+    if (
+        not isinstance(choices, SequenceABC)
+        or isinstance(choices, (str, bytes, bytearray))
+        or len(choices) == 0
+    ):
+        raise RuntimeError(
+            f"{operation} returned no choices from the LLM backend. "
+            "Verify backend credentials, model deployment, and response format."
+        )
+    return choices[0]
+
+
 @dataclass
 class JSONCallResult:
     """Structured result returned by :meth:`LLMBackend.json_call`."""
@@ -236,7 +252,7 @@ class AzureOpenAIBackend(LLMBackend):
         resp = self.client.chat.completions.create(**kwargs)
         latency = time.time() - t0
         self._post_call()
-        choice = resp.choices[0]
+        choice = _first_choice_or_raise(resp, operation="json_call")
         message = getattr(choice, "message", None)
         content = getattr(message, "content", None) if message else None
         parsed = getattr(message, "parsed", None) if message else None
@@ -299,7 +315,7 @@ class AzureOpenAIBackend(LLMBackend):
         resp = self.client.chat.completions.create(**kwargs)
         latency = time.time() - t0
         self._post_call()
-        choice = resp.choices[0]
+        choice = _first_choice_or_raise(resp, operation="forced_choice")
         logprobs_obj = getattr(choice, "logprobs", None)
         items = getattr(logprobs_obj, "content", None) or []
         letter_logps = {letter: -1e9 for letter in letters}
@@ -840,4 +856,3 @@ def build_llm_backend(cfg: LLMConfig) -> LLMBackend:
     if backend_name in {"exllama", "exllamav2", "local"}:
         return ExLlamaV2Backend(cfg)
     raise ValueError(f"Unsupported LLM backend: {cfg.backend}")
-

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -876,6 +876,8 @@ def _run_prompt_inference_batches(
     manifest_path: Path,
 ) -> dict:
     log = logging.getLogger(__name__)
+    max_batches = int(job.batch_limit) if job.batch_limit and int(job.batch_limit) > 0 else None
+    processed_batches = 0
 
     try:
         rules_map = label_config_bundle.current_rules_map()
@@ -891,6 +893,8 @@ def _run_prompt_inference_batches(
     label_types = label_types or {}
 
     for batch in manifest.get("batches", []):
+        if max_batches is not None and processed_batches >= max_batches:
+            break
         batch_id = batch.get("batch_id")
         out_path_str = batch.get("output_path")
         out_path = inference_job_dir / str(out_path_str) if out_path_str else None
@@ -944,6 +948,7 @@ def _run_prompt_inference_batches(
         batch["status"] = "completed"
         batch["n_rows"] = len(df_out)
         batch["output_path"] = str(Path("outputs") / out_path.name)
+        processed_batches += 1
 
         write_manifest_atomic(manifest_path, manifest)
 


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when LLM backends return no completion choices and provide a clearer error message for `json_call`/`forced_choice` operations.
- Allow prompt inference jobs to respect a `batch_limit` so large prompt jobs can be processed incrementally and avoid processing more batches than requested.

### Description
- Add helper `_first_choice_or_raise` in `vaannotate_ai_backend/llm_backends.py` to validate and return the first choice or raise a descriptive `RuntimeError` when no choices are present.
- Use `_first_choice_or_raise` in `AzureOpenAIBackend.json_call` and `AzureOpenAIBackend.forced_choice` instead of indexing `resp.choices[0]` directly.
- Implement `batch_limit` handling in `_run_prompt_inference_batches` within `vaannotate_ai_backend/pipelines/large_corpus_jobs.py` by honoring `job.batch_limit`, tracking `processed_batches`, and stopping after the cap is reached.
- Add unit tests: `test_prompt_inference_batch_limit_caps_processed_batches` to verify batching and output files, and `test_first_choice_or_raise_returns_first_choice` / `test_first_choice_or_raise_raises_for_empty_choices` to validate the new choice-checking behavior, plus the necessary import updates in `tests/test_llm_reasoning.py`.

### Testing
- Ran targeted unit tests for the new logic: `tests/test_large_corpus_jobs.py::test_prompt_inference_batch_limit_caps_processed_batches`, and `tests/test_llm_reasoning.py::test_first_choice_or_raise_returns_first_choice` and `::test_first_choice_or_raise_raises_for_empty_choices`, and all passed.
- Verified that prompt inference produced the expected completed and pending batch statuses and that output files were created only for processed batches in the capped run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4199d05908327a861d61b595bff8f)