### PR TITLE
Update default Azure OpenAI deployment to gpt-4.1

### DIFF
--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -67,7 +67,7 @@ class RAGConfig:
 @dataclass
 class LLMConfig:
     model_name: str = field(
-        default_factory=lambda: os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
+        default_factory=lambda: os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1")
     )
     backend: str = field(default_factory=lambda: os.getenv("LLM_BACKEND", "azure"))
     temperature: float = 0.2


### PR DESCRIPTION
### Motivation
- Ensure the repository's Azure OpenAI default model aligns with the new deployment name so code that relies on the fallback uses `gpt-4.1` when `AZURE_OPENAI_DEPLOYMENT` is unset.

### Description
- Changed the fallback value in `LLMConfig.model_name` in `vaannotate/vaannotate_ai_backend/config.py` from `"gpt-4o"` to `"gpt-4.1"`.

### Testing
- Ran automated checks including `rg -n "gpt-4o"`, `rg -n "gpt-4o|gpt-4\.1"`, inspected the updated lines with `nl -ba`, and verified the diff and `git status` to confirm the change; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68f013b048327873945632dbfebf2)