### PR TITLE
Add include_reasoning flag to label sets and propagate through UI, CLI, and round builder

### DIFF
--- a/tests/test_llm_reasoning.py
+++ b/tests/test_llm_reasoning.py
@@ -427,3 +427,32 @@ def test_multi_label_few_shot_answer_is_wrapped_by_label(tmp_path):
     )
     parsed = json.loads(assistant_example)
     assert parsed == {"Flag": {"prediction": "yes"}}
+
+
+def test_multilabel_prompt_supports_per_label_reasoning_flags(tmp_path):
+    class DummyBackend:
+        def json_call(self, *_, **__):  # pragma: no cover - not invoked in this test
+            raise AssertionError("json_call should not be reached")
+
+    llm_cfg = ai_config.LLMConfig()
+    llm_cfg.include_reasoning = False
+    llm_cfg.include_reasoning_by_label = {"A": True, "B": False}
+    annotator = LLMLabeler(
+        llm_backend=DummyBackend(),
+        label_config_bundle=LabelConfigBundle(),
+        llm_config=llm_cfg,
+        sc_cfg=ai_config.SCJitterConfig(),
+        cache_dir=str(tmp_path),
+    )
+
+    payload = annotator.build_multi_label_prompt_payload(
+        label_ids=["A", "B"],
+        label_types={"A": "categorical", "B": "categorical"},
+        rules_map={"A": "", "B": ""},
+        ctx_snippets=[{"doc_id": "doc-1", "chunk_id": 1, "text": "note", "metadata": {}}],
+    )
+    schema = payload["response_format"]["json_schema"]
+    a_props = ((schema.get("properties") or {}).get("A", {}) or {}).get("properties") or {}
+    b_props = ((schema.get("properties") or {}).get("B", {}) or {}).get("properties") or {}
+    assert "reasoning" in a_props
+    assert "reasoning" not in b_props

--- a/tests/test_project_label_config.py
+++ b/tests/test_project_label_config.py
@@ -192,6 +192,7 @@ def test_label_keywords_and_examples_round_trip(tmp_path: Path) -> None:
                 "name": "Keywords",
                 "type": "text",
                 "required": False,
+                "include_reasoning": True,
                 "keywords": ["alpha", "beta"],
                 "few_shot_examples": [
                     {"context": "example context", "answer": "answer text"}
@@ -217,6 +218,7 @@ def test_label_keywords_and_examples_round_trip(tmp_path: Path) -> None:
     assert fetched.get("include_reasoning") is True
     assert isinstance(labels, list) and labels
     label = labels[0]
+    assert label["include_reasoning"] is True
     assert label["keywords"] == ["alpha", "beta"]
     assert label["few_shot_examples"] == [
         {"context": "example context", "answer": "answer text"}

--- a/tests/test_project_label_config.py
+++ b/tests/test_project_label_config.py
@@ -184,6 +184,7 @@ def test_label_keywords_and_examples_round_trip(tmp_path: Path) -> None:
         "pheno_id": "phen",
         "version": 1,
         "created_by": "tester",
+        "include_reasoning": True,
         "notes": None,
         "labels": [
             {
@@ -213,6 +214,7 @@ def test_label_keywords_and_examples_round_trip(tmp_path: Path) -> None:
         fetched = fetch_labelset(conn, "ls_features")
 
     labels = fetched.get("labels", [])
+    assert fetched.get("include_reasoning") is True
     assert isinstance(labels, list) and labels
     label = labels[0]
     assert label["keywords"] == ["alpha", "beta"]
@@ -244,3 +246,11 @@ def test_apply_label_queries_and_extract(tmp_path: Path) -> None:
     }
     extracted = RoundBuilder._extract_label_queries(config_override)
     assert extracted == {"lab1": "override query", "lab2": "second"}
+
+
+def test_round_builder_prefers_labelset_reasoning_flag() -> None:
+    builder = RoundBuilder.__new__(RoundBuilder)
+    config = {"final_llm_include_reasoning": False, "llm_labeling": {"include_reasoning": False}}
+
+    assert builder._final_llm_include_reasoning(config, labelset={"include_reasoning": True}) is True
+    assert builder._final_llm_include_reasoning(config, labelset={"include_reasoning": False}) is False

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -3588,6 +3588,7 @@ class AIRoundWorker(QtCore.QObject):
                     version=1,
                     created_at=context.created_at,
                     created_by=context.created_by,
+                    include_reasoning=0,
                     notes="Auto-generated",
                 )
                 labelset.save(conn)
@@ -4441,6 +4442,7 @@ class ProjectContext(QtCore.QObject):
         labelset_id: str,
         created_by: str,
         notes: str,
+        include_reasoning: bool,
         labels: List[Dict[str, object]],
         pheno_id: Optional[str] = None,
     ) -> models.LabelSet:
@@ -4455,6 +4457,7 @@ class ProjectContext(QtCore.QObject):
             version=1,
             created_at=created_at,
             created_by=created_by,
+            include_reasoning=1 if include_reasoning else 0,
             notes=notes,
         )
         db = self.require_db()
@@ -4944,6 +4947,9 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         form.addRow("Created by", self.creator_edit)
         self.notes_edit = QtWidgets.QPlainTextEdit()
         form.addRow("Notes", self.notes_edit)
+        self.include_reasoning_checkbox = QtWidgets.QCheckBox("Include reasoning in LLM outputs")
+        self.include_reasoning_checkbox.setChecked(False)
+        form.addRow("Reasoning", self.include_reasoning_checkbox)
         layout.addLayout(form)
 
         self.label_list = QtWidgets.QListWidget()
@@ -5033,6 +5039,8 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         return candidate
 
     def _apply_copied_labelset(self, payload: Dict[str, object]) -> None:
+        if hasattr(self, "include_reasoning_checkbox"):
+            self.include_reasoning_checkbox.setChecked(bool(payload.get("include_reasoning")))
         used_ids = set(self.ctx.list_all_label_ids())
         new_labels: List[Dict[str, object]] = []
         id_map: Dict[str, str] = {}
@@ -5246,6 +5254,7 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
             "labelset_id": self.id_edit.text().strip(),
             "created_by": self.creator_edit.text().strip() or "admin",
             "notes": self.notes_edit.toPlainText().strip() or "",
+            "include_reasoning": bool(self.include_reasoning_checkbox.isChecked()),
             "labels": labels_payload,
         }
 
@@ -5602,6 +5611,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self._ai_log_dialog: Optional[AIRoundLogDialog] = None
         self.ai_log_output: Optional[QtWidgets.QPlainTextEdit] = None
         self._ai_engine_overrides: Dict[str, Any] = {}
+        self._labelset_include_reasoning = False
         self._assisted_review_reminder_shown = False
         self._llm_prompt_shown = False
         self.ctx.project_changed.connect(self._refresh_labelset_options)
@@ -5662,9 +5672,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         backend_choice = self._current_ai_backend()
         if backend_choice:
             llm_cfg["backend"] = backend_choice
-        include_checkbox = getattr(self, "ai_include_reasoning_checkbox", None)
-        if isinstance(include_checkbox, QtWidgets.QCheckBox):
-            llm_cfg["include_reasoning"] = bool(include_checkbox.isChecked())
+        llm_cfg["include_reasoning"] = bool(getattr(self, "_labelset_include_reasoning", False))
         if backend_choice == "azure":
             if hasattr(self, "ai_azure_key_edit"):
                 azure_key = self.ai_azure_key_edit.text().strip()
@@ -5753,10 +5761,6 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         reranker_path = effective_cfg.get("reranker_model_dir")
         if hasattr(self, "ai_reranker_path_edit") and isinstance(reranker_path, str):
             self.ai_reranker_path_edit.setText(reranker_path)
-        include_reasoning = llm_cfg.get("include_reasoning")
-        checkbox = getattr(self, "ai_include_reasoning_checkbox", None)
-        if isinstance(checkbox, QtWidgets.QCheckBox) and isinstance(include_reasoning, bool):
-            checkbox.setChecked(include_reasoning)
         if backend_choice == "azure":
             if hasattr(self, "ai_azure_key_edit") and llm_cfg.get("azure_api_key"):
                 self.ai_azure_key_edit.setText(str(llm_cfg.get("azure_api_key")))
@@ -5816,6 +5820,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
 
     def _on_labelset_changed(self) -> None:
         schema = self._active_label_schema()
+        self._labelset_include_reasoning = bool(schema.get("include_reasoning")) if isinstance(schema, Mapping) else False
         keywords: Dict[str, List[str]] = {}
         queries: Dict[str, str] = {}
         few_shot: Dict[str, List[Dict[str, str]]] = {}
@@ -5889,6 +5894,13 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             self._ai_engine_overrides["llm"] = llm_cfg
             updated = True
 
+        llm_cfg = self._ai_engine_overrides.get("llm") if isinstance(self._ai_engine_overrides.get("llm"), Mapping) else {}
+        if not isinstance(llm_cfg, Mapping) or llm_cfg.get("include_reasoning") != self._labelset_include_reasoning:
+            llm_cfg = dict(llm_cfg)
+            llm_cfg["include_reasoning"] = self._labelset_include_reasoning
+            self._ai_engine_overrides["llm"] = llm_cfg
+            updated = True
+
         if updated:
             self._apply_ai_config_to_controls(self._ai_engine_overrides)
 
@@ -5911,9 +5923,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             self.random_final_llm_group.setEnabled(bool(checked))
 
     def _on_ai_final_llm_toggled(self, checked: bool) -> None:
-        checkbox = getattr(self, "ai_include_reasoning_checkbox", None)
-        if isinstance(checkbox, QtWidgets.QCheckBox):
-            checkbox.setEnabled(bool(checked))
+        _ = checked
 
     def _on_assisted_review_toggled(self, checked: bool) -> None:
         if hasattr(self, "assisted_review_spin"):
@@ -6296,9 +6306,6 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         random_rerank_row.setStretch(1, 0)
         random_llm_layout.addRow("Re-ranker model", random_rerank_row)
 
-        self.random_include_reasoning_checkbox = QtWidgets.QCheckBox("Include reasoning")
-        self.random_include_reasoning_checkbox.setChecked(False)
-        random_llm_layout.addRow("Include reasoning", self.random_include_reasoning_checkbox)
 
         self._random_azure_widgets = [
             w
@@ -6464,9 +6471,6 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.ai_final_llm_checkbox.toggled.connect(self._on_ai_final_llm_toggled)
         ai_config_layout.addRow("Final LLM labeling", self.ai_final_llm_checkbox)
 
-        self.ai_include_reasoning_checkbox = QtWidgets.QCheckBox("Include reasoning")
-        self.ai_include_reasoning_checkbox.setChecked(False)
-        ai_config_layout.addRow("Include reasoning", self.ai_include_reasoning_checkbox)
         self.ai_context_order_combo = QtWidgets.QComboBox()
         self.ai_context_order_combo.addItem("Relevance ranking", "relevance")
         self.ai_context_order_combo.addItem("Chronological", "chronological")
@@ -6771,12 +6775,6 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         if hasattr(self, "random_final_llm_checkbox") and isinstance(final_llm_value, bool):
             self.random_final_llm_checkbox.setChecked(final_llm_value)
             self._on_random_final_llm_toggled(final_llm_value)
-        include_reasoning_value = config.get("final_llm_include_reasoning")
-        if (
-            hasattr(self, "random_include_reasoning_checkbox")
-            and isinstance(include_reasoning_value, bool)
-        ):
-            self.random_include_reasoning_checkbox.setChecked(include_reasoning_value)
 
     def _collect_filters(self) -> SamplingFilters:
         conditions: List[MetadataFilterCondition] = []
@@ -7565,11 +7563,8 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 )
             except Exception:  # noqa: BLE001
                 overrides["final_llm_labeling_n_consistency"] = 1
-        include_reasoning_value: Optional[bool] = None
-        include_checkbox = getattr(self, "ai_include_reasoning_checkbox", None)
-        if isinstance(include_checkbox, QtWidgets.QCheckBox):
-            include_reasoning_value = bool(include_checkbox.isChecked())
-            overrides["final_llm_include_reasoning"] = include_reasoning_value
+        include_reasoning_value = bool(getattr(self, "_labelset_include_reasoning", False))
+        overrides["final_llm_include_reasoning"] = include_reasoning_value
         llmfirst_overrides: Dict[str, Any] = {}
         if isinstance(overrides.get("llmfirst"), Mapping):
             llmfirst_overrides.update(overrides.get("llmfirst", {}))
@@ -7593,8 +7588,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         backend_choice = self._current_ai_backend()
         if backend_choice:
             llm_overrides["backend"] = backend_choice
-        if include_reasoning_value is not None:
-            llm_overrides["include_reasoning"] = include_reasoning_value
+        llm_overrides["include_reasoning"] = include_reasoning_value
         if backend_choice == "azure":
             if hasattr(self, "ai_azure_version_edit"):
                 version = self.ai_azure_version_edit.text().strip()
@@ -8125,6 +8119,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 payload["created_by"] = labelset_row["created_by"]
                 payload["created_at"] = labelset_row["created_at"]
                 payload["notes"] = labelset_row["notes"]
+                payload["include_reasoning"] = bool(labelset_row["include_reasoning"])
             return payload
 
         if conn is not None:
@@ -8325,6 +8320,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                     version=1,
                     created_at=created_at,
                     created_by="system",
+                    include_reasoning=0,
                     notes="Auto-generated",
                 )
                 labelset.save(conn)
@@ -8375,9 +8371,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 final_llm_enabled = bool(self.random_final_llm_checkbox.isChecked())
                 config_payload["final_llm_labeling"] = final_llm_enabled
             if final_llm_enabled or assisted_enabled:
-                include_reasoning = False
-                if isinstance(getattr(self, "random_include_reasoning_checkbox", None), QtWidgets.QCheckBox):
-                    include_reasoning = bool(self.random_include_reasoning_checkbox.isChecked())
+                include_reasoning = bool(getattr(self, "_labelset_include_reasoning", False))
                 config_payload["final_llm_include_reasoning"] = include_reasoning
                 backend_choice = self._current_random_backend()
                 if backend_choice:
@@ -9005,6 +8999,7 @@ class ProjectTreeWidget(QtWidgets.QTreeWidget):
                 labelset_id=str(values.get("labelset_id", "")),
                 created_by=str(values.get("created_by", "admin")),
                 notes=str(values.get("notes", "")),
+                include_reasoning=bool(values.get("include_reasoning")),
                 labels=[dict(label) for label in values.get("labels", [])],
             )
         except Exception as exc:  # noqa: BLE001

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -3603,6 +3603,7 @@ class AIRoundWorker(QtCore.QObject):
                         rules=label.get("rules", ""),
                         gating_expr=None,
                         na_allowed=int(label.get("na_allowed", False)),
+                        include_reasoning=int(label.get("include_reasoning", False)),
                         unit=None,
                         min=None,
                         max=None,
@@ -4474,6 +4475,7 @@ class ProjectContext(QtCore.QObject):
                     rules=label.get("rules", ""),
                     gating_expr=label.get("gating_expr"),
                     na_allowed=1 if label.get("na_allowed") else 0,
+                    include_reasoning=1 if label.get("include_reasoning", include_reasoning) else 0,
                     unit=label.get("unit"),
                     min=label.get("min"),
                     max=label.get("max"),
@@ -4731,6 +4733,8 @@ class LabelEditorDialog(QtWidgets.QDialog):
         form.addRow("Required", self.required_check)
         self.na_check = QtWidgets.QCheckBox("Allow N/A")
         form.addRow("N/A", self.na_check)
+        self.include_reasoning_check = QtWidgets.QCheckBox("Include reasoning")
+        form.addRow("Reasoning", self.include_reasoning_check)
         self.gating_edit = QtWidgets.QLineEdit()
         form.addRow("Gating expression", self.gating_edit)
         self.rules_edit = QtWidgets.QPlainTextEdit()
@@ -4782,6 +4786,7 @@ class LabelEditorDialog(QtWidgets.QDialog):
             self.type_combo.setCurrentIndex(index)
         self.required_check.setChecked(bool(data.get("required")))
         self.na_check.setChecked(bool(data.get("na_allowed")))
+        self.include_reasoning_check.setChecked(bool(data.get("include_reasoning")))
         self.gating_edit.setText(str(data.get("gating_expr", "")))
         self.rules_edit.setPlainText(str(data.get("rules", "")))
         self.unit_edit.setText(str(data.get("unit") or ""))
@@ -4907,6 +4912,7 @@ class LabelEditorDialog(QtWidgets.QDialog):
             "type": type_value,
             "required": self.required_check.isChecked(),
             "na_allowed": self.na_check.isChecked(),
+            "include_reasoning": self.include_reasoning_check.isChecked(),
             "gating_expr": self.gating_edit.text().strip() or None,
             "rules": self.rules_edit.toPlainText().strip(),
             "unit": self.unit_edit.text().strip() or None,
@@ -5612,6 +5618,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.ai_log_output: Optional[QtWidgets.QPlainTextEdit] = None
         self._ai_engine_overrides: Dict[str, Any] = {}
         self._labelset_include_reasoning = False
+        self._label_reasoning_by_label: Dict[str, bool] = {}
         self._assisted_review_reminder_shown = False
         self._llm_prompt_shown = False
         self.ctx.project_changed.connect(self._refresh_labelset_options)
@@ -5672,7 +5679,15 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         backend_choice = self._current_ai_backend()
         if backend_choice:
             llm_cfg["backend"] = backend_choice
-        llm_cfg["include_reasoning"] = bool(getattr(self, "_labelset_include_reasoning", False))
+        reasoning_map = {
+            str(label_id): bool(value)
+            for label_id, value in getattr(self, "_label_reasoning_by_label", {}).items()
+            if str(label_id)
+        }
+        llm_cfg["include_reasoning"] = any(reasoning_map.values()) if reasoning_map else bool(
+            getattr(self, "_labelset_include_reasoning", False)
+        )
+        llm_cfg["include_reasoning_by_label"] = reasoning_map
         if backend_choice == "azure":
             if hasattr(self, "ai_azure_key_edit"):
                 azure_key = self.ai_azure_key_edit.text().strip()
@@ -5820,7 +5835,9 @@ class RoundBuilderDialog(QtWidgets.QDialog):
 
     def _on_labelset_changed(self) -> None:
         schema = self._active_label_schema()
-        self._labelset_include_reasoning = bool(schema.get("include_reasoning")) if isinstance(schema, Mapping) else False
+        labelset_default_reasoning = bool(schema.get("include_reasoning")) if isinstance(schema, Mapping) else False
+        self._labelset_include_reasoning = labelset_default_reasoning
+        self._label_reasoning_by_label = {}
         keywords: Dict[str, List[str]] = {}
         queries: Dict[str, str] = {}
         few_shot: Dict[str, List[Dict[str, str]]] = {}
@@ -5832,6 +5849,9 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 label_id = str(label.get("label_id") or "")
                 if not label_id:
                     continue
+                self._label_reasoning_by_label[label_id] = bool(
+                    label.get("include_reasoning", labelset_default_reasoning)
+                )
                 label_keywords = label.get("keywords")
                 if isinstance(label_keywords, Sequence):
                     kw_values = [str(kw).strip() for kw in label_keywords if str(kw).strip()]
@@ -5895,9 +5915,19 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             updated = True
 
         llm_cfg = self._ai_engine_overrides.get("llm") if isinstance(self._ai_engine_overrides.get("llm"), Mapping) else {}
-        if not isinstance(llm_cfg, Mapping) or llm_cfg.get("include_reasoning") != self._labelset_include_reasoning:
+        target_include = bool(self._labelset_include_reasoning)
+        if self._label_reasoning_by_label:
+            target_include = any(self._label_reasoning_by_label.values())
+        target_reasoning_map = {k: bool(v) for k, v in self._label_reasoning_by_label.items()}
+        current_map = llm_cfg.get("include_reasoning_by_label") if isinstance(llm_cfg, Mapping) else None
+        if (
+            not isinstance(llm_cfg, Mapping)
+            or llm_cfg.get("include_reasoning") != target_include
+            or current_map != target_reasoning_map
+        ):
             llm_cfg = dict(llm_cfg)
-            llm_cfg["include_reasoning"] = self._labelset_include_reasoning
+            llm_cfg["include_reasoning"] = target_include
+            llm_cfg["include_reasoning_by_label"] = target_reasoning_map
             self._ai_engine_overrides["llm"] = llm_cfg
             updated = True
 
@@ -7563,7 +7593,14 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 )
             except Exception:  # noqa: BLE001
                 overrides["final_llm_labeling_n_consistency"] = 1
-        include_reasoning_value = bool(getattr(self, "_labelset_include_reasoning", False))
+        reasoning_map = {
+            str(label_id): bool(value)
+            for label_id, value in getattr(self, "_label_reasoning_by_label", {}).items()
+            if str(label_id)
+        }
+        include_reasoning_value = any(reasoning_map.values()) if reasoning_map else bool(
+            getattr(self, "_labelset_include_reasoning", False)
+        )
         overrides["final_llm_include_reasoning"] = include_reasoning_value
         llmfirst_overrides: Dict[str, Any] = {}
         if isinstance(overrides.get("llmfirst"), Mapping):
@@ -7589,6 +7626,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         if backend_choice:
             llm_overrides["backend"] = backend_choice
         llm_overrides["include_reasoning"] = include_reasoning_value
+        llm_overrides["include_reasoning_by_label"] = reasoning_map
         if backend_choice == "azure":
             if hasattr(self, "ai_azure_version_edit"):
                 version = self.ai_azure_version_edit.text().strip()
@@ -8104,6 +8142,9 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                         "type": label["type"],
                         "required": bool(label["required"]),
                         "na_allowed": bool(label["na_allowed"]),
+                        "include_reasoning": bool(label["include_reasoning"])
+                        if "include_reasoning" in label.keys()
+                        else bool(labelset_row["include_reasoning"]) if labelset_row else False,
                         "rules": label["rules"],
                         "unit": label["unit"],
                         "range": {"min": label["min"], "max": label["max"]},
@@ -8335,6 +8376,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                         rules="",
                         gating_expr=None,
                         na_allowed=0,
+                        include_reasoning=0,
                         unit=None,
                         min=None,
                         max=None,
@@ -8372,6 +8414,8 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 config_payload["final_llm_labeling"] = final_llm_enabled
             if final_llm_enabled or assisted_enabled:
                 include_reasoning = bool(getattr(self, "_labelset_include_reasoning", False))
+                if getattr(self, "_label_reasoning_by_label", {}):
+                    include_reasoning = any(bool(v) for v in self._label_reasoning_by_label.values())
                 config_payload["final_llm_include_reasoning"] = include_reasoning
                 backend_choice = self._current_random_backend()
                 if backend_choice:
@@ -8422,6 +8466,12 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                         if max_new > 0:
                             backend_cfg["local_max_new_tokens"] = max_new
                 if backend_cfg:
+                    if getattr(self, "_label_reasoning_by_label", {}):
+                        backend_cfg["include_reasoning_by_label"] = {
+                            str(label_id): bool(value)
+                            for label_id, value in self._label_reasoning_by_label.items()
+                            if str(label_id)
+                        }
                     config_payload.setdefault("ai_backend", {}).update(backend_cfg)
             if assisted_enabled:
                 config_payload["assisted_review"] = {

--- a/vaannotate/admin_cli.py
+++ b/vaannotate/admin_cli.py
@@ -122,6 +122,7 @@ def createlabelset(
             created_by=data.get("created_by", "cli"),
             notes=data.get("notes"),
             labels=data["labels"],
+            include_reasoning=bool(data.get("include_reasoning", False)),
         )
         conn.commit()
     print(f"Label set {data['labelset_id']} stored")

--- a/vaannotate/project.py
+++ b/vaannotate/project.py
@@ -122,15 +122,16 @@ def add_labelset(
     created_by: str,
     notes: str | None,
     labels: Iterable[dict],
+    include_reasoning: bool = False,
 ) -> None:
     created_at = datetime.utcnow().isoformat()
     conn.execute(
         """
         INSERT OR REPLACE INTO label_sets(
-            labelset_id, project_id, pheno_id, version, created_at, created_by, notes
-        ) VALUES (?,?,?,?,?,?,?)
+            labelset_id, project_id, pheno_id, version, created_at, created_by, include_reasoning, notes
+        ) VALUES (?,?,?,?,?,?,?,?)
         """,
-        (labelset_id, project_id, pheno_id, version, created_at, created_by, notes),
+        (labelset_id, project_id, pheno_id, version, created_at, created_by, 1 if include_reasoning else 0, notes),
     )
     seen_label_ids: set[str] = set()
     for idx, label in enumerate(labels):
@@ -274,6 +275,7 @@ def fetch_labelset(conn: sqlite3.Connection, labelset_id: str) -> dict:
             }
         )
     labelset = dict(labelset_row)
+    labelset["include_reasoning"] = bool(labelset.get("include_reasoning"))
     labelset["labels"] = label_dicts
     return labelset
 

--- a/vaannotate/project.py
+++ b/vaannotate/project.py
@@ -160,8 +160,8 @@ def add_labelset(
         conn.execute(
             """
             INSERT OR REPLACE INTO labels(
-                label_id,labelset_id,name,type,required,order_index,rules,gating_expr,na_allowed,unit,min,max,keywords_json,few_shot_json
-            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                label_id,labelset_id,name,type,required,order_index,rules,gating_expr,na_allowed,include_reasoning,unit,min,max,keywords_json,few_shot_json
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             """,
             (
                 label_id,
@@ -173,6 +173,7 @@ def add_labelset(
                 label.get("rules"),
                 label.get("gating_expr"),
                 1 if label.get("na_allowed") else 0,
+                1 if label.get("include_reasoning", include_reasoning) else 0,
                 label.get("unit"),
                 label.get("min"),
                 label.get("max"),
@@ -266,6 +267,7 @@ def fetch_labelset(conn: sqlite3.Connection, labelset_id: str) -> dict:
                 "rules": label["rules"],
                 "gating_expr": label["gating_expr"],
                 "na_allowed": bool(label["na_allowed"]),
+                "include_reasoning": bool(label["include_reasoning"]) if "include_reasoning" in label.keys() else bool(labelset_row["include_reasoning"]),
                 "unit": label["unit"],
                 "min": label["min"],
                 "max": label["max"],

--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -1226,6 +1226,41 @@ class RoundBuilder:
         return cleaned
 
     @staticmethod
+    def _extract_label_reasoning_map(
+        config: Mapping[str, Any],
+        labelset: Mapping[str, Any] | None = None,
+    ) -> Dict[str, bool]:
+        result: Dict[str, bool] = {}
+        ai_backend_cfg = config.get("ai_backend") if isinstance(config.get("ai_backend"), Mapping) else {}
+        overrides = ai_backend_cfg.get("config_overrides") if isinstance(ai_backend_cfg, Mapping) and isinstance(ai_backend_cfg.get("config_overrides"), Mapping) else {}
+        llm_overrides = overrides.get("llm") if isinstance(overrides, Mapping) and isinstance(overrides.get("llm"), Mapping) else {}
+        for candidate in (
+            ai_backend_cfg.get("include_reasoning_by_label") if isinstance(ai_backend_cfg, Mapping) else None,
+            llm_overrides.get("include_reasoning_by_label") if isinstance(llm_overrides, Mapping) else None,
+        ):
+            if isinstance(candidate, Mapping):
+                for label_id, value in candidate.items():
+                    parsed = RoundBuilder._coerce_optional_bool(value)
+                    if parsed is not None:
+                        result[str(label_id)] = parsed
+        if labelset:
+            labels = labelset.get("labels") if isinstance(labelset, Mapping) else None
+            if isinstance(labels, Sequence):
+                default_reasoning = RoundBuilder._coerce_optional_bool(labelset.get("include_reasoning"))
+                for label in labels:
+                    if not isinstance(label, Mapping):
+                        continue
+                    label_id = str(label.get("label_id") or "")
+                    if not label_id:
+                        continue
+                    parsed = RoundBuilder._coerce_optional_bool(label.get("include_reasoning"))
+                    if parsed is None:
+                        parsed = default_reasoning
+                    if parsed is not None:
+                        result[label_id] = parsed
+        return result
+
+    @staticmethod
     def _extract_label_keywords(config: Mapping[str, Any]) -> Dict[str, list[str]]:
         ai_backend_cfg = config.get("ai_backend") if isinstance(config.get("ai_backend"), Mapping) else {}
         rag_cfg = ai_backend_cfg.get("rag") if isinstance(ai_backend_cfg, Mapping) and isinstance(ai_backend_cfg.get("rag"), Mapping) else {}
@@ -1415,6 +1450,9 @@ class RoundBuilder:
         cfg.final_llm_labeling_n_consistency = max(1, consistency)
         setattr(cfg.llmfirst, "final_llm_label_consistency", cfg.final_llm_labeling_n_consistency)
         setattr(cfg.llm, "include_reasoning", bool(include_reasoning))
+        label_reasoning_map = self._extract_label_reasoning_map(config, labelset)
+        if label_reasoning_map:
+            setattr(cfg.llm, "include_reasoning_by_label", label_reasoning_map)
         few_shot_examples = self._extract_few_shot_examples(config, labelset)
         if few_shot_examples:
             try:

--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -319,7 +319,7 @@ class RoundBuilder:
         else:
             final_llm_enabled = bool(final_llm_flag)
         config["final_llm_labeling"] = final_llm_enabled
-        include_reasoning = self._final_llm_include_reasoning(config)
+        include_reasoning = self._final_llm_include_reasoning(config, labelset=None)
         config["final_llm_include_reasoning"] = include_reasoning
         final_llm_outputs: Dict[str, str] = {}
         overrides = {
@@ -364,6 +364,8 @@ class RoundBuilder:
                         corpus_path = (self.project_root / corpus_path).resolve()
                 with self._connect_corpus(corpus_path) as corpus_conn:
                     labelset = fetch_labelset(project_conn, config["labelset_id"])
+                    include_reasoning = self._final_llm_include_reasoning(config, labelset=labelset)
+                    config["final_llm_include_reasoning"] = include_reasoning
                     round_number = config.get("round_number")
                     csv_override: Path | None = None
                     if not preselected_units_csv:
@@ -1030,7 +1032,7 @@ class RoundBuilder:
                     reviewer_assignments=reviewer_assignments,
                     config=config,
                     config_base=config_base,
-                    include_reasoning=self._final_llm_include_reasoning(config),
+                    include_reasoning=self._final_llm_include_reasoning(config, labelset=labelset),
                 )
                 if auto_submit_llm and outputs:
                     try:
@@ -1127,8 +1129,15 @@ class RoundBuilder:
                 return False
         return None
 
-    def _final_llm_include_reasoning(self, config: Mapping[str, Any]) -> bool:
-        candidates: list[object] = [config.get("final_llm_include_reasoning")]
+    def _final_llm_include_reasoning(
+        self,
+        config: Mapping[str, Any],
+        labelset: Mapping[str, Any] | None = None,
+    ) -> bool:
+        candidates: list[object] = []
+        if isinstance(labelset, Mapping):
+            candidates.append(labelset.get("include_reasoning"))
+        candidates.append(config.get("final_llm_include_reasoning"))
         llm_cfg = config.get("llm_labeling")
         if isinstance(llm_cfg, Mapping):
             candidates.append(llm_cfg.get("include_reasoning"))

--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -66,6 +66,7 @@ PROJECT_SCHEMA = [
         rules TEXT,
         gating_expr TEXT,
         na_allowed INTEGER DEFAULT 0,
+        include_reasoning INTEGER NOT NULL DEFAULT 0,
         unit TEXT,
         min REAL,
         max REAL,
@@ -73,6 +74,9 @@ PROJECT_SCHEMA = [
         few_shot_json TEXT,
         PRIMARY KEY(labelset_id, label_id)
     );
+    """,
+    """
+    ALTER TABLE labels ADD COLUMN include_reasoning INTEGER NOT NULL DEFAULT 0;
     """,
     """
     CREATE TABLE IF NOT EXISTS label_options(

--- a/vaannotate/schema.py
+++ b/vaannotate/schema.py
@@ -46,10 +46,14 @@ PROJECT_SCHEMA = [
         version INTEGER NOT NULL,
         created_at TEXT NOT NULL,
         created_by TEXT NOT NULL,
+        include_reasoning INTEGER NOT NULL DEFAULT 0,
         notes TEXT,
         FOREIGN KEY(project_id) REFERENCES projects(project_id),
         FOREIGN KEY(pheno_id) REFERENCES phenotypes(pheno_id)
     );
+    """,
+    """
+    ALTER TABLE label_sets ADD COLUMN include_reasoning INTEGER NOT NULL DEFAULT 0;
     """,
     """
     CREATE TABLE IF NOT EXISTS labels(

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -169,6 +169,7 @@ class Label(Record):
     rules: str
     gating_expr: Optional[str]
     na_allowed: int
+    include_reasoning: int
     unit: Optional[str]
     min: Optional[float]
     max: Optional[float]
@@ -188,6 +189,7 @@ class Label(Record):
             rules TEXT NOT NULL,
             gating_expr TEXT NULL,
             na_allowed INTEGER NOT NULL,
+            include_reasoning INTEGER NOT NULL DEFAULT 0,
             unit TEXT NULL,
             min REAL NULL,
             max REAL NULL,

--- a/vaannotate/shared/models.py
+++ b/vaannotate/shared/models.py
@@ -136,6 +136,7 @@ class LabelSet(Record):
     version: int
     created_at: str
     created_by: str
+    include_reasoning: int
     notes: str
 
     __tablename__ = "label_sets"
@@ -148,6 +149,7 @@ class LabelSet(Record):
             version INTEGER NOT NULL,
             created_at TEXT NOT NULL,
             created_by TEXT NOT NULL,
+            include_reasoning INTEGER NOT NULL DEFAULT 0,
             notes TEXT NOT NULL,
             FOREIGN KEY(pheno_id) REFERENCES phenotypes(pheno_id),
             FOREIGN KEY(project_id) REFERENCES projects(project_id)

--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -82,6 +82,7 @@ class LLMConfig:
     max_context_chars: int = 1200000
     rpm_limit: Optional[int] = 30
     include_reasoning: bool = False
+    include_reasoning_by_label: dict[str, bool] = field(default_factory=dict)
     # Azure OpenAI specific knobs
     azure_api_key: Optional[str] = field(
         default_factory=lambda: os.getenv("AZURE_OPENAI_API_KEY")

--- a/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
+++ b/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
@@ -196,6 +196,24 @@ class LLMLabeler:
             return []
         return [entry for entry in label_examples if isinstance(entry, Mapping)]
 
+    def _include_reasoning_for_label(self, label_id: str) -> bool:
+        per_label = getattr(self.cfg, "include_reasoning_by_label", {}) or {}
+        if isinstance(per_label, Mapping):
+            for key in (str(label_id), str(label_id).lower()):
+                if key in per_label:
+                    value = per_label.get(key)
+                    if isinstance(value, bool):
+                        return value
+                    if isinstance(value, (int, float)):
+                        return bool(int(value))
+                    if isinstance(value, str):
+                        text = value.strip().lower()
+                        if text in {"1", "true", "t", "yes", "y", "on"}:
+                            return True
+                        if text in {"0", "false", "f", "no", "n", "off"}:
+                            return False
+        return bool(getattr(self.cfg, "include_reasoning", True))
+
     def build_single_label_prompt_payload(
         self,
         *,
@@ -206,7 +224,7 @@ class LLMLabeler:
         temperature: float | None = None,
         system_suffix: str = "",
     ) -> dict[str, Any]:
-        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
+        include_reasoning = self._include_reasoning_for_label(label_id)
         ordered_snippets = self._ordered_snippets(snippets)
         ctx_text = self._build_context_text(ordered_snippets)
         opts = _options_for_label(label_id, label_type, self.label_config)
@@ -274,7 +292,7 @@ class LLMLabeler:
         rules_map: Mapping[str, str],
         ctx_snippets: list[dict],
     ) -> dict[str, Any]:
-        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
+        include_reasoning_by_label = {str(lid): self._include_reasoning_for_label(str(lid)) for lid in label_ids}
         ordered_snippets = self._ordered_snippets(ctx_snippets)
         ctx_text = self._build_context_text(ordered_snippets)
 
@@ -299,6 +317,7 @@ class LLMLabeler:
                     "Set prediction to a JSON object with each selected option key set to 'Yes' (omit or set to 'No' when unsupported)."
                 )
             label_summaries.append("\n".join(label_lines))
+            include_reasoning = include_reasoning_by_label.get(str(lid), bool(getattr(self.cfg, "include_reasoning", True)))
             label_schema = {
                 "type": "object",
                 "properties": {"prediction": self._prediction_schema(ltype, option_values, self.CATEGORICAL_TYPES)},
@@ -310,7 +329,8 @@ class LLMLabeler:
             schema["properties"][lid] = label_schema
             schema["required"].append(lid)
 
-        response_keys = self._response_keys_text(include_reasoning)
+        any_reasoning = any(include_reasoning_by_label.values())
+        response_keys = self._response_keys_text(any_reasoning)
         system_prompt = "\n\n".join(
             [
                 "You are a meticulous clinical annotator for EHR data.",
@@ -321,7 +341,7 @@ class LLMLabeler:
                 "\n\n".join(label_summaries),
             ]
         )
-        few_shot_msgs = self._few_shot_messages_for_labels(label_ids, include_reasoning=include_reasoning)
+        few_shot_msgs = self._few_shot_messages_for_labels(label_ids, include_reasoning_by_label=include_reasoning_by_label)
         return {
             "messages": [{"role": "system", "content": system_prompt}, *few_shot_msgs, {"role": "user", "content": ctx_text}],
             "prompt": {"system": system_prompt, "messages": few_shot_msgs, "user": ctx_text},
@@ -532,9 +552,16 @@ class LLMLabeler:
                 messages.append({"role": "assistant", "content": self._compact_json(normalized)})
         return messages
 
-    def _few_shot_messages_for_labels(self, label_ids: Iterable[str], *, include_reasoning: bool) -> list[dict[str, str]]:
+    def _few_shot_messages_for_labels(
+        self,
+        label_ids: Iterable[str],
+        *,
+        include_reasoning_by_label: Mapping[str, bool] | None = None,
+    ) -> list[dict[str, str]]:
         messages: list[dict[str, str]] = []
+        reasoning_map = include_reasoning_by_label or {}
         for label_id in label_ids:
+            include_reasoning = bool(reasoning_map.get(str(label_id), self._include_reasoning_for_label(str(label_id))))
             for entry in self._raw_few_shot_examples(label_id):
                 context = entry.get("context")
                 answer = entry.get("answer")
@@ -670,7 +697,7 @@ class LLMLabeler:
                 obj = content if isinstance(content, Mapping) else None
 
             pred_raw = (obj or {}).get("prediction")
-            reasoning = (obj or {}).get("reasoning") if bool(getattr(self.cfg, "include_reasoning", True)) else None
+            reasoning = (obj or {}).get("reasoning") if self._include_reasoning_for_label(label_id) else None
             pred_norm = None
             if use_options:
                 if is_multi_select:
@@ -810,7 +837,6 @@ class LLMLabeler:
         ]
 
         categorical_types = self.CATEGORICAL_TYPES
-        include_reasoning = bool(getattr(self.cfg, "include_reasoning", True))
         predictions: dict[str, dict] = {}
         for lid in label_ids:
             ltype = label_types.get(lid, "categorical") if isinstance(label_types, Mapping) else "categorical"
@@ -821,7 +847,12 @@ class LLMLabeler:
             is_multi_select = lt_norm == "categorical_multi"
 
             raw_entry = (obj or {}).get(lid) if isinstance(obj, Mapping) else None
-            reasoning = raw_entry.get("reasoning") if include_reasoning and isinstance(raw_entry, Mapping) else None
+            include_reasoning_for_label = self._include_reasoning_for_label(str(lid))
+            reasoning = (
+                raw_entry.get("reasoning")
+                if include_reasoning_for_label and isinstance(raw_entry, Mapping)
+                else None
+            )
             raw_prediction = None
             if isinstance(raw_entry, Mapping):
                 raw_prediction = raw_entry.get("prediction")


### PR DESCRIPTION
### Motivation

- Introduce a per-labelset `include_reasoning` flag so label sets can opt in/out of including LLM reasoning in generated outputs and final-LLM labeling. 
- Ensure the flag is persisted in the database and respected by round generation and AI configuration logic. 
- Surface the setting in the UI and CLI so users can create/copy label sets with reasoning enabled.

### Description

- Database/schema: add `include_reasoning INTEGER NOT NULL DEFAULT 0` to the `label_sets` table and include an `ALTER TABLE` statement in `schema.py` to add the column for existing DBs. 
- Data model and storage: add `include_reasoning` to the `LabelSet` dataclass in `shared/models.py` and include the column in `add_labelset` (`project.py`) and `fetch_labelset` to round-trip the value. 
- Rounds and AI logic: extend `RoundBuilder._final_llm_include_reasoning` to accept an optional `labelset` argument and make the labelset value the highest priority when determining the final `include_reasoning` boolean; propagate labelset-aware value into `generate_round` and final-LLM flows. 
- CLI: add `include_reasoning` handling to `createlabelset` in `admin_cli.py`. 
- UI: add a "Include reasoning in LLM outputs" checkbox to the label-set creation wizard (`LabelSetWizardDialog`) and wire copying/loading to preserve `include_reasoning`; remove various redundant per-dialog LLM reasoning checkboxes and instead track labelset-level reasoning via `_labelset_include_reasoning` in `RoundBuilderDialog`, and ensure AI engine overrides and collected round configuration include the resolved flag. 
- Tests: update `tests/test_project_label_config.py` to include `include_reasoning` in a labelset payload round-trip test and add a unit test `test_round_builder_prefers_labelset_reasoning_flag` for preference ordering.

### Testing

- Ran unit tests in `tests/test_project_label_config.py` which now include the round-trip check for `include_reasoning` and the `test_round_builder_prefers_labelset_reasoning_flag` test, and they passed. 
- Ran the full test suite with `pytest` locally and observed no failures related to the changed flows. 
- Exercised CLI `createlabelset` and UI label-set creation/copy workflows in basic smoke checks to confirm the flag is persisted and used by the round builder.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6924110908327b57979b53b5e80c5)