### PR TITLE
Import LLMLabeler and LabelAwarePooler in orchestration._build_shared_components

### DIFF
--- a/vaannotate/vaannotate_ai_backend/orchestration.py
+++ b/vaannotate/vaannotate_ai_backend/orchestration.py
@@ -84,7 +84,7 @@ def _build_shared_components(
             except Exception:
                 pass
     from .llm_backends import build_llm_backend
-    from .services import ContextBuilder
+    from .services import ContextBuilder, LLMLabeler
     from .services.rag_retriever import RAGRetriever
 
     rag = RAGRetriever(
@@ -115,6 +115,8 @@ def _build_shared_components(
 
     pooler = None
     if include_pooler:
+        from .services.pooling import LabelAwarePooler
+
         pooler = LabelAwarePooler(
             repo,
             store,


### PR DESCRIPTION
### Motivation
- Prevent a runtime `NameError` when assembling AI backend shared components where `LLMLabeler` was referenced but only available under `TYPE_CHECKING`.
- Ensure the pooler is constructed without referencing undefined names by importing `LabelAwarePooler` at use-site.

### Description
- Add a local runtime import of `LLMLabeler` alongside `ContextBuilder` in `orchestration._build_shared_components` so `LLMLabeler` is available when `include_llm=True`.
- Add a just-in-time import of `LabelAwarePooler` inside the `include_pooler` branch before constructing the pooler.
- No behavioral changes beyond fixing missing runtime imports; function signatures and return shape are unchanged.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_public_api.py` which passed (`1 passed`).
- Ran `python -m py_compile vaannotate/vaannotate_ai_backend/orchestration.py` which succeeded with no syntax errors.
- Attempted broader backend tests (`pytest -q tests/test_ai_backend_queries.py tests/test_ai_backend_config.py tests/test_large_corpus_jobs.py`) but collection failed in this environment due to unrelated setup issues (`ModuleNotFoundError` without `PYTHONPATH` and a local `pandas` attribute mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7dd0dece483278de38a11ca8bb4b9)