### PR TITLE
Lazy-load heavy pipeline/service imports to avoid torch DLL crashes in inference CLI

### DIFF
--- a/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
+++ b/vaannotate/vaannotate_ai_backend/large_corpus_cli.py
@@ -5,15 +5,36 @@ import json
 import logging
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from .pipelines.large_corpus_jobs import (
-    PromptInferenceJob,
-    PromptPrecomputeJob,
-    run_prompt_inference_job,
-    run_prompt_precompute_job,
-)
 from .utils.job_manifest import read_manifest
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .pipelines.large_corpus_jobs import PromptInferenceJob, PromptPrecomputeJob
+
+
+def _jobs_api() -> dict[str, Any]:
+    from .pipelines.large_corpus_jobs import (
+        PromptInferenceJob,
+        PromptPrecomputeJob,
+        run_prompt_inference_job,
+        run_prompt_precompute_job,
+    )
+
+    return {
+        "PromptInferenceJob": PromptInferenceJob,
+        "PromptPrecomputeJob": PromptPrecomputeJob,
+        "run_prompt_inference_job": run_prompt_inference_job,
+        "run_prompt_precompute_job": run_prompt_precompute_job,
+    }
+
+
+def run_prompt_precompute_job(job: Any) -> None:
+    _jobs_api()["run_prompt_precompute_job"](job)
+
+
+def run_prompt_inference_job(job: Any) -> None:
+    _jobs_api()["run_prompt_inference_job"](job)
 
 LOG = logging.getLogger(__name__)
 
@@ -75,7 +96,7 @@ def create_prompt_precompute_job(
     dataset_column_map: dict[str, str] | None = None,
     job_dir: str | Path | None = None,
     env_overrides: dict[str, str] | None = None,
-) -> PromptPrecomputeJob:
+) -> "PromptPrecomputeJob":
     """Create and run a prompt precompute job."""
 
     project_root = Path(project_root)
@@ -83,6 +104,7 @@ def create_prompt_precompute_job(
         project_root, experiment_name, Path(experiments_dir) if experiments_dir else None
     )
 
+    PromptPrecomputeJob = _jobs_api()["PromptPrecomputeJob"]
     job = PromptPrecomputeJob(
         job_id=job_id or _default_job_id("prompt-precompute"),
         project_root=project_root,
@@ -122,7 +144,7 @@ def create_prompt_inference_job(
     job_dir: str | Path | None = None,
     batch_limit: int | None = None,
     off_hours_only: bool = False,
-) -> PromptInferenceJob:
+) -> "PromptInferenceJob":
     """Create and run a prompt inference job."""
 
     project_root = Path(project_root)
@@ -130,6 +152,7 @@ def create_prompt_inference_job(
         project_root, experiment_name, Path(experiments_dir) if experiments_dir else None
     )
 
+    PromptInferenceJob = _jobs_api()["PromptInferenceJob"]
     job = PromptInferenceJob(
         job_id=job_id or _default_job_id("prompt-infer"),
         prompt_job_id=prompt_job_id,
@@ -162,7 +185,7 @@ def resume_prompt_inference_job(
     off_hours_only: bool | None = None,
     project_root: str | Path | None = None,
     prompt_job_dir: str | Path | None = None,
-) -> PromptInferenceJob:
+) -> "PromptInferenceJob":
     """Resume a prompt inference job from an existing inference job directory."""
 
     resolved_job_dir = Path(job_dir) if job_dir else Path.cwd()
@@ -204,6 +227,7 @@ def resume_prompt_inference_job(
         else resolved_project_root / "admin_tools" / "prompt_jobs" / prompt_job_id
     )
 
+    PromptInferenceJob = _jobs_api()["PromptInferenceJob"]
     job = PromptInferenceJob(
         job_id=str(manifest.get("job_id") or resolved_job_dir.name),
         prompt_job_id=prompt_job_id,

--- a/vaannotate/vaannotate_ai_backend/pipelines/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/__init__.py
@@ -1,7 +1,10 @@
 from typing import TYPE_CHECKING, Any
 
-from .active_learning import ActiveLearningPipeline
-from .inference import InferencePipeline
+if TYPE_CHECKING:  # pragma: no cover
+    from .active_learning import ActiveLearningPipeline
+    from .inference import InferencePipeline
+    from .large_corpus_jobs import PromptInferenceJob, PromptPrecomputeJob
+
 from .prompt_tasks import (
     FamilyPromptTask,
     SinglePromptTask,
@@ -11,16 +14,20 @@ from .prompt_tasks import (
     single_prompt_tasks_to_df,
 )
 
-if TYPE_CHECKING:  # pragma: no cover
-    # Import lazily at runtime to avoid circular import during orchestration setup.
-    from .large_corpus_jobs import PromptInferenceJob, PromptPrecomputeJob
-
 
 def __getattr__(name: str) -> Any:
+    if name in {"ActiveLearningPipeline", "InferencePipeline"}:
+        from .active_learning import ActiveLearningPipeline
+        from .inference import InferencePipeline
+
+        return {
+            "ActiveLearningPipeline": ActiveLearningPipeline,
+            "InferencePipeline": InferencePipeline,
+        }[name]
     if name in {"PromptInferenceJob", "PromptPrecomputeJob"}:
         from .large_corpus_jobs import PromptInferenceJob, PromptPrecomputeJob
 
-        return {  # type: ignore[return-value]
+        return {
             "PromptInferenceJob": PromptInferenceJob,
             "PromptPrecomputeJob": PromptPrecomputeJob,
         }[name]

--- a/vaannotate/vaannotate_ai_backend/services/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/services/__init__.py
@@ -1,11 +1,15 @@
 """Service-layer utilities for active learning and inference pipelines."""
 
-from .context_builder import ContextBuilder
-from .diversity import DiversitySelector
-from .disagreement import DisagreementScorer
-from .llm_labeler import LLMLabeler, LLM_RECORDER
-from .uncertainty import LLMUncertaintyScorer
-from .selection import ActiveLearningSelector
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .context_builder import ContextBuilder
+    from .diversity import DiversitySelector
+    from .disagreement import DisagreementScorer
+    from .llm_labeler import LLMLabeler, LLM_RECORDER
+    from .selection import ActiveLearningSelector
+    from .uncertainty import LLMUncertaintyScorer
+
 
 __all__ = [
     "ContextBuilder",
@@ -16,3 +20,34 @@ __all__ = [
     "ActiveLearningSelector",
     "LLMUncertaintyScorer",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"ContextBuilder"}:
+        from .context_builder import ContextBuilder
+
+        return ContextBuilder
+    if name in {"DiversitySelector"}:
+        from .diversity import DiversitySelector
+
+        return DiversitySelector
+    if name in {"DisagreementScorer"}:
+        from .disagreement import DisagreementScorer
+
+        return DisagreementScorer
+    if name in {"LLMLabeler", "LLM_RECORDER"}:
+        from .llm_labeler import LLMLabeler, LLM_RECORDER
+
+        return {
+            "LLMLabeler": LLMLabeler,
+            "LLM_RECORDER": LLM_RECORDER,
+        }[name]
+    if name in {"ActiveLearningSelector"}:
+        from .selection import ActiveLearningSelector
+
+        return ActiveLearningSelector
+    if name in {"LLMUncertaintyScorer"}:
+        from .uncertainty import LLMUncertaintyScorer
+
+        return LLMUncertaintyScorer
+    raise AttributeError(name)


### PR DESCRIPTION
### Motivation
- Importing the AI backend entrypoints (pipelines/services) during CLI startup could eagerly pull in heavy ML deps (sentence-transformers / torch) and trigger DLL initialization failures on Windows; the CLI should be safe to import when those components are not needed.
- The goal is to defer importing embedding/index/labeler internals until the code path actually needs them so lightweight CLI usage and tests don't load torch at module import time.

### Description
- Changed `vaannotate_ai_backend/pipelines/__init__.py` to expose `ActiveLearningPipeline` and `InferencePipeline` via `TYPE_CHECKING` and a runtime `__getattr__` that lazily imports those classes only when accessed.
- Changed `vaannotate_ai_backend/services/__init__.py` to use `TYPE_CHECKING` and a runtime `__getattr__` to lazy-resolve service exports (e.g. `ContextBuilder`, `LLMLabeler`, `LLM_RECORDER`) to avoid importing embedding/retrieval code on import.
- Updated `vaannotate_ai_backend/large_corpus_cli.py` to defer importing `pipelines.large_corpus_jobs` with a `_jobs_api()` helper and thin `run_prompt_precompute_job` / `run_prompt_inference_job` wrappers and to use quoted forward refs for job return annotations, preserving the CLI surface while avoiding heavyweight imports at module import time.
- The public CLI surface and test monkeypatch points were preserved so existing user and test code continue to work.

### Testing
- Ran the targeted smoke and CLI tests with `PYTHONPATH=. pytest -q tests/test_large_corpus_cli.py tests/ai_backend/test_cli_smoke.py tests/test_public_api.py`, which completed successfully with all tests passing.
- Result: `6 passed` (with 3 warnings) during the validation run of the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d46817a9608327a70c9dc97f39ab56)