### PR TITLE
Restore module-level imports and remove debug prints in inference experiments

### DIFF
--- a/vaannotate/vaannotate_ai_backend/experiments.py
+++ b/vaannotate/vaannotate_ai_backend/experiments.py
@@ -9,9 +9,11 @@ import pandas as pd
 
 from .config import OrchestratorConfig, Paths
 from .label_configs import LabelConfigBundle, EMPTY_BUNDLE
+from .orchestration import BackendSession
+from .orchestrator import _apply_overrides, run_inference
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .orchestration import BackendSession
+    pass
 
 
 def _normalize_local_model_overrides(
@@ -238,9 +240,6 @@ def run_inference_experiments(
     Dict[str, InferenceExperimentResult]
         Mapping from experiment name to result objects.
     """
-    from .orchestration import BackendSession
-    from .orchestrator import _apply_overrides, run_inference
-
     base_outdir = Path(base_outdir)
     base_outdir.mkdir(parents=True, exist_ok=True)
 
@@ -325,24 +324,6 @@ def run_inference_experiments(
         else:
             exp_session = session or _build_session_for_cfg(name, sweep_cfg)
 
-        #debugging block
-        print(
-            f"=== DEBUG experiments.run_inference_experiments: sweep={name} ==="
-        )
-        rag_overrides = (normalized_overrides.get("rag") or {}) if isinstance(normalized_overrides, dict) else {}
-        print(
-            "  normalized_overrides.rag:",
-            "top_k_final=", rag_overrides.get("top_k_final"),
-            "per_label_topk=", rag_overrides.get("per_label_topk"),
-            "chunk_size=", rag_overrides.get("chunk_size"),
-        )
-        print(
-            "  sweep_cfg.rag:",
-            "top_k_final=", getattr(sweep_cfg.rag, "top_k_final", None),
-            "per_label_topk=", getattr(sweep_cfg.rag, "per_label_topk", None),
-            "chunk_size=", getattr(sweep_cfg.rag, "chunk_size", None),
-        )
-        
         df, artifacts = run_inference(
             notes_df=index_notes_df,
             ann_df=index_ann_df,

--- a/vaannotate/vaannotate_ai_backend/project_experiments.py
+++ b/vaannotate/vaannotate_ai_backend/project_experiments.py
@@ -457,17 +457,6 @@ def run_project_inference_experiments(
         session=session,
     )
 
-        # DEBUG: print rag overrides per sweep
-    print("=== DEBUG project_experiments.run_project_inference_experiments ===")
-    for name, overrides in sweeps_with_base.items():
-        rag_cfg = (overrides.get("rag") or {}) if isinstance(overrides, dict) else {}
-        print(
-            f"  sweep={name} rag overrides:",
-            "top_k_final=", rag_cfg.get("top_k_final"),
-            "per_label_topk=", rag_cfg.get("per_label_topk"),
-            "chunk_size=", rag_cfg.get("chunk_size"),
-        )
-
     for name, result in results.items():
         pred_df = getattr(result, "dataframe", None)
 


### PR DESCRIPTION
### Motivation
- Make the inference experiments module patchable by tests/monkeypatch and avoid noisy CLI/log output during sweeps by removing leftover debug prints.

### Description
- Reintroduced module-level imports for `BackendSession` and `run_inference` in `vaannotate/vaannotate_ai_backend/experiments.py` so external code/tests can reference and monkeypatch those symbols.
- Removed ad-hoc debug `print(...)` blocks from `experiments.py` and `project_experiments.py` to stop polluting runtime output.
- No changes to experiment execution logic or session construction beyond the import/print cleanup.

### Testing
- Ran `pytest -q tests/ai_backend/test_experiments.py tests/ai_backend/test_project_experiments.py`, and the targeted suite passed (`15 passed`, `3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69f2edbd083279446e0cb5a8847f5)