### PR TITLE
Fix legacy include_reasoning fallback and add few‑shot reasoning support

### DIFF
--- a/tests/test_llm_reasoning.py
+++ b/tests/test_llm_reasoning.py
@@ -429,6 +429,39 @@ def test_multi_label_few_shot_answer_is_wrapped_by_label(tmp_path):
     assert parsed == {"Flag": {"prediction": "yes"}}
 
 
+def test_few_shot_reasoning_field_is_included_when_enabled(tmp_path):
+    class DummyBackend:
+        def json_call(self, *_, **__):  # pragma: no cover - not invoked in this test
+            raise AssertionError("json_call should not be reached")
+
+    llm_cfg = ai_config.LLMConfig()
+    llm_cfg.include_reasoning = True
+    llm_cfg.few_shot_examples = {
+        "Flag": [{"context": "c1", "answer": "yes", "reasoning": "because evidence supports it"}]
+    }
+    annotator = LLMLabeler(
+        llm_backend=DummyBackend(),
+        label_config_bundle=LabelConfigBundle(),
+        llm_config=llm_cfg,
+        sc_cfg=ai_config.SCJitterConfig(),
+        cache_dir=str(tmp_path),
+    )
+
+    payload = annotator.build_single_label_prompt_payload(
+        label_id="Flag",
+        label_type="categorical",
+        label_rules="",
+        snippets=[{"doc_id": "doc-1", "chunk_id": 1, "text": "note", "metadata": {}}],
+    )
+    assistant_example = next(
+        msg["content"] for msg in payload["messages"] if msg["role"] == "assistant"
+    )
+    assert json.loads(assistant_example) == {
+        "prediction": "yes",
+        "reasoning": "because evidence supports it",
+    }
+
+
 def test_multilabel_prompt_supports_per_label_reasoning_flags(tmp_path):
     class DummyBackend:
         def json_call(self, *_, **__):  # pragma: no cover - not invoked in this test

--- a/tests/test_project_label_config.py
+++ b/tests/test_project_label_config.py
@@ -1,4 +1,5 @@
 import sys
+import sqlite3
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -256,3 +257,65 @@ def test_round_builder_prefers_labelset_reasoning_flag() -> None:
 
     assert builder._final_llm_include_reasoning(config, labelset={"include_reasoning": True}) is True
     assert builder._final_llm_include_reasoning(config, labelset={"include_reasoning": False}) is False
+
+
+def test_fetch_labelset_backfills_reasoning_for_legacy_schema() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE label_sets (
+            labelset_id TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL,
+            pheno_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            created_by TEXT NOT NULL,
+            notes TEXT
+        );
+        CREATE TABLE labels (
+            label_id TEXT NOT NULL,
+            labelset_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            type TEXT NOT NULL,
+            required INTEGER NOT NULL DEFAULT 0,
+            order_index INTEGER NOT NULL,
+            rules TEXT,
+            gating_expr TEXT,
+            na_allowed INTEGER NOT NULL DEFAULT 0,
+            unit TEXT,
+            min REAL,
+            max REAL,
+            keywords_json TEXT,
+            few_shot_json TEXT,
+            PRIMARY KEY(labelset_id, label_id)
+        );
+        CREATE TABLE label_options (
+            option_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            labelset_id TEXT NOT NULL,
+            label_id TEXT NOT NULL,
+            value TEXT NOT NULL,
+            display TEXT NOT NULL,
+            order_index INTEGER NOT NULL DEFAULT 0,
+            weight REAL
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO label_sets(labelset_id, project_id, pheno_id, version, created_at, created_by, notes)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("legacy_ls", "proj", "phen", 1, "2026-01-01T00:00:00Z", "tester", ""),
+    )
+    conn.execute(
+        """
+        INSERT INTO labels(label_id, labelset_id, name, type, required, order_index, rules, gating_expr, na_allowed)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("l1", "legacy_ls", "Legacy", "text", 0, 0, "", None, 0),
+    )
+
+    fetched = fetch_labelset(conn, "legacy_ls")
+    assert fetched["include_reasoning"] is False
+    assert fetched["labels"][0]["include_reasoning"] is False

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -2715,6 +2715,7 @@ class _FewShotEntryDialog(QtWidgets.QDialog):
         *,
         context: str = "",
         answer: str = "",
+        reasoning: str = "",
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Edit few-shot example")
@@ -2736,6 +2737,13 @@ class _FewShotEntryDialog(QtWidgets.QDialog):
         self.answer_edit.setPlainText(str(answer))
         form.addRow("Answer", self.answer_edit)
 
+        self.reasoning_edit = QtWidgets.QPlainTextEdit()
+        self.reasoning_edit.setPlaceholderText(
+            "Optional reasoning/rationale paired with the answer."
+        )
+        self.reasoning_edit.setPlainText(str(reasoning))
+        form.addRow("Reasoning (optional)", self.reasoning_edit)
+
         layout.addLayout(form)
 
         buttons = QtWidgets.QDialogButtonBox(
@@ -2746,12 +2754,16 @@ class _FewShotEntryDialog(QtWidgets.QDialog):
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
 
-    def values(self) -> tuple[str, str]:
-        return self.context_edit.toPlainText().strip(), self.answer_edit.toPlainText().strip()
+    def values(self) -> tuple[str, str, str]:
+        return (
+            self.context_edit.toPlainText().strip(),
+            self.answer_edit.toPlainText().strip(),
+            self.reasoning_edit.toPlainText().strip(),
+        )
 
 
 class _FewShotTable(QtWidgets.QWidget):
-    """Simple table for entering context/answer pairs."""
+    """Simple table for entering context/answer/reasoning examples."""
 
     def __init__(self, existing: Sequence[Mapping[str, object]] | None = None) -> None:
         super().__init__()
@@ -2759,13 +2771,18 @@ class _FewShotTable(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
 
-        self._table = QtWidgets.QTableWidget(0, 2)
-        self._table.setHorizontalHeaderLabels(["Context", "Answer (JSON or text)"])
+        self._table = QtWidgets.QTableWidget(0, 3)
+        self._table.setHorizontalHeaderLabels(
+            ["Context", "Answer (JSON or text)", "Reasoning (optional)"]
+        )
         self._table.horizontalHeader().setSectionResizeMode(
             0, QtWidgets.QHeaderView.ResizeMode.Stretch
         )
         self._table.horizontalHeader().setSectionResizeMode(
             1, QtWidgets.QHeaderView.ResizeMode.Stretch
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            2, QtWidgets.QHeaderView.ResizeMode.Stretch
         )
         self._table.setSelectionBehavior(
             QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
@@ -2804,23 +2821,26 @@ class _FewShotTable(QtWidgets.QWidget):
                     continue
                 context = entry.get("context")
                 answer = entry.get("answer")
+                reasoning = entry.get("reasoning")
                 self._add_row(
                     context if context is not None else "",
                     answer if answer is not None else "",
+                    reasoning if reasoning is not None else "",
                 )
 
-    def _add_row(self, context: str = "", answer: str = "") -> None:
+    def _add_row(self, context: str = "", answer: str = "", reasoning: str = "") -> None:
         row = self._table.rowCount()
         self._table.insertRow(row)
         self._table.setItem(row, 0, QtWidgets.QTableWidgetItem(str(context)))
         self._table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(answer)))
+        self._table.setItem(row, 2, QtWidgets.QTableWidgetItem(str(reasoning)))
         self._table.selectRow(row)
 
     def _on_add(self) -> None:
         dialog = _FewShotEntryDialog(self)
         if dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
-            context, answer = dialog.values()
-            self._add_row(context, answer)
+            context, answer, reasoning = dialog.values()
+            self._add_row(context, answer, reasoning)
 
     def _on_edit(self) -> None:
         row = self._table.currentRow()
@@ -2854,30 +2874,37 @@ class _FewShotTable(QtWidgets.QWidget):
     def _edit_row(self, row: int) -> None:
         context_item = self._table.item(row, 0)
         answer_item = self._table.item(row, 1)
+        reasoning_item = self._table.item(row, 2)
         dialog = _FewShotEntryDialog(
             self,
             context=context_item.text() if context_item else "",
             answer=answer_item.text() if answer_item else "",
+            reasoning=reasoning_item.text() if reasoning_item else "",
         )
         if dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
-            context, answer = dialog.values()
+            context, answer, reasoning = dialog.values()
             self._table.setItem(row, 0, QtWidgets.QTableWidgetItem(context))
             self._table.setItem(row, 1, QtWidgets.QTableWidgetItem(answer))
+            self._table.setItem(row, 2, QtWidgets.QTableWidgetItem(reasoning))
 
     def to_examples(self) -> list[dict[str, str]]:
         examples: list[dict[str, str]] = []
         for row in range(self._table.rowCount()):
             context_item = self._table.item(row, 0)
             answer_item = self._table.item(row, 1)
+            reasoning_item = self._table.item(row, 2)
             context = context_item.text().strip() if context_item else ""
             answer = answer_item.text().strip() if answer_item else ""
-            if not context and not answer:
+            reasoning = reasoning_item.text().strip() if reasoning_item else ""
+            if not context and not answer and not reasoning:
                 continue
             example: dict[str, str] = {}
             if context:
                 example["context"] = context
             if answer:
                 example["answer"] = answer
+            if reasoning:
+                example["reasoning"] = reasoning
             if example:
                 examples.append(example)
         return examples
@@ -8084,6 +8111,14 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         conn: Optional[sqlite3.Connection] = None,
     ) -> Dict[str, object]:
         def fetch(connection: sqlite3.Connection) -> Dict[str, object]:
+            def row_has_key(row: sqlite3.Row | None, key: str) -> bool:
+                return bool(row is not None and key in row.keys())
+
+            def row_bool(row: sqlite3.Row | None, key: str, default: bool = False) -> bool:
+                if not row_has_key(row, key):
+                    return default
+                return bool(row[key])
+
             labelset_row = connection.execute(
                 "SELECT * FROM label_sets WHERE labelset_id=?",
                 (labelset_id,),
@@ -8131,6 +8166,8 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                                     example["context"] = str(entry.get("context"))
                                 if entry.get("answer"):
                                     example["answer"] = str(entry.get("answer"))
+                                if entry.get("reasoning"):
+                                    example["reasoning"] = str(entry.get("reasoning"))
                                 if example:
                                     few_shot_examples.append(example)
                     except Exception:  # noqa: BLE001
@@ -8142,9 +8179,11 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                         "type": label["type"],
                         "required": bool(label["required"]),
                         "na_allowed": bool(label["na_allowed"]),
-                        "include_reasoning": bool(label["include_reasoning"])
-                        if "include_reasoning" in label.keys()
-                        else bool(labelset_row["include_reasoning"]) if labelset_row else False,
+                        "include_reasoning": row_bool(
+                            label,
+                            "include_reasoning",
+                            default=row_bool(labelset_row, "include_reasoning", default=False),
+                        ),
                         "rules": label["rules"],
                         "unit": label["unit"],
                         "range": {"min": label["min"], "max": label["max"]},
@@ -8160,7 +8199,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 payload["created_by"] = labelset_row["created_by"]
                 payload["created_at"] = labelset_row["created_at"]
                 payload["notes"] = labelset_row["notes"]
-                payload["include_reasoning"] = bool(labelset_row["include_reasoning"])
+                payload["include_reasoning"] = row_bool(labelset_row, "include_reasoning", default=False)
             return payload
 
         if conn is not None:

--- a/vaannotate/project.py
+++ b/vaannotate/project.py
@@ -203,6 +203,14 @@ def add_labelset(
 
 
 def fetch_labelset(conn: sqlite3.Connection, labelset_id: str) -> dict:
+    def _row_has_key(row: sqlite3.Row | None, key: str) -> bool:
+        return bool(row is not None and key in row.keys())
+
+    def _row_bool(row: sqlite3.Row | None, key: str, default: bool = False) -> bool:
+        if not _row_has_key(row, key):
+            return default
+        return bool(row[key])
+
     labelset_row = conn.execute(
         "SELECT * FROM label_sets WHERE labelset_id=?",
         (labelset_id,),
@@ -252,6 +260,8 @@ def fetch_labelset(conn: sqlite3.Connection, labelset_id: str) -> dict:
                             example_payload["context"] = entry.get("context")
                         if entry.get("answer") is not None:
                             example_payload["answer"] = entry.get("answer")
+                        if entry.get("reasoning") is not None:
+                            example_payload["reasoning"] = entry.get("reasoning")
                         if example_payload:
                             few_shot_examples.append(example_payload)
             except Exception:  # noqa: BLE001
@@ -267,7 +277,11 @@ def fetch_labelset(conn: sqlite3.Connection, labelset_id: str) -> dict:
                 "rules": label["rules"],
                 "gating_expr": label["gating_expr"],
                 "na_allowed": bool(label["na_allowed"]),
-                "include_reasoning": bool(label["include_reasoning"]) if "include_reasoning" in label.keys() else bool(labelset_row["include_reasoning"]),
+                "include_reasoning": _row_bool(
+                    label,
+                    "include_reasoning",
+                    default=_row_bool(labelset_row, "include_reasoning", default=False),
+                ),
                 "unit": label["unit"],
                 "min": label["min"],
                 "max": label["max"],
@@ -277,7 +291,7 @@ def fetch_labelset(conn: sqlite3.Connection, labelset_id: str) -> dict:
             }
         )
     labelset = dict(labelset_row)
-    labelset["include_reasoning"] = bool(labelset.get("include_reasoning"))
+    labelset["include_reasoning"] = _row_bool(labelset_row, "include_reasoning", default=False)
     labelset["labels"] = label_dicts
     return labelset
 

--- a/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
+++ b/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
@@ -540,7 +540,16 @@ class LLMLabeler:
         label_examples = self._raw_few_shot_examples(label_id)
         messages: list[dict[str, str]] = []
         for entry in label_examples:
-            answer = entry.get("answer")
+            answer: Any = entry.get("answer")
+            reasoning = entry.get("reasoning")
+            if (
+                include_reasoning
+                and isinstance(reasoning, str)
+                and reasoning.strip()
+                and answer is not None
+                and not isinstance(answer, Mapping)
+            ):
+                answer = {"prediction": answer, "reasoning": reasoning}
             context = entry.get("context")
             if context is not None:
                 ctx_text = str(context)
@@ -564,7 +573,16 @@ class LLMLabeler:
             include_reasoning = bool(reasoning_map.get(str(label_id), self._include_reasoning_for_label(str(label_id))))
             for entry in self._raw_few_shot_examples(label_id):
                 context = entry.get("context")
-                answer = entry.get("answer")
+                answer: Any = entry.get("answer")
+                reasoning = entry.get("reasoning")
+                if (
+                    include_reasoning
+                    and isinstance(reasoning, str)
+                    and reasoning.strip()
+                    and answer is not None
+                    and not isinstance(answer, Mapping)
+                ):
+                    answer = {"prediction": answer, "reasoning": reasoning}
                 if context is not None:
                     ctx_text = str(context).strip()
                     if ctx_text:


### PR DESCRIPTION
### Motivation
- Recent change made `include_reasoning` a per-label attribute which caused older labelset schemas (without that column) to raise errors when loading or copying label sets, so fetching must be backward compatible and default to no reasoning for legacy rows. 
- The few‑shot example builder did not allow entering paired reasoning/rationale examples to teach the LLM to emit reasoning; the UI and prompt construction should preserve and use an optional `reasoning` field.

### Description
- Added safe helpers to `fetch_labelset` to detect missing row keys and return a boolean default, and used them to default `include_reasoning` to `False` when the column is absent (file: `vaannotate/project.py`).
- Preserved and expose an optional per-example `reasoning` field when parsing stored few‑shot JSON in `fetch_labelset` (file: `vaannotate/project.py`).
- Updated the Admin UI label schema loader to use the same defensive `include_reasoning` fallback and to read `reasoning` from few‑shot examples (file: `vaannotate/AdminApp/main.py`).
- Extended the few‑shot editor dialogs/tables to add an explicit "Reasoning (optional)" column and to serialize it back into the per‑label mapping (file: `vaannotate/AdminApp/main.py`).
- Adjusted LLM few‑shot prompt construction so that when reasoning is enabled and an example provides a separate `reasoning` string, the example answer is converted into a structured `{"prediction": ..., "reasoning": ...}` object before normalization (file: `vaannotate/vaannotate_ai_backend/services/llm_labeler.py`).
- Added regression tests: `test_fetch_labelset_backfills_reasoning_for_legacy_schema` and `test_few_shot_reasoning_field_is_included_when_enabled` (files: `tests/test_project_label_config.py`, `tests/test_llm_reasoning.py`).

### Testing
- Ran the two targeted pytest cases with `pytest -q tests/test_project_label_config.py::test_fetch_labelset_backfills_reasoning_for_legacy_schema tests/test_llm_reasoning.py::test_few_shot_reasoning_field_is_included_when_enabled` and both tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a9b94a388327b229dcf34496960d)