### PR TITLE
Move IndexConfig to lightweight module and add lazy imports to avoid heavy ML imports on CLI paths

### DIFF
--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from .core.embeddings import IndexConfig
+from .core.index_config import IndexConfig
 
 
 def _env_int(name: str, default: Optional[int] = None) -> Optional[int]:

--- a/vaannotate/vaannotate_ai_backend/core/__init__.py
+++ b/vaannotate/vaannotate_ai_backend/core/__init__.py
@@ -1,13 +1,19 @@
-"""Core primitives for the VAAnnotate AI backend."""
+"""Core primitives for the VAAnnotate AI backend.
 
-from .data import DataRepository
-from .embeddings import (
-    EmbeddingStore,
-    IndexConfig,
-    Models,
-    build_models_from_env,
-)
-from .retrieval import RetrievalCoordinator, SemanticQuery
+Exports are loaded lazily so importing ``vaannotate_ai_backend.core`` does not
+eagerly import heavyweight ML dependencies (for example torch/sentence-transformers)
+on CLI code paths that only need lightweight config types.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .data import DataRepository
+    from .embeddings import EmbeddingStore, Models, build_models_from_env
+    from .index_config import IndexConfig
+    from .retrieval import RetrievalCoordinator, SemanticQuery
 
 __all__ = [
     "DataRepository",
@@ -18,3 +24,27 @@ __all__ = [
     "RetrievalCoordinator",
     "SemanticQuery",
 ]
+
+
+def __getattr__(name: str):
+    if name == "DataRepository":
+        from .data import DataRepository
+
+        return DataRepository
+    if name in {"EmbeddingStore", "Models", "build_models_from_env"}:
+        from .embeddings import EmbeddingStore, Models, build_models_from_env
+
+        return {
+            "EmbeddingStore": EmbeddingStore,
+            "Models": Models,
+            "build_models_from_env": build_models_from_env,
+        }[name]
+    if name == "IndexConfig":
+        from .index_config import IndexConfig
+
+        return IndexConfig
+    if name in {"RetrievalCoordinator", "SemanticQuery"}:
+        from .retrieval import RetrievalCoordinator, SemanticQuery
+
+        return {"RetrievalCoordinator": RetrievalCoordinator, "SemanticQuery": SemanticQuery}[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vaannotate/vaannotate_ai_backend/core/embeddings.py
+++ b/vaannotate/vaannotate_ai_backend/core/embeddings.py
@@ -12,13 +12,13 @@ import re
 import time
 import unicodedata
 from collections import Counter, defaultdict
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
 from sentence_transformers import CrossEncoder, SentenceTransformer
 from ..utils.runtime import iter_with_bar as _iter_with_bar
+from .index_config import IndexConfig
 
 if TYPE_CHECKING:
     from ..config import ModelConfig
@@ -35,16 +35,6 @@ except Exception:
         from langchain.text_splitter import RecursiveCharacterTextSplitter  # type: ignore
     except Exception:
         raise ImportError("Please install langchain-text-splitters or langchain to use RecursiveCharacterTextSplitter.")
-@dataclass
-class IndexConfig:
-    type: str = "flat"    # flat | hnsw | ivf
-    nlist: int = 2048     # IVF lists
-    nprobe: int = 32      # IVF search probes
-    hnsw_M: int = 32      # HNSW graph degree
-    hnsw_efSearch: int = 64
-    persist: bool = True
-
-
 def _detect_device():
     import os
     # Allow explicit override when the caller wants to pin models to a device.
@@ -758,5 +748,4 @@ class EmbeddingStore:
                 except Exception:
                     continue
         return [i for i,m in enumerate(self.chunk_meta) if m.get("unit_id")==uid]
-
 

--- a/vaannotate/vaannotate_ai_backend/core/index_config.py
+++ b/vaannotate/vaannotate_ai_backend/core/index_config.py
@@ -1,0 +1,19 @@
+"""Lightweight index configuration types for retrieval backends.
+
+This module intentionally avoids importing heavyweight ML dependencies so it can
+be imported safely by CLI/config code paths that do not need model loading.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class IndexConfig:
+    type: str = "flat"    # flat | hnsw | ivf
+    nlist: int = 2048     # IVF lists
+    nprobe: int = 32      # IVF search probes
+    hnsw_M: int = 32      # HNSW graph degree
+    hnsw_efSearch: int = 64
+    persist: bool = True

--- a/vaannotate/vaannotate_ai_backend/orchestration.py
+++ b/vaannotate/vaannotate_ai_backend/orchestration.py
@@ -4,29 +4,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
-from typing import Mapping, Sequence
+from typing import TYPE_CHECKING, Mapping, Sequence
 
 from .config import OrchestratorConfig, Paths
 from .core.data import DataRepository
-from .core.embeddings import EmbeddingStore, Models, build_models_from_env
 from .label_configs import LabelConfigBundle
-from .llm_backends import build_llm_backend
-from .pipelines.active_learning import ActiveLearningPipeline
-from .pipelines.inference import InferencePipeline
-from .services import (
-    ActiveLearningSelector,
-    ContextBuilder,
-    DiversitySelector,
-    DisagreementScorer,
-    LLMLabeler,
-    LLMUncertaintyScorer,
-)
-from .services.disagreement_expander import DisagreementExpander
-from .services.pooling import LabelAwarePooler, kcenter_select
-from .services.rag_retriever import RAGRetriever
 from .utils.io import read_table
 from .utils.jsonish import _jsonify_cols
 from .utils.runtime import check_cancelled, iter_with_bar
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .core.embeddings import EmbeddingStore, Models
+    from .pipelines.active_learning import ActiveLearningPipeline
+    from .pipelines.inference import InferencePipeline
+    from .services import LLMLabeler
 
 
 def _build_shared_components(
@@ -45,8 +36,12 @@ def _build_shared_components(
     repo = DataRepository(notes_df, ann_df, phenotype_level=phenotype_level)
 
     if models is None:
+        from .core.embeddings import build_models_from_env
+
         models = build_models_from_env(cfg.models)
     if store is None:
+        from .core.embeddings import EmbeddingStore
+
         store = EmbeddingStore(
             models,
             cache_dir=paths.cache_dir,
@@ -88,6 +83,10 @@ def _build_shared_components(
                 setattr(cfg.llm, "few_shot_examples", extracted)
             except Exception:
                 pass
+    from .llm_backends import build_llm_backend
+    from .services import ContextBuilder
+    from .services.rag_retriever import RAGRetriever
+
     rag = RAGRetriever(
         store,
         models,
@@ -141,7 +140,7 @@ def _build_shared_components(
 
 
 def _build_rerank_rule_overrides(
-    llm_labeler: LLMLabeler, rules_map: Mapping[str, str]
+    llm_labeler: "LLMLabeler", rules_map: Mapping[str, str]
 ) -> dict[str, str]:
     if not llm_labeler or not isinstance(rules_map, Mapping):
         return {}
@@ -188,6 +187,16 @@ def build_active_learning_runner(
     models: Models | None = None,
     store: EmbeddingStore | None = None,
 ) -> ActiveLearningPipeline:
+    from .pipelines.active_learning import ActiveLearningPipeline
+    from .services import (
+        ActiveLearningSelector,
+        DiversitySelector,
+        DisagreementScorer,
+        LLMUncertaintyScorer,
+    )
+    from .services.disagreement_expander import DisagreementExpander
+    from .services.pooling import LabelAwarePooler, kcenter_select
+
     components = _build_shared_components(
         paths,
         cfg,
@@ -262,6 +271,8 @@ def build_inference_runner(
     models: Models | None = None,
     store: EmbeddingStore | None = None,
 ) -> InferencePipeline:
+    from .pipelines.inference import InferencePipeline
+
     components = _build_shared_components(
         paths,
         cfg,
@@ -302,6 +313,8 @@ class BackendSession:
         constructing the EmbeddingStore, but does not instantiate any
         downstream components (retriever, labeler, etc.).
         """
+        from .core.embeddings import EmbeddingStore, build_models_from_env
+
         models = build_models_from_env(cfg.models)
         store = EmbeddingStore(
             models,


### PR DESCRIPTION
### Motivation
- Avoid importing heavyweight ML dependencies (torch/sentence-transformers/faiss/langchain) when importing top-level `vaannotate_ai_backend.core` or CLI/config code paths by deferring model-heavy imports.
- Provide a small, safe location for `IndexConfig` so configuration code can import index types without pulling in embedding/model code.

### Description
- Added `vaannotate_ai_backend/core/index_config.py` which defines a lightweight `IndexConfig` dataclass and avoids ML dependencies. 
- Removed the `IndexConfig` dataclass from `core/embeddings.py` and updated `core/embeddings.py` and `vaannotate_ai_backend/config.py` to import `IndexConfig` from the new `core.index_config` module. 
- Reworked `vaannotate_ai_backend/core/__init__.py` to expose types lazily using `TYPE_CHECKING` and a `__getattr__` implementation so the module no longer eagerly imports heavy ML modules. 
- Updated `vaannotate_ai_backend/orchestration.py` to use `TYPE_CHECKING` for type-only imports and to import heavy symbols (`EmbeddingStore`, `Models`, `build_models_from_env`, `build_llm_backend`, services, and pipelines) inside functions to defer runtime import cost.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ff0b4d7483278f359815b0cf6d5d)