### PR TITLE
Lazy-load AI backend package exports to prevent eager Torch DLL load in CLI

### DIFF
--- a/vaannotate/vaannotate_ai_backend/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/__init__.py
@@ -6,11 +6,12 @@ workflows via :func:`build_next_batch` and :func:`run_inference`.
 
 __version__ = "0.1.0"
 
-from .orchestrator import build_next_batch, run_inference
-from .orchestration import BackendSession
-from .adapters import BackendResult, export_inputs_from_repo, run_ai_backend_and_collect
-from .experiments import InferenceExperimentResult, run_inference_experiments
-from .utils.runtime import CancelledError
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .adapters import BackendResult
+    from .experiments import InferenceExperimentResult
+    from .orchestration import BackendSession
 
 # Layering overview:
 # - core.*: primitives such as DataRepository, EmbeddingStore, and RetrievalCoordinator
@@ -31,3 +32,38 @@ __all__ = [
     "InferenceExperimentResult",
     "run_inference_experiments",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve public exports to avoid importing heavy deps at package import."""
+    if name in {"build_next_batch", "run_inference"}:
+        from .orchestrator import build_next_batch, run_inference
+
+        return {
+            "build_next_batch": build_next_batch,
+            "run_inference": run_inference,
+        }[name]
+    if name in {"BackendResult", "export_inputs_from_repo", "run_ai_backend_and_collect"}:
+        from .adapters import BackendResult, export_inputs_from_repo, run_ai_backend_and_collect
+
+        return {
+            "BackendResult": BackendResult,
+            "export_inputs_from_repo": export_inputs_from_repo,
+            "run_ai_backend_and_collect": run_ai_backend_and_collect,
+        }[name]
+    if name == "CancelledError":
+        from .utils.runtime import CancelledError
+
+        return CancelledError
+    if name == "BackendSession":
+        from .orchestration import BackendSession
+
+        return BackendSession
+    if name in {"InferenceExperimentResult", "run_inference_experiments"}:
+        from .experiments import InferenceExperimentResult, run_inference_experiments
+
+        return {
+            "InferenceExperimentResult": InferenceExperimentResult,
+            "run_inference_experiments": run_inference_experiments,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
### Motivation
- CLI entrypoints imported `vaannotate.vaannotate_ai_backend` eagerly, which pulled in `orchestrator -> config -> core.embeddings -> sentence_transformers -> torch` and could trigger Windows `WinError 1114` during package import even for flows that don't need embeddings. 
- The goal is to defer heavy imports so CLI resume and other lightweight flows don't fail due to premature Torch DLL initialization.

### Description
- Replaced top-level eager re-exports in `vaannotate/vaannotate_ai_backend/__init__.py` with a module-level `__getattr__` that lazily imports and returns symbols on first access. 
- The lazy resolver handles `build_next_batch`, `run_inference`, adapter helpers (`BackendResult`, `export_inputs_from_repo`, `run_ai_backend_and_collect`), `CancelledError`, `BackendSession`, and experiment helpers (`InferenceExperimentResult`, `run_inference_experiments`).
- `__all__` and the public API surface are preserved so existing import sites continue to work unchanged.

### Testing
- Running `pytest -q tests/test_public_api.py tests/ai_backend/test_cli_smoke.py tests/test_large_corpus_cli.py` initially failed in the container with `ModuleNotFoundError` due to `vaannotate` not being on `PYTHONPATH`.
- Re-running with `PYTHONPATH=. pytest -q tests/test_public_api.py tests/ai_backend/test_cli_smoke.py tests/test_large_corpus_cli.py` succeeded and the selected tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d431463bbc8327a96315f4836ae9c8)