### PR TITLE
Preserve few-shot reasoning metadata for active-learning rounds

### DIFF
--- a/tests/test_project_label_config.py
+++ b/tests/test_project_label_config.py
@@ -301,6 +301,55 @@ def test_round_builder_prefers_labelset_reasoning_flag() -> None:
     assert builder._final_llm_include_reasoning(config, labelset={"include_reasoning": False}) is False
 
 
+def test_round_builder_preserves_few_shot_reasoning() -> None:
+    config = {
+        "ai_backend": {
+            "llm": {
+                "few_shot_examples": {
+                    "flag": [
+                        {
+                            "context": "ctx",
+                            "answer": '{"prediction":"yes"}',
+                            "reasoning": "because",
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    labelset = {
+        "labels": [
+            {
+                "label_id": "fallback",
+                "few_shot_examples": [
+                    {
+                        "context": "fallback ctx",
+                        "answer": '{"prediction":"no"}',
+                        "reasoning": "fallback reasoning",
+                    }
+                ],
+            }
+        ]
+    }
+
+    extracted = RoundBuilder._extract_few_shot_examples(config, labelset=labelset)
+
+    assert extracted["flag"] == [
+        {
+            "context": "ctx",
+            "answer": '{"prediction":"yes"}',
+            "reasoning": "because",
+        }
+    ]
+    assert extracted["fallback"] == [
+        {
+            "context": "fallback ctx",
+            "answer": '{"prediction":"no"}',
+            "reasoning": "fallback reasoning",
+        }
+    ]
+
+
 def test_fetch_labelset_backfills_reasoning_for_legacy_schema() -> None:
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -3001,6 +3001,53 @@ class AIAdvancedConfigDialog(QtWidgets.QDialog):
     }
 
     _WORKFLOW_FIELD_ALLOWLISTS: dict[str, dict[str, set[str]]] = {
+        "active_learning": {
+            "index": {"type", "nlist", "nprobe", "hnsw_M", "hnsw_efSearch", "persist"},
+            "rag": {
+                "chunk_size",
+                "chunk_overlap",
+                "normalize_embeddings",
+                "top_k_final",
+                "use_mmr",
+                "mmr_lambda",
+                "keyword_fraction",
+                "min_context_chunks",
+                "neighbor_hops",
+                "pool_factor",
+                "pool_oversample",
+            },
+            "llm": {
+                "model_name",
+                "backend",
+                "temperature",
+                "timeout",
+                "retry_max",
+                "retry_backoff",
+                "max_context_chars",
+                "rpm_limit",
+                "include_reasoning",
+                "azure_api_version",
+                "azure_endpoint",
+                "local_model_dir",
+                "local_max_seq_len",
+                "local_max_new_tokens",
+                "context_order",
+            },
+            "select": {"batch_size", "pct_disagreement", "pct_uncertain", "pct_easy_qc", "pct_diversity"},
+            "llmfirst": {
+                "inference_labeling_mode",
+                "single_prompt_max_labels",
+                "single_prompt_max_chars",
+                "single_doc_context",
+                "single_doc_full_context_max_chars",
+                "context_order",
+                "progress_min_interval_s",
+            },
+            "disagree": {"method", "top_n", "min_gap"},
+            "diversity": {"enabled", "method", "k_clusters", "max_per_cluster"},
+            "scjitter": {"enabled", "temp_jitter", "top_p_jitter"},
+            "orchestrator": {"final_llm_labeling", "final_llm_labeling_n_consistency"},
+        },
         "prompt_precompute": {
             "index": {"type", "nlist", "nprobe", "hnsw_M", "hnsw_efSearch", "persist"},
             "rag": {
@@ -6172,6 +6219,8 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                             example["context"] = str(entry.get("context"))
                         if entry.get("answer"):
                             example["answer"] = str(entry.get("answer"))
+                        if entry.get("reasoning"):
+                            example["reasoning"] = str(entry.get("reasoning"))
                         if example:
                             parsed_examples.append(example)
                     if parsed_examples:

--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -1193,6 +1193,8 @@ class RoundBuilder:
                         example["context"] = str(entry.get("context"))
                     if entry.get("answer") is not None:
                         example["answer"] = str(entry.get("answer"))
+                    if entry.get("reasoning") is not None:
+                        example["reasoning"] = str(entry.get("reasoning"))
                     if example:
                         parsed_examples.append(example)
                 if parsed_examples:
@@ -1219,6 +1221,8 @@ class RoundBuilder:
                             example["context"] = str(entry.get("context"))
                         if entry.get("answer") is not None:
                             example["answer"] = str(entry.get("answer"))
+                        if entry.get("reasoning") is not None:
+                            example["reasoning"] = str(entry.get("reasoning"))
                         if example:
                             parsed_examples.append(example)
                     if parsed_examples and label_id not in cleaned:

--- a/vaannotate/vaannotate_ai_backend/orchestration.py
+++ b/vaannotate/vaannotate_ai_backend/orchestration.py
@@ -72,6 +72,8 @@ def _build_shared_components(
                     payload["context"] = str(example.get("context"))
                 if example.get("answer") is not None:
                     payload["answer"] = str(example.get("answer"))
+                if example.get("reasoning") is not None:
+                    payload["reasoning"] = str(example.get("reasoning"))
                 if payload:
                     parsed.append(payload)
             if parsed:


### PR DESCRIPTION
### Motivation
- Few-shot examples contained a `reasoning` field that was being dropped when rounds were built, so rationale text wasn't reaching the AI backend. 
- Few-shot/keyword inputs on the Round Builder advanced settings should not override label-set-owned values for active-learning workflows. 
- Ensure downstream orchestration receives the same few-shot payload (including `reasoning`) the round builder assembles.

### Description
- Preserve per-example `reasoning` when hydrating few-shot examples in the Round Builder UI (AdminApp). (changes in `vaannotate/AdminApp/main.py`)
- Preserve `reasoning` in `RoundBuilder._extract_few_shot_examples(...)` so config-sourced and labelset-sourced examples include `reasoning` when returned. (changes in `vaannotate/rounds.py`)
- Preserve `reasoning` when the AI orchestration fallback materializes `cfg.llm.few_shot_examples` from label configuration. (changes in `vaannotate/vaannotate_ai_backend/orchestration.py`)
- Tighten the Active Learning advanced-settings allowlist to hide editable round-level few-shot/keyword fields so label-set metadata remains authoritative. (changes in `vaannotate/AdminApp/main.py`)
- Add a regression test `test_round_builder_preserves_few_shot_reasoning` validating both explicit override and labelset fallback paths. (changes in `tests/test_project_label_config.py`)

### Testing
- Ran `pytest -q tests/test_project_label_config.py::test_round_builder_preserves_few_shot_reasoning tests/test_project_label_config.py::test_round_builder_prefers_labelset_reasoning_flag` and both tests passed (`2 passed`).
- Ran `pytest -q tests/test_llm_reasoning.py::test_few_shot_reasoning_field_is_included_when_enabled` and it passed (`1 passed`).
- Verified Python syntax with `python -m py_compile` for the modified modules and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e22fba548327a197e362f075ffbd)