### PR TITLE
Avoid eager torch imports in CLI config paths

### DIFF
--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from .core.embeddings import IndexConfig
+from .core.index_config import IndexConfig
 
 
 def _env_int(name: str, default: Optional[int] = None) -> Optional[int]:

--- a/vaannotate/vaannotate_ai_backend/core/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/core/__init__.py
@@ -1,13 +1,19 @@
-"""Core primitives for the VAAnnotate AI backend."""
+"""Core primitives for the VAAnnotate AI backend.
 
-from .data import DataRepository
-from .embeddings import (
-    EmbeddingStore,
-    IndexConfig,
-    Models,
-    build_models_from_env,
-)
-from .retrieval import RetrievalCoordinator, SemanticQuery
+Exports are loaded lazily so importing ``vaannotate_ai_backend.core`` does not
+eagerly import heavyweight ML dependencies (for example torch/sentence-transformers)
+on CLI code paths that only need lightweight config types.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .data import DataRepository
+    from .embeddings import EmbeddingStore, Models, build_models_from_env
+    from .index_config import IndexConfig
+    from .retrieval import RetrievalCoordinator, SemanticQuery
 
 __all__ = [
     "DataRepository",
@@ -18,3 +24,27 @@ __all__ = [
     "RetrievalCoordinator",
     "SemanticQuery",
 ]
+
+
+def __getattr__(name: str):
+    if name == "DataRepository":
+        from .data import DataRepository
+
+        return DataRepository
+    if name in {"EmbeddingStore", "Models", "build_models_from_env"}:
+        from .embeddings import EmbeddingStore, Models, build_models_from_env
+
+        return {
+            "EmbeddingStore": EmbeddingStore,
+            "Models": Models,
+            "build_models_from_env": build_models_from_env,
+        }[name]
+    if name == "IndexConfig":
+        from .index_config import IndexConfig
+
+        return IndexConfig
+    if name in {"RetrievalCoordinator", "SemanticQuery"}:
+        from .retrieval import RetrievalCoordinator, SemanticQuery
+
+        return {"RetrievalCoordinator": RetrievalCoordinator, "SemanticQuery": SemanticQuery}[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vaannotate/vaannotate_ai_backend/core/embeddings.py
+++ b/vaannotate/vaannotate_ai_backend/core/embeddings.py
@@ -12,13 +12,13 @@ import re
 import time
 import unicodedata
 from collections import Counter, defaultdict
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
 from sentence_transformers import CrossEncoder, SentenceTransformer
 from ..utils.runtime import iter_with_bar as _iter_with_bar
+from .index_config import IndexConfig
 
 if TYPE_CHECKING:
     from ..config import ModelConfig
@@ -35,16 +35,6 @@ except Exception:
         from langchain.text_splitter import RecursiveCharacterTextSplitter  # type: ignore
     except Exception:
         raise ImportError("Please install langchain-text-splitters or langchain to use RecursiveCharacterTextSplitter.")
-@dataclass
-class IndexConfig:
-    type: str = "flat"    # flat | hnsw | ivf
-    nlist: int = 2048     # IVF lists
-    nprobe: int = 32      # IVF search probes
-    hnsw_M: int = 32      # HNSW graph degree
-    hnsw_efSearch: int = 64
-    persist: bool = True
-
-
 def _detect_device():
     import os
     # Allow explicit override when the caller wants to pin models to a device.
@@ -758,5 +748,4 @@ class EmbeddingStore:
                 except Exception:
                     continue
         return [i for i,m in enumerate(self.chunk_meta) if m.get("unit_id")==uid]
-
 

--- a/vaannotate/vaannotate_ai_backend/core/index_config.py
+++ b/vaannotate/vaannotate_ai_backend/core/index_config.py
@@ -1,0 +1,19 @@
+"""Lightweight index configuration types for retrieval backends.
+
+This module intentionally avoids importing heavyweight ML dependencies so it can
+be imported safely by CLI/config code paths that do not need model loading.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class IndexConfig:
+    type: str = "flat"    # flat | hnsw | ivf
+    nlist: int = 2048     # IVF lists
+    nprobe: int = 32      # IVF search probes
+    hnsw_M: int = 32      # HNSW graph degree
+    hnsw_efSearch: int = 64
+    persist: bool = True


### PR DESCRIPTION
### Motivation
- CLI resume and other config-only entrypoints were failing at import time because `config` transitively imported `core.embeddings`, which imports `sentence_transformers`/`torch` and can raise Windows DLL initialization errors (e.g. `WinError 1114`).
- The intent of this change is to prevent heavyweight ML dependencies from being loaded during simple CLI/config operations so those flows don't fail before job logic runs.

### Description
- Added a lightweight `core/index_config.py` module that defines `IndexConfig` without importing any ML libraries so config-only code paths remain safe to import.
- Updated `config.py` to import `IndexConfig` from the new lightweight module instead of `core.embeddings`.
- Refactored `core/__init__.py` to lazily export `DataRepository`, embedding/retrieval symbols and `IndexConfig` via `__getattr__`, avoiding eager imports of `sentence_transformers`/`torch` on module import.
- Modified `core/embeddings.py` to import `IndexConfig` from the new module and removed the duplicate local definition so embedding behaviour is unchanged while decoupling import timing.

### Testing
- Ran `python -m compileall vaannotate/vaannotate_ai_backend/core/__init__.py vaannotate/vaannotate_ai_backend/core/index_config.py vaannotate/vaannotate_ai_backend/core/embeddings.py vaannotate/vaannotate_ai_backend/config.py` to ensure files compile, which succeeded.
- Performed a smoke test by instantiating `OrchestratorConfig` with `python - <<'PY'\nfrom vaannotate.vaannotate_ai_backend.config import OrchestratorConfig\ncfg = OrchestratorConfig()\nprint(type(cfg.index).__name__, cfg.index.type)\nPY` to verify `IndexConfig` can be loaded without touching `torch`, which succeeded (printed `IndexConfig flat`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ff0b4d7483278f359815b0cf6d5d)