### PR TITLE
Support off-hours large-corpus inference, default logprob disabling, and per-batch status updates

### DIFF
--- a/tests/test_large_corpus_jobs.py
+++ b/tests/test_large_corpus_jobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 import sys
 
@@ -262,6 +263,128 @@ def test_prompt_inference_resumes_with_manifest_overrides(monkeypatch, tmp_path:
     manifest = jobs.read_manifest(job_dir / "job_manifest.json")
     assert manifest and manifest.get("cfg_overrides") == inference_manifest["cfg_overrides"]
     assert manifest.get("llm_overrides") == inference_manifest["llm_overrides"]
+
+
+def test_prompt_inference_defaults_logprobs_off(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    prompt_job_dir = project_root / "admin_tools" / "prompt_jobs" / "prompt-1"
+    prompt_job_dir.mkdir(parents=True)
+    (prompt_job_dir / "job_manifest.json").write_text(
+        json.dumps(
+            {
+                "pheno_id": "p1",
+                "labelset_id": "ls",
+                "phenotype_level": "single_doc",
+                "labeling_mode": "single_prompt",
+                "batches": [],
+            }
+        )
+    )
+
+    captured: dict[str, object] = {}
+
+    class DummyLLMLabeler:
+        def __init__(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            self.label_config = {}
+
+    def fake_build_llm_backend(llm_cfg):  # type: ignore[no-untyped-def]
+        captured["logprobs"] = llm_cfg.logprobs
+        captured["top_logprobs"] = llm_cfg.top_logprobs
+        return object()
+
+    def fake_load_label_config_bundle(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return type(
+            "Bundle",
+            (),
+            {
+                "current_rules_map": staticmethod(lambda *_args, **_kwargs: {}),
+                "current_label_types": staticmethod(lambda *_args, **_kwargs: {}),
+                "current_config": {},
+            },
+        )()
+
+    monkeypatch.setattr(jobs, "build_llm_backend", fake_build_llm_backend)
+    monkeypatch.setattr(jobs, "LLMLabeler", DummyLLMLabeler)
+    monkeypatch.setattr(jobs, "_load_label_config_bundle", fake_load_label_config_bundle)
+    monkeypatch.setattr(jobs, "_run_prompt_inference_batches", lambda manifest, *_args, **_kwargs: manifest)
+
+    job = jobs.PromptInferenceJob(
+        job_id="job-default-logprobs-off",
+        prompt_job_id="prompt-1",
+        project_root=project_root,
+        prompt_job_dir=prompt_job_dir,
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        llm_overrides=None,
+        job_dir=project_root / "admin_tools" / "prompt_inference" / "job-default-logprobs-off",
+    )
+
+    jobs.run_prompt_inference_job(job)
+
+    assert captured["logprobs"] is False
+    assert captured["top_logprobs"] == 0
+
+
+def test_prompt_inference_respects_explicit_logprobs_override(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    prompt_job_dir = project_root / "admin_tools" / "prompt_jobs" / "prompt-1"
+    prompt_job_dir.mkdir(parents=True)
+    (prompt_job_dir / "job_manifest.json").write_text(
+        json.dumps(
+            {
+                "pheno_id": "p1",
+                "labelset_id": "ls",
+                "phenotype_level": "single_doc",
+                "labeling_mode": "single_prompt",
+                "batches": [],
+            }
+        )
+    )
+
+    captured: dict[str, object] = {}
+
+    class DummyLLMLabeler:
+        def __init__(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            self.label_config = {}
+
+    def fake_build_llm_backend(llm_cfg):  # type: ignore[no-untyped-def]
+        captured["logprobs"] = llm_cfg.logprobs
+        captured["top_logprobs"] = llm_cfg.top_logprobs
+        return object()
+
+    def fake_load_label_config_bundle(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return type(
+            "Bundle",
+            (),
+            {
+                "current_rules_map": staticmethod(lambda *_args, **_kwargs: {}),
+                "current_label_types": staticmethod(lambda *_args, **_kwargs: {}),
+                "current_config": {},
+            },
+        )()
+
+    monkeypatch.setattr(jobs, "build_llm_backend", fake_build_llm_backend)
+    monkeypatch.setattr(jobs, "LLMLabeler", DummyLLMLabeler)
+    monkeypatch.setattr(jobs, "_load_label_config_bundle", fake_load_label_config_bundle)
+    monkeypatch.setattr(jobs, "_run_prompt_inference_batches", lambda manifest, *_args, **_kwargs: manifest)
+
+    job = jobs.PromptInferenceJob(
+        job_id="job-explicit-logprobs-on",
+        prompt_job_id="prompt-1",
+        project_root=project_root,
+        prompt_job_dir=prompt_job_dir,
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        llm_overrides={"logprobs": True, "top_logprobs": 3},
+        job_dir=project_root / "admin_tools" / "prompt_inference" / "job-explicit-logprobs-on",
+    )
+
+    jobs.run_prompt_inference_job(job)
+
+    assert captured["logprobs"] is True
+    assert captured["top_logprobs"] == 3
 
 
 def test_prompt_precompute_external_dataset_family_generates_all_labels(monkeypatch, tmp_path: Path) -> None:
@@ -625,3 +748,149 @@ def test_prompt_inference_batch_limit_caps_processed_batches(monkeypatch, tmp_pa
     assert (inference_job_dir / "outputs" / "outputs_batch_00000.parquet").exists()
     assert (inference_job_dir / "outputs" / "outputs_batch_00001.parquet").exists()
     assert not (inference_job_dir / "outputs" / "outputs_batch_00002.parquet").exists()
+
+
+def test_inference_off_hours_window_logic_weekday_and_weekend() -> None:
+    # Monday daytime ET -> blocked
+    monday_day_utc = datetime(2026, 1, 5, 17, 0, tzinfo=timezone.utc)  # 12:00 ET
+    assert jobs._in_off_hours_inference_window(monday_day_utc) is False
+
+    # Monday late ET -> allowed
+    monday_night_utc = datetime(2026, 1, 6, 4, 0, tzinfo=timezone.utc)  # 23:00 ET Monday
+    assert jobs._in_off_hours_inference_window(monday_night_utc) is True
+
+    # Saturday daytime ET -> allowed
+    saturday_utc = datetime(2026, 1, 10, 16, 0, tzinfo=timezone.utc)  # 11:00 ET Saturday
+    assert jobs._in_off_hours_inference_window(saturday_utc) is True
+
+
+def test_inference_off_hours_waits_between_batches(monkeypatch, tmp_path: Path) -> None:
+    prompt_job_dir = tmp_path / "prompt_job"
+    inference_job_dir = tmp_path / "inference_job"
+    prompt_job_dir.mkdir(parents=True)
+    inference_job_dir.mkdir(parents=True)
+    (inference_job_dir / "outputs").mkdir(parents=True)
+
+    pd.DataFrame({"x": [1]}).to_parquet(prompt_job_dir / "prompts_0.parquet", index=False)
+
+    manifest = {
+        "batches": [
+            {
+                "batch_id": 0,
+                "prompt_batch_path": "prompts_0.parquet",
+                "status": "pending",
+                "n_rows": 0,
+                "output_path": None,
+            }
+        ]
+    }
+
+    job = jobs.PromptInferenceJob(
+        job_id="inf-off-hours",
+        prompt_job_id="prompt-1",
+        project_root=tmp_path,
+        prompt_job_dir=prompt_job_dir,
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        llm_overrides=None,
+        job_dir=inference_job_dir,
+        off_hours_only=True,
+    )
+
+    waited: list[bool] = []
+    monkeypatch.setattr(jobs, "_wait_for_off_hours_inference_window", lambda *_args, **_kwargs: waited.append(True))
+    monkeypatch.setattr(
+        jobs,
+        "_run_single_prompt_batch",
+        lambda *_args, **_kwargs: pd.DataFrame([{"unit_id": "u1", "label_id": "l1"}]),
+    )
+
+    class DummyBundle:
+        @staticmethod
+        def current_rules_map(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+        @staticmethod
+        def current_label_types(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+    jobs._run_prompt_inference_batches(
+        manifest,
+        job,
+        jobs.OrchestratorConfig(),
+        llm_labeler=object(),
+        label_config_bundle=DummyBundle(),
+        prompt_job_dir=prompt_job_dir,
+        inference_job_dir=inference_job_dir,
+        manifest_path=inference_job_dir / "job_manifest.json",
+    )
+
+    assert waited == [True]
+
+
+def test_prompt_inference_emits_status_after_each_completed_batch(monkeypatch, tmp_path: Path) -> None:
+    prompt_job_dir = tmp_path / "prompt_job"
+    inference_job_dir = tmp_path / "inference_job"
+    prompt_job_dir.mkdir(parents=True)
+    inference_job_dir.mkdir(parents=True)
+    (inference_job_dir / "outputs").mkdir(parents=True)
+
+    for batch_id in range(2):
+        pd.DataFrame({"x": [batch_id]}).to_parquet(prompt_job_dir / f"prompts_{batch_id}.parquet", index=False)
+
+    manifest = {
+        "batches": [
+            {
+                "batch_id": i,
+                "prompt_batch_path": f"prompts_{i}.parquet",
+                "status": "pending",
+                "n_rows": 0,
+                "output_path": None,
+            }
+            for i in range(2)
+        ]
+    }
+
+    statuses: list[str] = []
+    job = jobs.PromptInferenceJob(
+        job_id="inf-status",
+        prompt_job_id="prompt-1",
+        project_root=tmp_path,
+        prompt_job_dir=prompt_job_dir,
+        phenotype_level="single_doc",
+        labeling_mode="single_prompt",
+        cfg_overrides={},
+        llm_overrides=None,
+        job_dir=inference_job_dir,
+        status_callback=statuses.append,
+    )
+
+    monkeypatch.setattr(
+        jobs,
+        "_run_single_prompt_batch",
+        lambda *_args, **_kwargs: pd.DataFrame([{"unit_id": "u1", "label_id": "l1"}]),
+    )
+
+    class DummyBundle:
+        @staticmethod
+        def current_rules_map(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+        @staticmethod
+        def current_label_types(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return {}
+
+    jobs._run_prompt_inference_batches(
+        manifest,
+        job,
+        jobs.OrchestratorConfig(),
+        llm_labeler=object(),
+        label_config_bundle=DummyBundle(),
+        prompt_job_dir=prompt_job_dir,
+        inference_job_dir=inference_job_dir,
+        manifest_path=inference_job_dir / "job_manifest.json",
+    )
+
+    per_batch_statuses = [msg for msg in statuses if msg.startswith("Completed inference batch ")]
+    assert len(per_batch_statuses) == 2

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -1180,6 +1180,7 @@ class _LargeCorpusJobWorker(QtCore.QObject):
                 run_prompt_precompute_job(self.precompute_job)
                 self.log_message.emit("Prompt precompute job completed.")
             elif self.inference_job is not None:
+                self.inference_job.status_callback = self.log_message.emit
                 self.log_message.emit(
                     f"Starting prompt inference job {self.inference_job.job_id}…"
                 )
@@ -1430,6 +1431,12 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         self.inference_batch_limit.setMaximum(1000000)
         self.inference_batch_limit.setValue(0)
         form.addRow("Batch limit (0 = all)", self.inference_batch_limit)
+
+        self.inference_off_hours_only = QtWidgets.QCheckBox(
+            "Only run off-hours/weekends (10p-6a ET weekdays; all day Sat/Sun)"
+        )
+        self.inference_off_hours_only.setChecked(False)
+        form.addRow("Run window", self.inference_off_hours_only)
 
         self.inference_cfg_overrides = QtWidgets.QPlainTextEdit()
         self.inference_cfg_overrides.setPlaceholderText("Optional JSON overrides for AI config")
@@ -2121,6 +2128,10 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
         if not llm_overrides and manifest_llm:
             llm_overrides = manifest_llm
             self.inference_llm_overrides.setPlainText(json.dumps(llm_overrides, indent=2))
+        if isinstance(manifest, Mapping):
+            manifest_off_hours_only = manifest.get("off_hours_only")
+            if isinstance(manifest_off_hours_only, bool):
+                self.inference_off_hours_only.setChecked(manifest_off_hours_only)
 
         level = str(self.pheno_row.get("level") or "single_doc")
         if isinstance(prompt_manifest, Mapping):
@@ -2138,6 +2149,7 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
             if prompt_mode:
                 labeling_mode = str(prompt_mode)
         batch_limit = int(self.inference_batch_limit.value()) or None
+        off_hours_only = bool(self.inference_off_hours_only.isChecked())
 
         return PromptInferenceJob(
             job_id=job_id,
@@ -2150,6 +2162,7 @@ class LargeCorpusJobDialog(QtWidgets.QDialog):
             llm_overrides=llm_overrides or None,
             job_dir=inference_dir,
             batch_limit=batch_limit,
+            off_hours_only=off_hours_only,
         )
 
     def _on_run_precompute(self) -> None:

--- a/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
+++ b/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
@@ -120,6 +120,7 @@ def create_prompt_inference_job(
     prompt_job_dir: str | Path | None = None,
     job_dir: str | Path | None = None,
     batch_limit: int | None = None,
+    off_hours_only: bool = False,
 ) -> PromptInferenceJob:
     """Create and run a prompt inference job."""
 
@@ -139,6 +140,7 @@ def create_prompt_inference_job(
         llm_overrides=llm_overrides,
         job_dir=Path(job_dir) if job_dir else None,
         batch_limit=batch_limit,
+        off_hours_only=off_hours_only,
     )
 
     run_prompt_inference_job(job)
@@ -187,6 +189,11 @@ def main(argv: list[str] | None = None) -> None:
     infer.add_argument("--prompt-job-dir", type=Path)
     infer.add_argument("--job-dir", type=Path)
     infer.add_argument("--batch-limit", type=int)
+    infer.add_argument(
+        "--off-hours-only",
+        action="store_true",
+        help="Restrict large-corpus inference to 10pm-6am ET on weekdays and all weekend.",
+    )
     infer.add_argument("--cfg", help="JSON overrides or path to JSON file")
     infer.add_argument("--llm-cfg", help="LLM-only overrides or path to JSON file")
     infer.add_argument("--experiment-name", help="Name from experiments manifest")
@@ -235,6 +242,7 @@ def main(argv: list[str] | None = None) -> None:
             prompt_job_dir=args.prompt_job_dir,
             job_dir=args.job_dir,
             batch_limit=args.batch_limit,
+            off_hours_only=bool(args.off_hours_only),
         )
 
 

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -4,9 +4,11 @@ import logging
 import os
 import time
 import hashlib
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -67,6 +69,24 @@ class PromptInferenceJob:
     llm_overrides: dict[str, Any] | None
     job_dir: Path | None = None
     batch_limit: int | None = None
+    off_hours_only: bool = False
+    status_callback: Callable[[str], None] | None = None
+
+
+def _inference_explicitly_configures_logprobs(
+    cfg_overrides: dict[str, Any] | None,
+    llm_overrides: dict[str, Any] | None,
+) -> bool:
+    cfg_llm = cfg_overrides.get("llm") if isinstance(cfg_overrides, dict) else None
+    if isinstance(cfg_llm, dict) and (
+        "logprobs" in cfg_llm or "top_logprobs" in cfg_llm
+    ):
+        return True
+    if isinstance(llm_overrides, dict) and (
+        "logprobs" in llm_overrides or "top_logprobs" in llm_overrides
+    ):
+        return True
+    return False
 
 
 def _empty_annotations_frame() -> pd.DataFrame:
@@ -146,6 +166,16 @@ def _emit_precompute_status(job: PromptPrecomputeJob, message: str) -> None:
             job.status_callback(message)
         except Exception:
             logger.debug("Prompt precompute status callback failed", exc_info=True)
+
+
+def _emit_inference_status(job: PromptInferenceJob, message: str) -> None:
+    logger = logging.getLogger(__name__)
+    logger.info(message)
+    if job.status_callback is not None:
+        try:
+            job.status_callback(message)
+        except Exception:
+            logger.debug("Prompt inference status callback failed", exc_info=True)
 
 
 def _format_eta(seconds: float | None) -> str:
@@ -725,7 +755,7 @@ def run_prompt_inference_job(job: PromptInferenceJob) -> None:
     """
 
     log = logging.getLogger(__name__)
-    log.info("Starting prompt inference job %s", job.job_id)
+    _emit_inference_status(job, f"Starting prompt inference job {job.job_id}")
 
     job_dir = job.job_dir or job.project_root / "admin_tools" / "prompt_inference" / job.job_id
     job_dir.mkdir(parents=True, exist_ok=True)
@@ -760,6 +790,10 @@ def run_prompt_inference_job(job: PromptInferenceJob) -> None:
         if not job.llm_overrides and isinstance(manifest_llm, dict):
             job.llm_overrides = manifest_llm
 
+        manifest_off_hours_only = manifest.get("off_hours_only")
+        if not job.off_hours_only and isinstance(manifest_off_hours_only, bool):
+            job.off_hours_only = manifest_off_hours_only
+
     cfg = OrchestratorConfig()
     overrides = _normalize_local_model_overrides(job.cfg_overrides or {})
     if overrides:
@@ -770,6 +804,10 @@ def run_prompt_inference_job(job: PromptInferenceJob) -> None:
         _apply_overrides(cfg, {"llm": llm_overrides})
         if "llmfirst" in llm_overrides:
             _apply_overrides(cfg, {"llmfirst": llm_overrides.get("llmfirst")})
+
+    if not _inference_explicitly_configures_logprobs(job.cfg_overrides, job.llm_overrides):
+        cfg.llm.logprobs = False
+        cfg.llm.top_logprobs = 0
 
     pheno_id = prompt_manifest.get("pheno_id") if prompt_manifest else None
     labelset_id = prompt_manifest.get("labelset_id") if prompt_manifest else None
@@ -803,14 +841,26 @@ def run_prompt_inference_job(job: PromptInferenceJob) -> None:
             "phenotype_level": job.phenotype_level,
             "cfg_overrides": job.cfg_overrides,
             "llm_overrides": job.llm_overrides or {},
+            "off_hours_only": bool(job.off_hours_only),
             "batches": [],
         }
     elif isinstance(manifest, dict):
         manifest["cfg_overrides"] = job.cfg_overrides
         manifest["llm_overrides"] = job.llm_overrides or {}
+        manifest["off_hours_only"] = bool(job.off_hours_only)
 
     manifest = _initialize_and_update_batches_for_prompt_inference(manifest, job, prompt_manifest)
     write_manifest_atomic(manifest_path, manifest)
+
+    total_batches = len(manifest.get("batches", []))
+    completed_batches = sum(
+        1 for batch in manifest.get("batches", []) if batch.get("status") == "completed"
+    )
+    _emit_inference_status(
+        job,
+        f"Prepared prompt inference for {total_batches} batches "
+        f"({completed_batches} already completed).",
+    )
 
     manifest = _run_prompt_inference_batches(
         manifest,
@@ -824,6 +874,13 @@ def run_prompt_inference_job(job: PromptInferenceJob) -> None:
     )
 
     write_manifest_atomic(manifest_path, manifest)
+    completed_after = sum(
+        1 for batch in manifest.get("batches", []) if batch.get("status") == "completed"
+    )
+    _emit_inference_status(
+        job,
+        f"Prompt inference finished: {completed_after}/{len(manifest.get('batches', []))} batches completed.",
+    )
 
 
 def _initialize_and_update_batches_for_prompt_inference(
@@ -891,8 +948,15 @@ def _run_prompt_inference_batches(
 
     rules_map = rules_map or {}
     label_types = label_types or {}
+    total_batches = len(manifest.get("batches", []))
+    completed_batches = sum(
+        1 for batch in manifest.get("batches", []) if batch.get("status") == "completed"
+    )
+    started_at = time.time()
 
     for batch in manifest.get("batches", []):
+        if job.off_hours_only:
+            _wait_for_off_hours_inference_window(log)
         if max_batches is not None and processed_batches >= max_batches:
             break
         batch_id = batch.get("batch_id")
@@ -949,10 +1013,80 @@ def _run_prompt_inference_batches(
         batch["n_rows"] = len(df_out)
         batch["output_path"] = str(Path("outputs") / out_path.name)
         processed_batches += 1
+        completed_batches += 1
 
         write_manifest_atomic(manifest_path, manifest)
+        elapsed = max(time.time() - started_at, 1e-6)
+        avg_seconds_per_batch = elapsed / max(completed_batches, 1)
+        remaining_batches = max(total_batches - completed_batches, 0)
+        eta_seconds = avg_seconds_per_batch * remaining_batches
+        _emit_inference_status(
+            job,
+            f"Completed inference batch {int(batch_id) + 1}/{total_batches}: "
+            f"{completed_batches}/{total_batches} batches done, "
+            f"{remaining_batches} remaining, {_format_eta(eta_seconds)}.",
+        )
 
     return manifest
+
+
+def _in_off_hours_inference_window(now_utc: datetime | None = None) -> bool:
+    """Return True when now is in the allowed large-corpus inference window.
+
+    Allowed schedule:
+    - Monday-Friday: 10:00 PM to 6:00 AM America/New_York
+    - Saturday-Sunday: all day
+    """
+
+    if now_utc is None:
+        now_utc = datetime.now(timezone.utc)
+    if now_utc.tzinfo is None:
+        now_utc = now_utc.replace(tzinfo=timezone.utc)
+
+    now_est = now_utc.astimezone(ZoneInfo("America/New_York"))
+    weekday = now_est.weekday()  # 0=Mon ... 6=Sun
+    if weekday >= 5:
+        return True
+    return now_est.hour >= 22 or now_est.hour < 6
+
+
+def _seconds_until_next_off_hours_window(now_utc: datetime | None = None) -> float:
+    """Return seconds until the next allowed inference window in America/New_York."""
+
+    if now_utc is None:
+        now_utc = datetime.now(timezone.utc)
+    if now_utc.tzinfo is None:
+        now_utc = now_utc.replace(tzinfo=timezone.utc)
+
+    eastern = ZoneInfo("America/New_York")
+    now_est = now_utc.astimezone(eastern)
+    if _in_off_hours_inference_window(now_utc):
+        return 0.0
+
+    weekday = now_est.weekday()
+    current_day_at_22 = now_est.replace(hour=22, minute=0, second=0, microsecond=0)
+    if weekday < 4:
+        next_start = current_day_at_22
+    elif weekday == 4:
+        # Friday daytime -> weekend opens at midnight between Friday/Saturday.
+        next_start = (now_est + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    else:
+        next_start = now_est
+
+    return max((next_start - now_est).total_seconds(), 0.0)
+
+
+def _wait_for_off_hours_inference_window(log: logging.Logger) -> None:
+    if _in_off_hours_inference_window():
+        return
+
+    seconds = _seconds_until_next_off_hours_window()
+    sleep_seconds = max(seconds, 60.0)
+    log.info(
+        "Off-hours-only inference enabled; pausing for %.0f seconds until next allowed window.",
+        sleep_seconds,
+    )
+    time.sleep(sleep_seconds)
 
 
 def _run_single_prompt_batch(


### PR DESCRIPTION
### Motivation
- Allow large-corpus inference to be restricted to off-hours/weekends to reduce daytime load and to surface per-batch progress to the UI/logs.
- Avoid collecting token logprobs by default for inference unless explicitly configured to reduce cost and latency.

### Description
- Add an `off_hours_only` flag to `PromptInferenceJob` and wire it through the CLI (`--off-hours-only`), the GUI (new checkbox), and manifest persistence.
- Implement window logic in `_in_off_hours_inference_window`, `_seconds_until_next_off_hours_window`, and `_wait_for_off_hours_inference_window` to enforce allowed schedule (10pm-6am ET weekdays, all weekend) and pause between batches when enabled.
- Default LLM logprob settings to disabled (`cfg.llm.logprobs = False`, `cfg.llm.top_logprobs = 0`) unless `logprobs`/`top_logprobs` are explicitly set in `cfg_overrides` or `llm_overrides` via helper `_inference_explicitly_configures_logprobs`.
- Add inference-specific status emission via `_emit_inference_status`, hook the GUI worker to send `status_callback` for inference, and emit per-batch ETA/status messages after each completed batch.

### Testing
- Ran the new unit tests in `tests/test_large_corpus_jobs.py` covering default/explicit logprob behavior, off-hours window logic, waiting behavior, and per-batch status emission using `pytest tests/test_large_corpus_jobs.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d421ae07f48327b354e9b5ef227843)