### PR TITLE
Add malformed JSON streak guard for large-corpus inference

### DIFF
--- a/tests/test_large_corpus_jobs.py
+++ b/tests/test_large_corpus_jobs.py
@@ -894,3 +894,103 @@ def test_prompt_inference_emits_status_after_each_completed_batch(monkeypatch, t
 
     per_batch_statuses = [msg for msg in statuses if msg.startswith("Completed inference batch ")]
     assert len(per_batch_statuses) == 2
+
+
+def test_single_prompt_batch_stops_after_consecutive_malformed_json() -> None:
+    df_prompts = pd.DataFrame(
+        [
+            {
+                "job_id": "j1",
+                "prompt_id": f"j1:unit:u{i}",
+                "unit_id": f"u{i}",
+                "label_ids": ["L1"],
+                "ctx_snippets": [],
+                "rules_map": {"L1": "rule"},
+                "label_types": {"L1": "categorical"},
+                "rag_fingerprint": "fp",
+                "prompt_payload": {},
+                "meta": {},
+            }
+            for i in range(10)
+        ]
+    )
+
+    class DummyLabeler:
+        def __init__(self) -> None:
+            self.cfg = type(
+                "Cfg",
+                (),
+                {"llmfirst": type("LLMFirst", (), {"malformed_json_unit_streak_limit": 10})()},
+            )()
+
+        def annotate_multi(self, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"runs": [], "predictions": {}, "json_valid": False}
+
+    class DummyBundle:
+        current = {}
+
+    try:
+        jobs._run_single_prompt_batch(
+            df_prompts,
+            llm_labeler=DummyLabeler(),
+            label_config_bundle=DummyBundle(),
+            rules_map={"L1": "rule"},
+            label_types={"L1": "categorical"},
+        )
+        assert False, "Expected RuntimeError after malformed JSON streak limit is reached"
+    except RuntimeError as exc:
+        assert "consecutive malformed JSON unit responses" in str(exc)
+
+
+def test_single_prompt_batch_resets_malformed_json_streak_after_valid_response() -> None:
+    df_prompts = pd.DataFrame(
+        [
+            {
+                "job_id": "j2",
+                "prompt_id": f"j2:unit:u{i}",
+                "unit_id": f"u{i}",
+                "label_ids": ["L1"],
+                "ctx_snippets": [],
+                "rules_map": {"L1": "rule"},
+                "label_types": {"L1": "categorical"},
+                "rag_fingerprint": "fp",
+                "prompt_payload": {},
+                "meta": {},
+            }
+            for i in range(12)
+        ]
+    )
+
+    class DummyLabeler:
+        def __init__(self) -> None:
+            self.cfg = type(
+                "Cfg",
+                (),
+                {"llmfirst": type("LLMFirst", (), {"malformed_json_unit_streak_limit": 10})()},
+            )()
+            self.calls = 0
+
+        def annotate_multi(self, **_kwargs):  # type: ignore[no-untyped-def]
+            self.calls += 1
+            if self.calls <= 9:
+                return {"runs": [], "predictions": {}, "json_valid": False}
+            if self.calls == 10:
+                return {
+                    "runs": [],
+                    "predictions": {"L1": {"prediction": "yes", "reasoning": None}},
+                    "json_valid": True,
+                }
+            return {"runs": [], "predictions": {}, "json_valid": False}
+
+    class DummyBundle:
+        current = {}
+
+    out = jobs._run_single_prompt_batch(
+        df_prompts,
+        llm_labeler=DummyLabeler(),
+        label_config_bundle=DummyBundle(),
+        rules_map={"L1": "rule"},
+        label_types={"L1": "categorical"},
+    )
+
+    assert len(out) == 12

--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -140,6 +140,7 @@ class LLMFirstConfig:
     inference_labeling_mode: str = "family"  # "family" | "single_prompt"
     single_prompt_max_labels: int = 64
     single_prompt_max_chars: int = 16000
+    malformed_json_unit_streak_limit: int = 10
     # forced-choice micro-probe
     fc_enable: bool = True
     #label enrichment for probe

--- a/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/large_corpus_jobs.py
@@ -1108,6 +1108,15 @@ def _run_single_prompt_batch(
     )
 
     rows: list[dict] = []
+    malformed_streak = 0
+    streak_limit = int(
+        getattr(
+            getattr(getattr(llm_labeler, "cfg", None), "llmfirst", None),
+            "malformed_json_unit_streak_limit",
+            10,
+        )
+        or 10
+    )
     for task in tasks:
         unit_id = str(task.unit_id)
         label_ids = [str(lid) for lid in task.label_ids]
@@ -1122,6 +1131,17 @@ def _run_single_prompt_batch(
 
         preds = result.get("predictions") or {}
         runs = result.get("runs", [])
+        json_valid = bool(result.get("json_valid", bool(preds)))
+        if not json_valid:
+            malformed_streak += 1
+            if malformed_streak >= streak_limit:
+                raise RuntimeError(
+                    "Stopping prompt inference after "
+                    f"{malformed_streak} consecutive malformed JSON unit responses. "
+                    "This usually indicates an LLM API outage or network connectivity issue."
+                )
+        else:
+            malformed_streak = 0
 
         parent_preds = {
             (unit_id, str(lid)): info.get("prediction") if isinstance(info, dict) else None

--- a/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
+++ b/vaannotate/vaannotate_ai_backend/services/llm_labeler.py
@@ -794,6 +794,8 @@ class LLMLabeler:
         Returns a dict with:
             {
                 "runs": [ ... raw call metadata ... ],
+                "json_valid": <bool>,
+                "error": <optional error string>,
                 "predictions": {
                     "<label_id>": {
                         "prediction": <value>,
@@ -836,7 +838,7 @@ class LLMLabeler:
             )
         except Exception:
             LLM_RECORDER.record("json_multi_error", {"unit_id": unit_id, "label_ids": label_ids})
-            return {"runs": [], "predictions": {}}
+            return {"runs": [], "predictions": {}, "json_valid": False, "error": "json_call_failed"}
 
         if isinstance(content, str):
             try:
@@ -846,6 +848,7 @@ class LLMLabeler:
         else:
             obj = content if isinstance(content, Mapping) else None
 
+        json_valid = isinstance(obj, Mapping)
         runs = [
             {
                 "raw_output": content,
@@ -894,7 +897,7 @@ class LLMLabeler:
 
             predictions[lid] = {"prediction": pred_norm, "reasoning": reasoning}
 
-        return {"runs": runs, "predictions": predictions}
+        return {"runs": runs, "predictions": predictions, "json_valid": json_valid, "error": None}
 
     def forced_choice_probe(
         self,


### PR DESCRIPTION
### Motivation
- Robustly detect and abort large-corpus inference when many consecutive units produce malformed or non-JSON responses, which typically indicates an LLM API outage or network issue. 
- Surface parse-health metadata from multi-label JSON calls so callers can distinguish parse failures from valid predictions. 

### Description
- Add `LLMFirstConfig.malformed_json_unit_streak_limit` (default `10`) to configure when inference should stop after consecutive malformed unit responses in single-prompt mode. 
- Extend `LLMLabeler.annotate_multi` to return `json_valid` and `error` alongside `runs` and `predictions` so callers can detect parse health explicitly. 
- Update `_run_single_prompt_batch` in `large_corpus_jobs` to maintain a consecutive malformed-JSON `malformed_streak`, reset it on a valid response, and raise a `RuntimeError` if the streak reaches the configured limit. 
- Add tests `test_single_prompt_batch_stops_after_consecutive_malformed_json` and `test_single_prompt_batch_resets_malformed_json_streak_after_valid_response` to validate stopping and streak-reset behavior. 

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_llm_backends_json_retry.py tests/test_large_corpus_jobs.py`, which completed successfully with `18 passed` and `3 warnings`. 
- An initial run without `PYTHONPATH` failed during collection due to module import paths, which was resolved by setting `PYTHONPATH=.`, after which the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6fc03e9388327a87391034c54550d)