### PR TITLE
Add rich gating expressions, labelset manager, and protections against editing/deleting labelsets used in rounds

### DIFF
--- a/tests/test_client_annotation_form.py
+++ b/tests/test_client_annotation_form.py
@@ -44,13 +44,59 @@ def test_boolean_selection_clears_between_units(qt_app: QtWidgets.QApplication) 
     )
 
     form.set_schema([label])
-    form.load_unit("unit-1", {label.label_id: {"value": "yes"}})
+    form.load_unit("unit-1", {label.label_id: {"value": "yes"}}, {})
     widgets = form.label_widgets[label.label_id]
     group: QtWidgets.QButtonGroup = widgets["button_group"]  # type: ignore[index]
     checked_buttons = [button for button in group.buttons() if button.isChecked()]
     assert len(checked_buttons) == 1
     assert checked_buttons[0].property("option_value") == "yes"
 
-    form.load_unit("unit-2", {})
+    form.load_unit("unit-2", {}, {})
     assert all(not button.isChecked() for button in group.buttons())
 
+
+def test_gating_expr_or_contains_shows_child_only_when_parent_matches(qt_app: QtWidgets.QApplication) -> None:
+    ctx = AssignmentContext()
+    form = AnnotationForm(ctx, _dummy_cursor, lambda: None)
+
+    parent = LabelDefinition(
+        label_id="parent",
+        name="Parent Label",
+        type="categorical_multi",
+        required=False,
+        na_allowed=False,
+        rules="",
+        unit=None,
+        value_range=None,
+        gating_expr=None,
+        options=[
+            {"value": "X", "display": "X"},
+            {"value": "Y", "display": "Y"},
+            {"value": "Z", "display": "Z"},
+        ],
+    )
+    child = LabelDefinition(
+        label_id="child",
+        name="Child Label",
+        type="text",
+        required=False,
+        na_allowed=False,
+        rules="",
+        unit=None,
+        value_range=None,
+        gating_expr="Parent Label contains 'X' or Parent Label contains 'Y'",
+        options=[],
+    )
+    form.set_schema([parent, child])
+    form.load_unit("unit-1", {}, {})
+
+    child_row = form.label_widgets["child"]["row_widget"]  # type: ignore[index]
+    assert isinstance(child_row, QtWidgets.QWidget)
+    assert child_row.isVisible() is False
+
+    parent_boxes = form.label_widgets["parent"]["checkboxes"]  # type: ignore[index]
+    parent_boxes[2].setChecked(True)  # Z
+    assert child_row.isVisible() is False
+
+    parent_boxes[0].setChecked(True)  # X
+    assert child_row.isVisible() is True

--- a/tests/test_label_dependencies.py
+++ b/tests/test_label_dependencies.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vaannotate.project import build_label_config
 from vaannotate.vaannotate_ai_backend.services.label_dependencies import evaluate_gating
 
 
@@ -16,3 +22,35 @@ def test_evaluate_gating_categorical_contains_with_or_logic() -> None:
 
     assert evaluate_gating("Child", "u1", parent_preds, label_types, label_config) is True
     assert evaluate_gating("Child", "u2", {("u2", "Parent"): "A,Z"}, label_types, label_config) is False
+
+
+def test_evaluate_gating_uses_build_label_config_rich_expr() -> None:
+    labelset = {
+        "labelset_id": "ls_or_contains",
+        "labelset_name": "Demo OR/contains",
+        "labels": [
+            {
+                "label_id": "Parent",
+                "name": "Parent Label",
+                "type": "categorical_multi",
+                "required": False,
+                "options": [
+                    {"value": "X", "display": "X"},
+                    {"value": "Y", "display": "Y"},
+                    {"value": "Z", "display": "Z"},
+                ],
+            },
+            {
+                "label_id": "Child",
+                "name": "Child Label",
+                "type": "text",
+                "required": False,
+                "gating_expr": "Parent Label contains 'X' or Parent Label contains 'Y'",
+                "options": [],
+            },
+        ],
+    }
+    label_config = build_label_config(labelset)
+    label_types = {"Parent": "categorical_multi", "Child": "text"}
+    assert evaluate_gating("Child", "u1", {("u1", "Parent"): "A,Z"}, label_types, label_config) is False
+    assert evaluate_gating("Child", "u1", {("u1", "Parent"): "A,Y,Z"}, label_types, label_config) is True

--- a/tests/test_project_context.py
+++ b/tests/test_project_context.py
@@ -13,6 +13,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from vaannotate.AdminApp.main import ProjectContext
+from vaannotate.project import init_project
 
 
 def test_project_context_defers_file_deletion(tmp_path: Path) -> None:
@@ -47,3 +48,81 @@ def test_registering_artifact_clears_pending_deletion(tmp_path: Path) -> None:
 
     ctx.register_text_file(text_path, "sample")
     assert not ctx._pending_deletions
+
+
+def test_project_context_allows_same_label_ids_across_labelsets(tmp_path: Path) -> None:
+    paths = init_project(tmp_path / "proj", "proj", "Project", "tester")
+    ctx = ProjectContext()
+    ctx.open_project(paths.root)
+    pheno = ctx.create_phenotype(name="Phen", level="single_doc", description="")
+
+    for labelset_id in ("ls_a", "ls_b"):
+        ctx.create_labelset(
+            labelset_id=labelset_id,
+            created_by="tester",
+            notes="",
+            include_reasoning=False,
+            pheno_id=pheno.pheno_id,
+            labels=[
+                {
+                    "label_id": "colitis",
+                    "name": "Colitis",
+                    "type": "boolean",
+                    "required": False,
+                    "na_allowed": False,
+                    "rules": "",
+                    "options": [{"value": "yes", "display": "Yes"}],
+                }
+            ],
+        )
+
+    details_a = ctx.load_labelset_details("ls_a")
+    details_b = ctx.load_labelset_details("ls_b")
+    assert details_a and details_b
+    assert details_a["labels"][0]["label_id"] == "colitis"
+    assert details_b["labels"][0]["label_id"] == "colitis"
+
+
+def test_project_context_blocks_update_delete_for_labelsets_used_by_rounds(tmp_path: Path) -> None:
+    paths = init_project(tmp_path / "proj", "proj", "Project", "tester")
+    ctx = ProjectContext()
+    ctx.open_project(paths.root)
+    pheno = ctx.create_phenotype(name="Phen", level="single_doc", description="")
+    ctx.create_labelset(
+        labelset_id="ls_used",
+        created_by="tester",
+        notes="",
+        include_reasoning=False,
+        pheno_id=pheno.pheno_id,
+        labels=[
+            {
+                "label_id": "colitis",
+                "name": "Colitis",
+                "type": "boolean",
+                "required": False,
+                "na_allowed": False,
+                "rules": "",
+                "options": [{"value": "yes", "display": "Yes"}],
+            }
+        ],
+    )
+    db = ctx.require_db()
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            INSERT INTO rounds(round_id,pheno_id,round_number,labelset_id,config_hash,rng_seed,status,created_at)
+            VALUES (?,?,?,?,?,?,?,?)
+            """,
+            ("r1", pheno.pheno_id, 1, "ls_used", "hash", 1, "draft", "2026-01-01T00:00:00"),
+        )
+    assert ctx.labelset_round_usage("ls_used") == 1
+    with pytest.raises(RuntimeError):
+        ctx.update_labelset(
+            labelset_id="ls_used",
+            created_by="tester",
+            notes="updated",
+            include_reasoning=False,
+            labels=[],
+        )
+    with pytest.raises(RuntimeError):
+        ctx.delete_labelset("ls_used")

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -4277,6 +4277,15 @@ class ProjectContext(QtCore.QObject):
             rows = conn.execute("SELECT label_id FROM labels").fetchall()
         return {str(row["label_id"]) for row in rows if row["label_id"]}
 
+    def labelset_round_usage(self, labelset_id: str) -> int:
+        db = self.require_db()
+        with db.connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) AS count FROM rounds WHERE labelset_id=?",
+                (labelset_id,),
+            ).fetchone()
+        return int((row["count"] if row else 0) or 0)
+
     def list_label_sets_for_pheno(self, pheno_id: str) -> List[Dict[str, object]]:
         db = self.require_db()
         with db.connect() as conn:
@@ -4528,6 +4537,82 @@ class ProjectContext(QtCore.QObject):
         self._mark_dirty()
         self.project_changed.emit()
         return record
+
+    def update_labelset(
+        self,
+        *,
+        labelset_id: str,
+        created_by: str,
+        notes: str,
+        include_reasoning: bool,
+        labels: List[Dict[str, object]],
+    ) -> None:
+        if self.labelset_round_usage(labelset_id) > 0:
+            raise RuntimeError("Label sets already used in rounds cannot be edited.")
+        db = self.require_db()
+        with db.transaction() as conn:
+            conn.execute(
+                """
+                UPDATE label_sets
+                SET created_by=?, notes=?, include_reasoning=?
+                WHERE labelset_id=?
+                """,
+                (created_by, notes, 1 if include_reasoning else 0, labelset_id),
+            )
+            conn.execute("DELETE FROM label_options WHERE labelset_id=?", (labelset_id,))
+            conn.execute("DELETE FROM labels WHERE labelset_id=?", (labelset_id,))
+            for order_index, label in enumerate(labels):
+                label_record = models.Label(
+                    label_id=label["label_id"],
+                    labelset_id=labelset_id,
+                    name=label["name"],
+                    type=label["type"],
+                    required=1 if label.get("required") else 0,
+                    order_index=order_index,
+                    rules=label.get("rules", ""),
+                    gating_expr=label.get("gating_expr"),
+                    na_allowed=1 if label.get("na_allowed") else 0,
+                    include_reasoning=1 if label.get("include_reasoning", include_reasoning) else 0,
+                    unit=label.get("unit"),
+                    min=label.get("min"),
+                    max=label.get("max"),
+                    keywords_json=json.dumps(label.get("keywords"))
+                    if isinstance(label.get("keywords"), (list, dict))
+                    else None,
+                    few_shot_json=json.dumps(label.get("few_shot_examples"))
+                    if isinstance(label.get("few_shot_examples"), list)
+                    else None,
+                )
+                label_record.save(conn)
+                for opt_index, option in enumerate(label.get("options", [])):
+                    option_record = models.LabelOption(
+                        option_id=option.get("option_id") or str(uuid.uuid4()),
+                        labelset_id=labelset_id,
+                        label_id=label_record.label_id,
+                        value=str(option.get("value", "")),
+                        display=str(option.get("display", option.get("value", ""))),
+                        order_index=opt_index,
+                        weight=option.get("weight"),
+                    )
+                    option_record.save(conn)
+        self._mark_dirty()
+        self.project_changed.emit()
+
+    def delete_labelset(self, labelset_id: str) -> None:
+        if self.labelset_round_usage(labelset_id) > 0:
+            raise RuntimeError("Label sets already used in rounds cannot be removed.")
+        db = self.require_db()
+        with db.transaction() as conn:
+            conn.execute("DELETE FROM label_options WHERE labelset_id=?", (labelset_id,))
+            conn.execute("DELETE FROM labels WHERE labelset_id=?", (labelset_id,))
+            conn.execute("DELETE FROM label_sets WHERE labelset_id=?", (labelset_id,))
+        project_root = self.project_root
+        if project_root:
+            labelset_dir = project_root / "label_sets" / labelset_id
+            if labelset_dir.exists():
+                shutil.rmtree(labelset_dir, ignore_errors=True)
+        self._mark_dirty()
+        self.project_changed.emit()
 
     def _ensure_phenotype_dir(self, name: str) -> Path:
         project_root = self.require_project()
@@ -4950,17 +5035,32 @@ class LabelEditorDialog(QtWidgets.QDialog):
 
 
 class LabelSetWizardDialog(QtWidgets.QDialog):
-    def __init__(self, ctx: ProjectContext, parent: Optional[QtWidgets.QWidget] = None) -> None:
+    def __init__(
+        self,
+        ctx: ProjectContext,
+        parent: Optional[QtWidgets.QWidget] = None,
+        *,
+        initial_payload: Optional[Dict[str, object]] = None,
+    ) -> None:
         super().__init__(parent)
         self.ctx = ctx
+        self._initial_payload = dict(initial_payload) if isinstance(initial_payload, dict) else None
+        self._editing_existing = self._initial_payload is not None
+        self._initial_labelset_id = (
+            str(self._initial_payload.get("labelset_id") or "").strip()
+            if self._initial_payload
+            else ""
+        )
         self.labels: List[Dict[str, object]] = []
         self.label_keywords: Dict[str, List[str]] = {}
         self.label_queries: Dict[str, str] = {}
         self.label_few_shot: Dict[str, List[Dict[str, str]]] = {}
-        self.setWindowTitle("Create label set")
+        self.setWindowTitle("Edit label set" if self._editing_existing else "Create label set")
         self.resize(520, 640)
         self._setup_ui()
         self._populate_copy_sources()
+        if self._initial_payload:
+            self._load_initial_payload(self._initial_payload)
 
     def _setup_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
@@ -5031,8 +5131,12 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         self.copy_combo.blockSignals(True)
         self.copy_combo.clear()
         self.copy_combo.addItem("Start from blank", None)
+        if self._editing_existing:
+            self.copy_combo.setEnabled(False)
         for row in self.ctx.list_label_sets():
             labelset_id = str(row["labelset_id"])
+            if self._editing_existing and labelset_id == self._initial_labelset_id:
+                continue
             created_at = ""
             if "created_at" in row.keys() and row["created_at"]:
                 created_at = str(row["created_at"])
@@ -5059,34 +5163,16 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
             return
         self._apply_copied_labelset(payload)
 
-    def _generate_unique_label_id(self, base_id: str, used_ids: Set[str]) -> str:
-        sanitized = re.sub(r"\s+", "_", base_id.strip()) if base_id.strip() else "label"
-        candidate = sanitized
-        if candidate in used_ids:
-            suffix = 2
-            candidate = f"{sanitized}_copy"
-            while candidate in used_ids:
-                candidate = f"{sanitized}_{suffix}"
-                suffix += 1
-        used_ids.add(candidate)
-        return candidate
-
     def _apply_copied_labelset(self, payload: Dict[str, object]) -> None:
         if hasattr(self, "include_reasoning_checkbox"):
             self.include_reasoning_checkbox.setChecked(bool(payload.get("include_reasoning")))
-        used_ids = set(self.ctx.list_all_label_ids())
         new_labels: List[Dict[str, object]] = []
-        id_map: Dict[str, str] = {}
         raw_labels = payload.get("labels") or []
         if isinstance(raw_labels, list):
             for label in raw_labels:
                 if not isinstance(label, (dict, ABCMapping)):
                     continue
                 label_data = dict(label)
-                old_id = str(label_data.get("label_id") or "")
-                new_id = self._generate_unique_label_id(old_id, used_ids)
-                id_map[old_id] = new_id
-                label_data["label_id"] = new_id
                 options_payload: List[Dict[str, object]] = []
                 options = label_data.get("options")
                 if isinstance(options, list):
@@ -5098,16 +5184,6 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
                         options_payload.append(option_data)
                 label_data["options"] = options_payload
                 new_labels.append(label_data)
-        for label in new_labels:
-            expr = label.get("gating_expr")
-            if not isinstance(expr, str) or not expr.strip():
-                continue
-            updated = expr
-            for old_id, new_id in id_map.items():
-                if not old_id:
-                    continue
-                updated = re.sub(rf"\b{re.escape(old_id)}\b", new_id, updated)
-            label["gating_expr"] = updated
         self.labels = new_labels
         self.label_keywords = {
             str(label.get("label_id") or ""): label.get("keywords", [])
@@ -5136,6 +5212,14 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         base_labelset_id = str(payload.get("labelset_id") or "").strip()
         if base_labelset_id:
             self.id_edit.setPlaceholderText(f"{base_labelset_id}_copy")
+
+    def _load_initial_payload(self, payload: Dict[str, object]) -> None:
+        self.id_edit.setText(str(payload.get("labelset_id") or ""))
+        self.id_edit.setReadOnly(True)
+        self.creator_edit.setText(str(payload.get("created_by") or self.creator_edit.text()))
+        self.notes_edit.setPlainText(str(payload.get("notes") or ""))
+        self.include_reasoning_checkbox.setChecked(bool(payload.get("include_reasoning")))
+        self._apply_copied_labelset(payload)
 
     def _refresh_label_list(self, preserve_resources: bool = True) -> None:
         self.label_list.clear()
@@ -5195,15 +5279,10 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
 
     def _add_label(self) -> None:
         existing_ids = {
-            str(label_id)
-            for label_id in self.ctx.list_all_label_ids()
-            if isinstance(label_id, str) and label_id
-        }
-        existing_ids.update(
             str(label.get("label_id"))
             for label in self.labels
             if isinstance(label.get("label_id"), str) and label.get("label_id")
-        )
+        }
         dialog = LabelEditorDialog(existing_ids=existing_ids, parent=self)
         if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
             return
@@ -5216,15 +5295,10 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         if row < 0 or row >= len(self.labels):
             return
         existing_ids = {
-            str(label_id)
-            for label_id in self.ctx.list_all_label_ids()
-            if isinstance(label_id, str) and label_id
-        }
-        existing_ids.update(
             str(label.get("label_id"))
             for index, label in enumerate(self.labels)
             if index != row and isinstance(label.get("label_id"), str) and label.get("label_id")
-        )
+        }
         dialog = LabelEditorDialog(existing_ids=existing_ids, data=self.labels[row], parent=self)
         if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
             return
@@ -5256,7 +5330,7 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
             QtWidgets.QMessageBox.warning(self, "Label set", "Enter a label set ID.")
             return
         existing = self.ctx.get_labelset(labelset_id)
-        if existing:
+        if existing and labelset_id != self._initial_labelset_id:
             QtWidgets.QMessageBox.warning(self, "Label set", "A label set with this ID already exists.")
             return
         if not self.labels:
@@ -5290,6 +5364,193 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
             "include_reasoning": bool(self.include_reasoning_checkbox.isChecked()),
             "labels": labels_payload,
         }
+
+
+class LabelSetManagerDialog(QtWidgets.QDialog):
+    def __init__(self, ctx: ProjectContext, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.ctx = ctx
+        self._entries: List[Dict[str, object]] = []
+        self.setWindowTitle("Manage label sets")
+        self.resize(760, 500)
+        self._setup_ui()
+        self._load()
+
+    def _setup_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        description = QtWidgets.QLabel(
+            "Add, edit, or remove project label sets. Label sets already used in rounds are locked."
+        )
+        description.setWordWrap(True)
+        layout.addWidget(description)
+
+        self.table = QtWidgets.QTableWidget(0, 5)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.table.setHorizontalHeaderLabels(
+            ["Label set", "Labels", "Created", "Created by", "Status"]
+        )
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        layout.addWidget(self.table)
+
+        button_row = QtWidgets.QHBoxLayout()
+        self.add_btn = QtWidgets.QPushButton("Add…")
+        self.edit_btn = QtWidgets.QPushButton("Edit…")
+        self.delete_btn = QtWidgets.QPushButton("Remove…")
+        close_btn = QtWidgets.QPushButton("Close")
+        self.add_btn.clicked.connect(self._on_add)
+        self.edit_btn.clicked.connect(self._on_edit)
+        self.delete_btn.clicked.connect(self._on_delete)
+        close_btn.clicked.connect(self.accept)
+        button_row.addWidget(self.add_btn)
+        button_row.addWidget(self.edit_btn)
+        button_row.addWidget(self.delete_btn)
+        button_row.addStretch(1)
+        button_row.addWidget(close_btn)
+        layout.addLayout(button_row)
+
+        self.table.selectionModel().selectionChanged.connect(self._update_actions)
+        self.table.itemDoubleClicked.connect(lambda _item: self._on_edit())
+
+    def _load(self) -> None:
+        rows = self.ctx.list_label_sets()
+        self._entries = []
+        self.table.setRowCount(0)
+        for row in rows:
+            record = dict(row)
+            labelset_id = str(record.get("labelset_id") or "")
+            if not labelset_id:
+                continue
+            usage_count = self.ctx.labelset_round_usage(labelset_id)
+            label_count = 0
+            payload = self.ctx.load_labelset_details(labelset_id)
+            if payload and isinstance(payload.get("labels"), list):
+                label_count = len(payload.get("labels") or [])
+            locked = usage_count > 0
+            self._entries.append(
+                {
+                    "labelset_id": labelset_id,
+                    "record": record,
+                    "usage_count": usage_count,
+                    "label_count": label_count,
+                    "locked": locked,
+                }
+            )
+
+        self.table.setRowCount(len(self._entries))
+        for idx, entry in enumerate(self._entries):
+            record = entry["record"]
+            labelset_id = str(entry["labelset_id"])
+            status = f"Locked (used in {entry['usage_count']} round(s))" if entry["locked"] else "Editable"
+            values = [
+                labelset_id,
+                str(entry["label_count"]),
+                str(record.get("created_at") or ""),
+                str(record.get("created_by") or ""),
+                status,
+            ]
+            for col, value in enumerate(values):
+                item = QtWidgets.QTableWidgetItem(value)
+                item.setData(QtCore.Qt.ItemDataRole.UserRole, labelset_id)
+                if entry["locked"]:
+                    item.setForeground(QtGui.QBrush(QtGui.QColor("#9aa0a6")))
+                self.table.setItem(idx, col, item)
+        if self._entries:
+            self.table.selectRow(0)
+        self._update_actions()
+
+    def _selected_entry(self) -> Optional[Dict[str, object]]:
+        row = self.table.currentRow()
+        if row < 0 or row >= len(self._entries):
+            return None
+        return self._entries[row]
+
+    def _update_actions(self) -> None:
+        entry = self._selected_entry()
+        locked = bool(entry.get("locked")) if entry else True
+        has_selection = entry is not None
+        self.edit_btn.setEnabled(has_selection and not locked)
+        self.delete_btn.setEnabled(has_selection and not locked)
+
+    def _on_add(self) -> None:
+        dialog = LabelSetWizardDialog(self.ctx, self)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        values = dialog.values()
+        try:
+            self.ctx.create_labelset(
+                labelset_id=str(values.get("labelset_id", "")),
+                created_by=str(values.get("created_by", "admin")),
+                notes=str(values.get("notes", "")),
+                include_reasoning=bool(values.get("include_reasoning")),
+                labels=[dict(label) for label in values.get("labels", [])],
+            )
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(self, "Label set", f"Failed to create label set: {exc}")
+            return
+        self._load()
+
+    def _on_edit(self) -> None:
+        entry = self._selected_entry()
+        if not entry:
+            return
+        if entry.get("locked"):
+            QtWidgets.QMessageBox.information(
+                self,
+                "Label set",
+                "Label sets already used in rounds cannot be edited.",
+            )
+            return
+        labelset_id = str(entry.get("labelset_id") or "")
+        payload = self.ctx.load_labelset_details(labelset_id)
+        if not payload:
+            return
+        dialog = LabelSetWizardDialog(self.ctx, self, initial_payload=payload)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        values = dialog.values()
+        try:
+            self.ctx.update_labelset(
+                labelset_id=labelset_id,
+                created_by=str(values.get("created_by", "admin")),
+                notes=str(values.get("notes", "")),
+                include_reasoning=bool(values.get("include_reasoning")),
+                labels=[dict(label) for label in values.get("labels", [])],
+            )
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(self, "Label set", f"Failed to update label set: {exc}")
+            return
+        self._load()
+
+    def _on_delete(self) -> None:
+        entry = self._selected_entry()
+        if not entry:
+            return
+        if entry.get("locked"):
+            QtWidgets.QMessageBox.information(
+                self,
+                "Label set",
+                "Label sets already used in rounds cannot be removed.",
+            )
+            return
+        labelset_id = str(entry.get("labelset_id") or "")
+        confirm = QtWidgets.QMessageBox.question(
+            self,
+            "Remove label set",
+            f"Remove label set '{labelset_id}'?",
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            QtWidgets.QMessageBox.StandardButton.No,
+        )
+        if confirm != QtWidgets.QMessageBox.StandardButton.Yes:
+            return
+        try:
+            self.ctx.delete_labelset(labelset_id)
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(self, "Label set", f"Failed to remove label set: {exc}")
+            return
+        self._load()
 
 
 class PhenotypeLabelSetsDialog(QtWidgets.QDialog):
@@ -9003,8 +9264,8 @@ class ProjectTreeWidget(QtWidgets.QTreeWidget):
         if node_type == "project":
             action = menu.addAction("Add phenotype…")
             action.triggered.connect(lambda: self._add_phenotype(item))
-            label_action = menu.addAction("Add label set…")
-            label_action.triggered.connect(lambda: self._add_labelset(item))
+            label_action = menu.addAction("Manage label sets…")
+            label_action.triggered.connect(lambda: self._manage_labelsets(item))
             corpus_action = menu.addAction("Create corpus…")
             corpus_action.triggered.connect(lambda: self._create_corpus(item))
         elif node_type == "corpus":
@@ -9077,8 +9338,12 @@ class ProjectTreeWidget(QtWidgets.QTreeWidget):
             return
         QtCore.QTimer.singleShot(0, lambda: self._select_corpus(record.corpus_id))
 
-    def _add_labelset(self, item: QtWidgets.QTreeWidgetItem) -> None:
+    def _manage_labelsets(self, item: QtWidgets.QTreeWidgetItem) -> None:
         del item
+        dialog = LabelSetManagerDialog(self.ctx, self)
+        dialog.exec()
+
+    def _add_labelset(self) -> None:
         dialog = LabelSetWizardDialog(self.ctx, self)
         if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
             return
@@ -9099,6 +9364,45 @@ class ProjectTreeWidget(QtWidgets.QTreeWidget):
             "Label set",
             f"Label set '{values.get('labelset_id')}' created.",
         )
+
+    def _edit_labelset(self, labelset_id: str) -> None:
+        payload = self.ctx.load_labelset_details(labelset_id)
+        if not payload:
+            QtWidgets.QMessageBox.warning(self, "Label set", f"Unable to load label set '{labelset_id}'.")
+            return
+        dialog = LabelSetWizardDialog(self.ctx, self, initial_payload=payload)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        values = dialog.values()
+        try:
+            self.ctx.update_labelset(
+                labelset_id=labelset_id,
+                created_by=str(values.get("created_by", "admin")),
+                notes=str(values.get("notes", "")),
+                include_reasoning=bool(values.get("include_reasoning")),
+                labels=[dict(label) for label in values.get("labels", [])],
+            )
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(self, "Label set", f"Failed to update label set: {exc}")
+            return
+        QtWidgets.QMessageBox.information(self, "Label set", f"Label set '{labelset_id}' updated.")
+
+    def _delete_labelset(self, labelset_id: str) -> None:
+        confirm = QtWidgets.QMessageBox.question(
+            self,
+            "Delete label set",
+            f"Delete label set '{labelset_id}'?",
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            QtWidgets.QMessageBox.StandardButton.No,
+        )
+        if confirm != QtWidgets.QMessageBox.StandardButton.Yes:
+            return
+        try:
+            self.ctx.delete_labelset(labelset_id)
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(self, "Label set", f"Failed to delete label set: {exc}")
+            return
+        QtWidgets.QMessageBox.information(self, "Label set", f"Label set '{labelset_id}' deleted.")
 
     def _view_labelsets(self, item: QtWidgets.QTreeWidgetItem) -> None:
         data = item.data(0, QtCore.Qt.ItemDataRole.UserRole) or {}

--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import sys
 import uuid
@@ -2231,19 +2232,141 @@ class AnnotationForm(QtWidgets.QScrollArea):
         expr = definition.gating_expr
         if not expr:
             return True
-        try:
-            field, expected = expr.split("==")
-        except ValueError:
+        conditions, logic = self._split_logical_conditions(expr)
+        if not conditions:
             return True
-        field = field.strip()
-        expected = expected.strip().strip("'\"")
-        parent_widgets = self._find_label_widgets(field)
-        if parent_widgets is None or not self._has_value(parent_widgets):
-            return False
-        value = values.get(field, "")
+        outcomes: List[bool] = []
+        for condition in conditions:
+            parsed = self._parse_condition(condition)
+            if not parsed:
+                continue
+            field = str(parsed.get("field") or "").strip()
+            if not field:
+                continue
+            parent_widgets = self._find_label_widgets(field)
+            if parent_widgets is None or not self._has_value(parent_widgets):
+                outcomes.append(False)
+                continue
+            outcomes.append(
+                self._matches_condition(
+                    values.get(field),
+                    str(parsed.get("op") or "in"),
+                    [str(v) for v in parsed.get("values", []) if v is not None],
+                )
+            )
+        if not outcomes:
+            return True
+        return any(outcomes) if logic == "OR" else all(outcomes)
+
+    @staticmethod
+    def _extract_condition_value(raw: str) -> Optional[str]:
+        text = raw.strip()
+        if not text:
+            return None
+        if text.startswith(("'", '"')) and text.endswith(("'", '"')) and len(text) >= 2:
+            return text[1:-1]
+        return text
+
+    @classmethod
+    def _parse_condition(cls, condition: str) -> Optional[Dict[str, object]]:
+        text = (condition or "").strip()
+        if not text:
+            return None
+
+        contains_match = re.match(
+            r"^(?P<field>.+?)\s+(?P<op>contains|not\s+contains)\s+(?P<rhs>.+)$",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if contains_match:
+            field = contains_match.group("field").strip()
+            rhs = cls._extract_condition_value(contains_match.group("rhs"))
+            if not field or rhs is None:
+                return None
+            op_token = contains_match.group("op").lower().replace(" ", "")
+            op = "notcontains" if op_token == "notcontains" else "contains"
+            return {"field": field, "op": op, "values": [rhs]}
+
+        in_match = re.match(
+            r"^(?P<field>.+?)\s+(?P<op>in|not\s+in)\s*\((?P<rhs>.+)\)\s*$",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if in_match:
+            field = in_match.group("field").strip()
+            raw_rhs = in_match.group("rhs")
+            vals = [
+                cls._extract_condition_value(part)
+                for part in re.split(r"\s*,\s*", raw_rhs)
+                if part.strip()
+            ]
+            values = [v for v in vals if v is not None]
+            if not field or not values:
+                return None
+            op_token = in_match.group("op").lower().replace(" ", "")
+            op = "notin" if op_token == "notin" else "in"
+            return {"field": field, "op": op, "values": values}
+
+        cmp_match = re.match(r"^(?P<field>.+?)\s*(?P<op>==|!=)\s*(?P<rhs>.+)$", text)
+        if cmp_match:
+            field = cmp_match.group("field").strip()
+            rhs = cls._extract_condition_value(cmp_match.group("rhs"))
+            if not field or rhs is None:
+                return None
+            op = "in" if cmp_match.group("op") == "==" else "notin"
+            return {"field": field, "op": op, "values": [rhs]}
+
+        return None
+
+    @staticmethod
+    def _split_logical_conditions(expr: str) -> Tuple[List[str], str]:
+        text = (expr or "").strip()
+        if not text:
+            return [], "AND"
+        parts = [p.strip() for p in re.split(r"\s+(and|or)\s+", text, flags=re.IGNORECASE) if p.strip()]
+        if len(parts) == 1:
+            return [parts[0]], "AND"
+        conditions: List[str] = []
+        operators: List[str] = []
+        for idx, part in enumerate(parts):
+            if idx % 2 == 0:
+                conditions.append(part)
+            else:
+                operators.append(part.upper())
+        if not operators:
+            return conditions, "AND"
+        if any(op != operators[0] for op in operators):
+            return conditions, "AND"
+        return conditions, operators[0]
+
+    @staticmethod
+    def _normalize_token(value: object) -> str:
+        return re.sub(r"\s+", " ", str(value or "").strip()).casefold()
+
+    @classmethod
+    def _value_tokens(cls, value: object) -> List[str]:
         if isinstance(value, list):
-            return expected in value
-        return str(value) == expected
+            return [cls._normalize_token(v) for v in value]
+        text = cls._normalize_token(value)
+        if not text:
+            return []
+        return [tok.strip() for tok in re.split(r"[,;\n]", text) if tok.strip()]
+
+    @classmethod
+    def _matches_condition(cls, parent_value: object, op: str, expected_values: List[str]) -> bool:
+        if not expected_values:
+            return False
+        expected = [cls._normalize_token(v) for v in expected_values]
+        scalar = cls._normalize_token(parent_value)
+        tokens = cls._value_tokens(parent_value)
+        op_key = (op or "in").strip().casefold()
+        if op_key == "contains":
+            return any(v in tokens for v in expected)
+        if op_key == "notcontains":
+            return all(v not in tokens for v in expected)
+        if op_key == "notin":
+            return scalar not in expected
+        return scalar in expected
 
     def _find_label_widgets(self, field: str) -> Optional[Dict[str, object]]:
         for widgets in self.label_widgets.values():


### PR DESCRIPTION
### Motivation
- Enable richer gating logic in the annotator so child labels can be shown/hidden based on expressive conditions like `contains`, `in`, `not in`, `==`, `!=` and combined `and`/`or` terms. 
- Prevent accidental modification or removal of label sets that have been used by rounds. 
- Provide a UI to inspect and manage label sets, with clear locking for label sets used by rounds.

### Description
- Implemented robust gating parsing and evaluation in `AnnotationForm` including `contains`/`not contains`, `in`/`not in`, `==`/`!=` and support for `and`/`or` combining logic via `_split_logical_conditions`, `_parse_condition`, `_matches_condition`, and token normalization functions, and added `import re`.
- Extended `LabelSetWizardDialog` to support editing via an `initial_payload` parameter, disable copying back onto itself, and pre-load initial data with `_load_initial_payload`.
- Added `labelset_round_usage`, `update_labelset`, and `delete_labelset` to `ProjectContext` to report usage counts and to block updates/deletes when a label set has been used in rounds.
- Added a `LabelSetManagerDialog` UI to list label sets, show usage/locked status, and provide add/edit/remove actions that respect the usage protections, and wired it into the project tree with `_manage_labelsets`.
- Simplified copy behavior in `_apply_copied_labelset` to avoid automatic remapping of label IDs when copying a label set.
- Added and updated unit tests: extended `tests/test_client_annotation_form.py` to exercise the new gating semantics, added `tests/test_label_dependencies.py` test to ensure config building works with rich expressions, and expanded `tests/test_project_context.py` to verify same label IDs across label sets and to assert that updating/deleting label sets used by rounds raises `RuntimeError`.

### Testing
- Ran the test suite with `pytest` focusing on the modified units including `tests/test_client_annotation_form.py`, `tests/test_label_dependencies.py`, and `tests/test_project_context.py`, and the added tests completed successfully.
- Verified the new gating-related unit tests exercise visibility toggling for child labels and they passed. 
- Verified project-context tests that check labelset usage counting and blocking of edit/delete operations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e793cbb4e48327af1ce4ed537a7caf)