### PR TITLE
Add retry and validation for JSON-object responses in LLM backends

### DIFF
--- a/tests/test_llm_backends_json_retry.py
+++ b/tests/test_llm_backends_json_retry.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from vaannotate.vaannotate_ai_backend.config import LLMConfig
+from vaannotate.vaannotate_ai_backend.llm_backends import AzureOpenAIBackend, ExLlamaV2Backend
+
+
+def _fake_response(content: str):
+    message = SimpleNamespace(content=content, parsed=None)
+    choice = SimpleNamespace(message=message, content=content, logprobs=None)
+    return SimpleNamespace(choices=[choice])
+
+
+def test_azure_json_call_retries_once_on_malformed_json():
+    backend = object.__new__(AzureOpenAIBackend)
+    backend.cfg = LLMConfig(model_name="fake-model")
+    backend._last_call_ts = 0.0
+
+    calls = {"count": 0}
+
+    def _create(**kwargs):  # noqa: ANN003
+        del kwargs
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _fake_response('{"prediction": "yes"')
+        return _fake_response('{"prediction": "yes"}')
+
+    backend.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=_create)))
+
+    result = backend.json_call(
+        [{"role": "user", "content": "test"}],
+        temperature=0.0,
+        logprobs=False,
+        top_logprobs=None,
+        response_format={"type": "json_object", "json_schema": {"type": "object"}},
+    )
+
+    assert calls["count"] == 2
+    assert result.data["prediction"] == "yes"
+
+
+def test_azure_json_call_fails_after_two_invalid_object_attempts():
+    backend = object.__new__(AzureOpenAIBackend)
+    backend.cfg = LLMConfig(model_name="fake-model")
+    backend._last_call_ts = 0.0
+
+    calls = {"count": 0}
+
+    def _create(**kwargs):  # noqa: ANN003
+        del kwargs
+        calls["count"] += 1
+        return _fake_response('["not-an-object"]')
+
+    backend.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=_create)))
+
+    try:
+        backend.json_call(
+            [{"role": "user", "content": "test"}],
+            temperature=0.0,
+            logprobs=False,
+            top_logprobs=None,
+            response_format={"type": "json_object", "json_schema": {"type": "object"}},
+        )
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "Failed to parse JSON response" in str(exc) or "Expected JSON object" in str(exc)
+        assert calls["count"] == 2
+
+
+def test_exllama_json_call_retries_once_on_non_object_json():
+    backend = object.__new__(ExLlamaV2Backend)
+    backend.cfg = LLMConfig(model_name="fake-local")
+    backend._last_call_ts = 0.0
+    backend._json_stop_conditions = ()
+    backend._format_messages = lambda messages: "prompt"  # noqa: ARG005
+
+    calls = {"count": 0}
+
+    def _generate(prompt, **kwargs):  # noqa: ANN003
+        del prompt, kwargs
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return '["bad"]', [], []
+        return '{"prediction":"no"}', [], []
+
+    backend._generate = _generate
+
+    result = backend.json_call(
+        [{"role": "user", "content": "test"}],
+        temperature=0.0,
+        logprobs=False,
+        top_logprobs=None,
+        response_format={"type": "json_object", "json_schema": {"type": "object"}},
+    )
+
+    assert calls["count"] == 2
+    assert result.data["prediction"] == "no"

--- a/vaannotate/vaannotate_ai_backend/llm_backends.py
+++ b/vaannotate/vaannotate_ai_backend/llm_backends.py
@@ -198,6 +198,52 @@ class LLMBackend:
         """Allow backends with external resources to provide an explicit close."""
         return None
 
+    @staticmethod
+    def _json_retry_limit(response_format: Optional[Mapping[str, Any]]) -> int:
+        """Return maximum attempts for JSON-object validation failures."""
+        return 2 if response_format else 1
+
+    @staticmethod
+    def _parse_json_candidate(
+        *,
+        content: Any,
+        parsed: Any = None,
+    ) -> tuple[Any, str]:
+        """Best-effort parse of backend response payload into a JSON candidate."""
+        text_content = content
+        if parsed is not None:
+            data_candidate = parsed
+            if not text_content:
+                try:
+                    text_content = json.dumps(parsed)
+                except Exception:
+                    text_content = str(parsed)
+            return data_candidate, str(text_content or "")
+
+        if text_content is None:
+            text_content = ""
+        text_content = str(text_content)
+        data_candidate: Any = text_content
+        if text_content:
+            data_candidate = json.loads(text_content)
+        return data_candidate, text_content
+
+    @staticmethod
+    def _validate_json_object_candidate(
+        *,
+        response_format: Optional[Mapping[str, Any]],
+        data_candidate: Any,
+        raw_content: str,
+    ) -> None:
+        """Raise when JSON mode is requested but response isn't a JSON object."""
+        if not response_format:
+            return
+        if not isinstance(data_candidate, MappingABC):
+            raise ValueError(
+                "Expected JSON object but received: "
+                f"{str(data_candidate if data_candidate is not None else raw_content)[:2000]}"
+            )
+
 
 class AzureOpenAIBackend(LLMBackend):
     """Backend that wraps Azure OpenAI chat completions."""
@@ -248,39 +294,37 @@ class AzureOpenAIBackend(LLMBackend):
                 kwargs["response_format"] = response_format
         if logprobs and top_logprobs:
             kwargs["top_logprobs"] = int(top_logprobs)
-        t0 = time.time()
-        resp = self.client.chat.completions.create(**kwargs)
-        latency = time.time() - t0
-        self._post_call()
-        choice = _first_choice_or_raise(resp, operation="json_call")
-        message = getattr(choice, "message", None)
-        content = getattr(message, "content", None) if message else None
-        parsed = getattr(message, "parsed", None) if message else None
-
-        # Azure JSON mode may populate `message.parsed` instead of `content`
-        if parsed is not None:
-            data_candidate = parsed
-            if not content:
-                try:
-                    content = json.dumps(parsed)
-                except Exception:
-                    content = str(parsed)
-        else:
+        max_attempts = self._json_retry_limit(response_format)
+        attempts = 0
+        last_exc: Exception | None = None
+        while True:
+            attempts += 1
+            t0 = time.time()
+            resp = self.client.chat.completions.create(**kwargs)
+            latency = time.time() - t0
+            self._post_call()
+            choice = _first_choice_or_raise(resp, operation="json_call")
+            message = getattr(choice, "message", None)
+            content = getattr(message, "content", None) if message else None
+            parsed = getattr(message, "parsed", None) if message else None
             if content is None:
                 content = getattr(choice, "content", "")
-            content = content or ""
-            data_candidate = content
-            if content:
-                try:
-                    data_candidate = json.loads(content)
-                except Exception as exc:
-                    if response_format:
+            try:
+                data_candidate, content = self._parse_json_candidate(content=content, parsed=parsed)
+                self._validate_json_object_candidate(
+                    response_format=response_format,
+                    data_candidate=data_candidate,
+                    raw_content=content,
+                )
+                break
+            except Exception as exc:
+                last_exc = exc
+                if attempts >= max_attempts:
+                    if response_format and isinstance(content, str):
                         snippet = content[:2000]
                         raise ValueError(f"Failed to parse JSON response: {snippet}") from exc
-
-        if response_format and not isinstance(data_candidate, MappingABC):
-            raise ValueError(f"Expected JSON object but received: {str(data_candidate)[:2000]}")
-
+                    raise
+                continue
         data = _reasoning_first(data_candidate)
         logprob_info = getattr(choice, "logprobs", None)
         if logprob_info is not None:
@@ -642,7 +686,8 @@ class ExLlamaV2Backend(LLMBackend):  # pragma: no cover - requires heavy optiona
         token_logprobs: List[float] = []
         data: Mapping[str, Any] | None = None
         latency = 0.0
-        while attempts < 2:
+        max_attempts = self._json_retry_limit(response_format)
+        while attempts < max_attempts:
             t0 = time.time()
             text, token_ids, token_logprobs = self._generate(
                 prompt,
@@ -653,12 +698,18 @@ class ExLlamaV2Backend(LLMBackend):  # pragma: no cover - requires heavy optiona
             latency = time.time() - t0
             self._post_call()
             try:
-                data = _reasoning_first(self._tolerant_json_loads(text))
+                parsed = self._tolerant_json_loads(text)
+                self._validate_json_object_candidate(
+                    response_format=response_format,
+                    data_candidate=parsed,
+                    raw_content=text,
+                )
+                data = _reasoning_first(parsed)
                 break
             except Exception as exc:
                 last_error = exc
                 attempts += 1
-                if attempts >= 2:
+                if attempts >= max_attempts:
                     raise
                 continue
         else:  # pragma: no cover - defensive


### PR DESCRIPTION
### Motivation

- Some backends can return malformed JSON or non-object JSON when `response_format` requests a JSON object, causing brittle parsing and unclear errors.
- Introduce a unified, best-effort parsing and retry strategy so backends will re-request once for recoverable JSON validation failures when JSON-object output is expected.

### Description

- Added helper methods on `LLMBackend`: `_json_retry_limit`, `_parse_json_candidate`, and `_validate_json_object_candidate` to centralize retry limits, tolerant parsing, and JSON-object validation.
- Updated `AzureOpenAIBackend.json_call` to loop up to the retry limit, use the new parsing/validation helpers, handle `message.parsed` vs `message.content`, and surface clearer errors on final failure.
- Updated `ExLlamaV2Backend.json_call` to use `_json_retry_limit` and `_validate_json_object_candidate`, and to validate parsed JSON before returning.
- Added unit tests in `tests/test_llm_backends_json_retry.py` covering Azure retry on malformed JSON, Azure failure after two invalid object attempts, and ExLlama retry behavior.

### Testing

- Added `tests/test_llm_backends_json_retry.py` with three tests: `test_azure_json_call_retries_once_on_malformed_json`, `test_azure_json_call_fails_after_two_invalid_object_attempts`, and `test_exllama_json_call_retries_once_on_non_object_json` which exercise retry and validation behavior.
- Ran the test suite with `pytest` including the new tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f5ce6cbc83279adfcf14f96c6b52)