### PR TITLE
Add label-first sampling: backend, pipeline integration, Admin UI and tests

### DIFF
--- a/tests/test_label_first_sampling.py
+++ b/tests/test_label_first_sampling.py
@@ -1,0 +1,171 @@
+import types
+from pathlib import Path
+
+import pandas as pd
+
+from vaannotate.vaannotate_ai_backend.pipelines.active_learning import ActiveLearningPipeline
+from vaannotate.vaannotate_ai_backend.services.label_first import parse_label_first_targets
+
+
+class _Repo:
+    def __init__(self, notes: pd.DataFrame, ann: pd.DataFrame) -> None:
+        self.notes = notes
+        self.ann = ann
+
+    def exclude_units(self, excluded_ids) -> int:  # pragma: no cover - trivial
+        _ = excluded_ids
+        return 0
+
+    def notes_by_doc(self):  # pragma: no cover - trivial
+        return {}
+
+
+class _Store:
+    def build_chunk_index(self, *_args, **_kwargs):  # pragma: no cover - trivial
+        return None
+
+
+class _Selector:
+    def __init__(self) -> None:
+        self.label_types = {}
+        self.current_label_ids = set()
+        self.seen_units = set()
+        self.unseen_pairs = set()
+
+    def _empty_unit_frame(self) -> pd.DataFrame:  # pragma: no cover - unused for label-first
+        return pd.DataFrame(columns=["unit_id", "label_id", "label_type", "selection_reason"])
+
+
+class _Diversity:
+    def select_diverse_units(self, *_, **__):  # pragma: no cover - unused for label-first
+        return pd.DataFrame(columns=["unit_id", "label_id", "label_type", "selection_reason"])
+
+
+class _FamilyLabeler:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def label_family_for_unit(self, unit_id, label_types, per_label_rules, **_kwargs):
+        _ = label_types
+        _ = per_label_rules
+        prediction = "yes" if str(unit_id) in {"u1", "u3"} else "no"
+        return [{"unit_id": unit_id, "label_id": "label_a", "prediction": prediction}]
+
+
+class _CtxBuilder:
+    def __init__(self, bundle):
+        self.label_config_bundle = bundle
+
+    def build_context_for_label(self, unit_id, *_args, **_kwargs):
+        score = {"u1": 0.95, "u2": 0.10, "u3": 0.90, "u4": 0.20}.get(str(unit_id), 0.0)
+        return [{"score": score}]
+
+    def build_context_for_family(self, *_args, **_kwargs):  # pragma: no cover - unused in this test
+        return []
+
+
+class _Bundle:
+    def legacy_rules_map(self):
+        return {}
+
+    def legacy_label_types(self):
+        return {}
+
+    def current_rules_map(self, *_args, **_kwargs):
+        return {"label_a": "rule"}
+
+    def current_label_types(self, *_args, **_kwargs):
+        return {"label_a": "categorical"}
+
+    def label_maps(self, label_config=None, ann_df=None):
+        _ = label_config
+        _ = ann_df
+        return (
+            self.legacy_rules_map(),
+            self.legacy_label_types(),
+            self.current_rules_map(),
+            self.current_label_types(),
+        )
+
+
+def test_parse_label_first_targets_filters_invalid_entries() -> None:
+    parsed = parse_label_first_targets(
+        [
+            {"label_id": "a", "values": ["yes", "possible"], "quota": 2, "operator": "in"},
+            {"label_id": "", "values": ["x"], "quota": 1},
+            {"label_id": "b", "value": "ok", "quota": 0},
+        ]
+    )
+    assert len(parsed) == 1
+    assert parsed[0].label_id == "a"
+    assert parsed[0].values == ("yes", "possible")
+
+
+def test_active_learning_pipeline_label_first_sampling_hits_quota(tmp_path: Path, monkeypatch) -> None:
+    notes = pd.DataFrame(
+        [
+            {"unit_id": "u1", "doc_id": "d1", "text": "alpha"},
+            {"unit_id": "u2", "doc_id": "d2", "text": "beta"},
+            {"unit_id": "u3", "doc_id": "d3", "text": "gamma"},
+            {"unit_id": "u4", "doc_id": "d4", "text": "delta"},
+        ]
+    )
+    ann = pd.DataFrame(columns=["unit_id", "label_id"])
+
+    select_cfg = types.SimpleNamespace(
+        batch_size=2,
+        pct_disagreement=0.0,
+        pct_diversity=0.0,
+        pct_uncertain=0.0,
+        pct_easy_qc=0.0,
+        sampling_mode="label_first",
+        label_first_targets=[
+            {"label_id": "label_a", "values": ["yes"], "quota": 2, "operator": "in"}
+        ],
+        label_first_pathway="enriched",
+        label_first_pool_initial_size=4,
+        label_first_pool_growth_step=2,
+        label_first_pool_max_size=8,
+    )
+    cfg = types.SimpleNamespace(
+        select=select_cfg,
+        rag=types.SimpleNamespace(),
+        index=types.SimpleNamespace(),
+        llm=types.SimpleNamespace(model_name="stub"),
+        diversity=types.SimpleNamespace(),
+        llmfirst=types.SimpleNamespace(
+            enrich=True,
+            progress_min_interval_s=0.0,
+            final_llm_label_consistency=1,
+            inference_labeling_mode="family",
+        ),
+        scjitter=types.SimpleNamespace(),
+        final_llm_labeling=False,
+    )
+
+    repo = _Repo(notes=notes, ann=ann)
+    bundle = _Bundle()
+    pipeline = ActiveLearningPipeline(
+        data_repo=repo,
+        emb_store=_Store(),
+        ctx_builder=_CtxBuilder(bundle),
+        llm_labeler=types.SimpleNamespace(family_labeler_cls=_FamilyLabeler),
+        disagreement_scorer=types.SimpleNamespace(),
+        uncertainty_scorer=types.SimpleNamespace(),
+        diversity_selector=_Diversity(),
+        selector=_Selector(),
+        config=cfg,
+        paths=types.SimpleNamespace(outdir=str(tmp_path)),
+        label_config={"label_a": {"label_id": "label_a"}},
+        label_config_bundle=bundle,
+        disagreement_builder_fn=lambda *_args, **_kwargs: pd.DataFrame(),
+        uncertain_builder_fn=lambda *_args, **_kwargs: pd.DataFrame(),
+        certain_builder_fn=lambda *_args, **_kwargs: pd.DataFrame(),
+    )
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", lambda self, *a, **k: None)
+
+    result = pipeline.run()
+    assert not result.empty
+    assert set(result["unit_id"].tolist()) >= {"u1", "u3"}
+    assert set(result["selection_reason"].tolist()) == {"label_first"}

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -5967,6 +5967,8 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self._ai_engine_overrides: Dict[str, Any] = {}
         self._labelset_include_reasoning = False
         self._label_reasoning_by_label: Dict[str, bool] = {}
+        self._label_first_targets: List[Dict[str, object]] = []
+        self._label_first_label_catalog: Dict[str, Dict[str, object]] = {}
         self._assisted_review_reminder_shown = False
         self._llm_prompt_shown = False
         self.ctx.project_changed.connect(self._refresh_labelset_options)
@@ -6022,6 +6024,20 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             select_cfg["pct_easy_qc"] = float(self.ai_easy_pct.value())
         if hasattr(self, "ai_diversity_pct"):
             select_cfg["pct_diversity"] = float(self.ai_diversity_pct.value())
+        using_label_first = bool(getattr(self, "label_first_radio", None) and self.label_first_radio.isChecked())
+        select_cfg["sampling_mode"] = "label_first" if using_label_first else "active_learning"
+        if using_label_first:
+            select_cfg["label_first_targets"] = copy.deepcopy(self._label_first_targets)
+            if hasattr(self, "label_first_pathway_combo"):
+                select_cfg["label_first_pathway"] = str(
+                    self.label_first_pathway_combo.currentData() or "enriched"
+                )
+            if hasattr(self, "label_first_pool_initial_spin"):
+                select_cfg["label_first_pool_initial_size"] = int(self.label_first_pool_initial_spin.value())
+            if hasattr(self, "label_first_pool_growth_spin"):
+                select_cfg["label_first_pool_growth_step"] = int(self.label_first_pool_growth_spin.value())
+            if hasattr(self, "label_first_pool_max_spin"):
+                select_cfg["label_first_pool_max_size"] = int(self.label_first_pool_max_spin.value())
         base_cfg["select"] = select_cfg
         llm_cfg = base_cfg.get("llm", {}) if isinstance(base_cfg.get("llm"), Mapping) else {}
         backend_choice = self._current_ai_backend()
@@ -6107,6 +6123,58 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             value = select_cfg.get(key)
             if isinstance(widget, QtWidgets.QDoubleSpinBox) and isinstance(value, (int, float)):
                 widget.setValue(float(value))
+        sampling_mode = str(select_cfg.get("sampling_mode") or "").strip().lower()
+        if sampling_mode == "label_first" and hasattr(self, "label_first_radio"):
+            self.label_first_radio.setChecked(True)
+        elif sampling_mode == "active_learning" and hasattr(self, "active_learning_radio"):
+            self.active_learning_radio.setChecked(True)
+        targets = select_cfg.get("label_first_targets")
+        if isinstance(targets, Sequence):
+            parsed_targets: List[Dict[str, object]] = []
+            for entry in targets:
+                if not isinstance(entry, Mapping):
+                    continue
+                label_id = str(entry.get("label_id") or "").strip()
+                if not label_id:
+                    continue
+                values = entry.get("values")
+                value_list = (
+                    [str(v).strip() for v in values if str(v).strip()]
+                    if isinstance(values, Sequence) and not isinstance(values, (str, bytes))
+                    else []
+                )
+                try:
+                    quota = int(entry.get("quota") or 0)
+                except (TypeError, ValueError):
+                    quota = 0
+                if quota <= 0:
+                    continue
+                parsed_targets.append(
+                    {
+                        "label_id": label_id,
+                        "values": value_list,
+                        "quota": quota,
+                        "operator": str(entry.get("operator") or "in").strip().lower(),
+                    }
+                )
+            self._label_first_targets = parsed_targets
+            self._render_label_first_targets()
+        if hasattr(self, "label_first_pathway_combo"):
+            idx = self.label_first_pathway_combo.findData(str(select_cfg.get("label_first_pathway") or ""))
+            if idx >= 0:
+                self.label_first_pathway_combo.setCurrentIndex(idx)
+        if hasattr(self, "label_first_pool_initial_spin"):
+            value = select_cfg.get("label_first_pool_initial_size")
+            if isinstance(value, (int, float)):
+                self.label_first_pool_initial_spin.setValue(int(value))
+        if hasattr(self, "label_first_pool_growth_spin"):
+            value = select_cfg.get("label_first_pool_growth_step")
+            if isinstance(value, (int, float)):
+                self.label_first_pool_growth_spin.setValue(int(value))
+        if hasattr(self, "label_first_pool_max_spin"):
+            value = select_cfg.get("label_first_pool_max_size")
+            if isinstance(value, (int, float)):
+                self.label_first_pool_max_spin.setValue(int(value))
         llm_cfg = (
             effective_cfg.get("llm", {})
             if isinstance(effective_cfg.get("llm"), Mapping)
@@ -6283,6 +6351,135 @@ class RoundBuilderDialog(QtWidgets.QDialog):
 
         if updated:
             self._apply_ai_config_to_controls(self._ai_engine_overrides)
+        self._refresh_label_first_catalog(schema)
+
+    def _refresh_label_first_catalog(self, schema: Optional[Mapping[str, object]]) -> None:
+        catalog: Dict[str, Dict[str, object]] = {}
+        labels = schema.get("labels") if isinstance(schema, Mapping) else None
+        if isinstance(labels, Sequence):
+            for label in labels:
+                if not isinstance(label, Mapping):
+                    continue
+                label_id = str(label.get("label_id") or "")
+                if not label_id:
+                    continue
+                options = label.get("options")
+                option_values: List[str] = []
+                if isinstance(options, Sequence):
+                    for option in options:
+                        if not isinstance(option, Mapping):
+                            continue
+                        value = str(option.get("value") or "").strip()
+                        if value:
+                            option_values.append(value)
+                catalog[label_id] = {
+                    "name": str(label.get("name") or label_id),
+                    "options": option_values,
+                }
+        self._label_first_label_catalog = catalog
+        combo = getattr(self, "label_first_label_combo", None)
+        if not isinstance(combo, QtWidgets.QComboBox):
+            return
+        combo.blockSignals(True)
+        combo.clear()
+        for label_id, entry in sorted(catalog.items(), key=lambda item: str(item[1].get("name", item[0])).lower()):
+            display = f"{entry.get('name', label_id)} ({label_id})"
+            combo.addItem(display, label_id)
+        combo.blockSignals(False)
+        self._render_label_first_targets()
+
+    def _render_label_first_targets(self) -> None:
+        widget = getattr(self, "label_first_target_list", None)
+        if not isinstance(widget, QtWidgets.QListWidget):
+            return
+        widget.clear()
+        cleaned: List[Dict[str, object]] = []
+        for target in self._label_first_targets:
+            if not isinstance(target, Mapping):
+                continue
+            label_id = str(target.get("label_id") or "").strip()
+            if not label_id:
+                continue
+            values = target.get("values")
+            if isinstance(values, Sequence) and not isinstance(values, (str, bytes)):
+                parsed_values = [str(v).strip() for v in values if str(v).strip()]
+            else:
+                parsed_values = [str(target.get("value") or "").strip()] if str(target.get("value") or "").strip() else []
+            try:
+                quota = int(target.get("quota") or 0)
+            except (TypeError, ValueError):
+                quota = 0
+            if quota <= 0:
+                continue
+            operator = str(target.get("operator") or "in").strip().lower()
+            entry = {
+                "label_id": label_id,
+                "values": parsed_values,
+                "quota": quota,
+                "operator": operator if operator in {"equals", "in"} else "in",
+            }
+            cleaned.append(entry)
+            label_meta = self._label_first_label_catalog.get(label_id, {})
+            label_name = str(label_meta.get("name") or label_id)
+            match_label = "equals" if entry["operator"] == "equals" else "any of"
+            values_text = ", ".join(parsed_values) if parsed_values else "(any non-empty)"
+            item = QtWidgets.QListWidgetItem(
+                f"{label_name} [{label_id}] • {match_label}: {values_text} • quota: {quota}"
+            )
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, entry)
+            widget.addItem(item)
+        self._label_first_targets = cleaned
+
+    def _on_add_label_first_target(self) -> None:
+        label_id = ""
+        if isinstance(getattr(self, "label_first_label_combo", None), QtWidgets.QComboBox):
+            data = self.label_first_label_combo.currentData()
+            label_id = str(data or "").strip()
+        if not label_id:
+            QtWidgets.QMessageBox.warning(self, "Label-first sampling", "Select a label target first.")
+            return
+        operator = "in"
+        if isinstance(getattr(self, "label_first_match_combo", None), QtWidgets.QComboBox):
+            operator = str(self.label_first_match_combo.currentData() or "in").strip().lower()
+        raw_values = (
+            self.label_first_values_edit.text().strip()
+            if isinstance(getattr(self, "label_first_values_edit", None), QtWidgets.QLineEdit)
+            else ""
+        )
+        values = [part.strip() for part in re.split(r"[,\n]", raw_values) if part.strip()]
+        if operator == "equals" and values:
+            values = values[:1]
+        if operator == "equals" and not values:
+            QtWidgets.QMessageBox.warning(
+                self, "Label-first sampling", "Provide exactly one value when using Equals."
+            )
+            return
+        quota = int(self.label_first_quota_spin.value()) if hasattr(self, "label_first_quota_spin") else 0
+        if quota <= 0:
+            QtWidgets.QMessageBox.warning(self, "Label-first sampling", "Quota must be greater than zero.")
+            return
+        self._label_first_targets.append(
+            {
+                "label_id": label_id,
+                "values": values,
+                "quota": quota,
+                "operator": operator,
+            }
+        )
+        if isinstance(getattr(self, "label_first_values_edit", None), QtWidgets.QLineEdit):
+            self.label_first_values_edit.clear()
+        self._render_label_first_targets()
+
+    def _on_remove_label_first_target(self) -> None:
+        widget = getattr(self, "label_first_target_list", None)
+        if not isinstance(widget, QtWidgets.QListWidget):
+            return
+        row = widget.currentRow()
+        if row < 0:
+            return
+        if 0 <= row < len(self._label_first_targets):
+            self._label_first_targets.pop(row)
+        self._render_label_first_targets()
 
     def _open_ai_advanced_settings(self) -> None:
         config = self._build_ai_config_snapshot()
@@ -6533,13 +6730,76 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         method_layout = QtWidgets.QHBoxLayout(method_group)
         self.random_sampling_radio = QtWidgets.QRadioButton("Random sampling")
         self.active_learning_radio = QtWidgets.QRadioButton("Active learning backend")
+        self.label_first_radio = QtWidgets.QRadioButton("Label-first sampling")
         method_layout.addWidget(self.random_sampling_radio)
         method_layout.addWidget(self.active_learning_radio)
+        method_layout.addWidget(self.label_first_radio)
         method_layout.addStretch()
         self.random_sampling_radio.setChecked(True)
         self.random_sampling_radio.toggled.connect(self._on_generation_mode_changed)
         self.active_learning_radio.toggled.connect(self._on_generation_mode_changed)
+        self.label_first_radio.toggled.connect(self._on_generation_mode_changed)
         scroll_layout.addWidget(method_group)
+
+        self.label_first_container = QtWidgets.QGroupBox("Label-first targets")
+        label_first_layout = QtWidgets.QVBoxLayout(self.label_first_container)
+        label_first_help = QtWidgets.QLabel(
+            "Pick label/value targets with quotas. The backend iteratively enriches and labels "
+            "new pools until quotas are met or candidates are exhausted."
+        )
+        label_first_help.setWordWrap(True)
+        label_first_layout.addWidget(label_first_help)
+        target_row = QtWidgets.QHBoxLayout()
+        self.label_first_label_combo = QtWidgets.QComboBox()
+        self.label_first_label_combo.setInsertPolicy(QtWidgets.QComboBox.InsertPolicy.NoInsert)
+        target_row.addWidget(self.label_first_label_combo, 2)
+        self.label_first_match_combo = QtWidgets.QComboBox()
+        self.label_first_match_combo.addItem("Equals", "equals")
+        self.label_first_match_combo.addItem("Any of (OR)", "in")
+        target_row.addWidget(self.label_first_match_combo, 1)
+        self.label_first_values_edit = QtWidgets.QLineEdit()
+        self.label_first_values_edit.setPlaceholderText("Value or comma-separated values")
+        target_row.addWidget(self.label_first_values_edit, 2)
+        self.label_first_quota_spin = QtWidgets.QSpinBox()
+        self.label_first_quota_spin.setRange(1, 1000000)
+        self.label_first_quota_spin.setValue(10)
+        target_row.addWidget(self.label_first_quota_spin, 1)
+        self.label_first_add_target_btn = QtWidgets.QPushButton("Add target")
+        self.label_first_add_target_btn.clicked.connect(self._on_add_label_first_target)
+        target_row.addWidget(self.label_first_add_target_btn, 0)
+        label_first_layout.addLayout(target_row)
+
+        self.label_first_target_list = QtWidgets.QListWidget()
+        self.label_first_target_list.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        label_first_layout.addWidget(self.label_first_target_list)
+        target_actions = QtWidgets.QHBoxLayout()
+        self.label_first_remove_target_btn = QtWidgets.QPushButton("Remove selected")
+        self.label_first_remove_target_btn.clicked.connect(self._on_remove_label_first_target)
+        target_actions.addWidget(self.label_first_remove_target_btn)
+        target_actions.addStretch()
+        label_first_layout.addLayout(target_actions)
+
+        lf_opts = QtWidgets.QFormLayout()
+        self.label_first_pathway_combo = QtWidgets.QComboBox()
+        self.label_first_pathway_combo.addItem("Targeted enrichment", "enriched")
+        self.label_first_pathway_combo.addItem("Random iterative", "random_iterative")
+        lf_opts.addRow("Pathway", self.label_first_pathway_combo)
+        self.label_first_pool_initial_spin = QtWidgets.QSpinBox()
+        self.label_first_pool_initial_spin.setRange(10, 1000000)
+        self.label_first_pool_initial_spin.setValue(200)
+        lf_opts.addRow("Initial pool size", self.label_first_pool_initial_spin)
+        self.label_first_pool_growth_spin = QtWidgets.QSpinBox()
+        self.label_first_pool_growth_spin.setRange(1, 1000000)
+        self.label_first_pool_growth_spin.setValue(100)
+        lf_opts.addRow("Pool growth step", self.label_first_pool_growth_spin)
+        self.label_first_pool_max_spin = QtWidgets.QSpinBox()
+        self.label_first_pool_max_spin.setRange(10, 2000000)
+        self.label_first_pool_max_spin.setValue(2000)
+        lf_opts.addRow("Max pool size", self.label_first_pool_max_spin)
+        label_first_layout.addLayout(lf_opts)
+        scroll_layout.addWidget(self.label_first_container)
 
         self.random_config_container = QtWidgets.QWidget()
         random_layout = QtWidgets.QVBoxLayout(self.random_config_container)
@@ -7297,12 +7557,16 @@ class RoundBuilderDialog(QtWidgets.QDialog):
 
     def _using_ai_backend(self) -> bool:
         radio = getattr(self, "active_learning_radio", None)
-        return bool(radio and radio.isChecked())
+        label_first = getattr(self, "label_first_radio", None)
+        return bool((radio and radio.isChecked()) or (label_first and label_first.isChecked()))
 
     def _on_generation_mode_changed(self) -> None:
         using_ai = self._using_ai_backend()
+        using_label_first = bool(getattr(self, "label_first_radio", None) and self.label_first_radio.isChecked())
         if hasattr(self, "random_config_container"):
             self.random_config_container.setVisible(not using_ai)
+        if hasattr(self, "label_first_container"):
+            self.label_first_container.setVisible(using_label_first)
         if hasattr(self, "ai_group"):
             show_ai = using_ai or self._ai_job_running
             self.ai_group.setVisible(show_ai)
@@ -7502,6 +7766,14 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         if not corpus_id:
             QtWidgets.QMessageBox.warning(self, "Round", "Select a corpus for this round.")
             return None
+        if bool(getattr(self, "label_first_radio", None) and self.label_first_radio.isChecked()):
+            if not self._label_first_targets:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Label-first sampling",
+                    "Add at least one label/value target before generating a label-first round.",
+                )
+                return None
         independent = bool(self.independent_checkbox.isChecked()) if hasattr(self, "independent_checkbox") else False
         sampling_metadata: Dict[str, object] = {"independent": independent}
         excluded_units = self._load_reviewed_unit_ids(corpus_id) if independent else set()
@@ -7932,6 +8204,22 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             select["pct_easy_qc"] = float(self.ai_easy_pct.value())
         if hasattr(self, "ai_diversity_pct"):
             select["pct_diversity"] = float(self.ai_diversity_pct.value())
+        using_label_first = bool(
+            getattr(self, "label_first_radio", None) and self.label_first_radio.isChecked()
+        )
+        select["sampling_mode"] = "label_first" if using_label_first else "active_learning"
+        if using_label_first:
+            select["label_first_targets"] = copy.deepcopy(self._label_first_targets)
+            if hasattr(self, "label_first_pathway_combo"):
+                select["label_first_pathway"] = str(
+                    self.label_first_pathway_combo.currentData() or "enriched"
+                )
+            if hasattr(self, "label_first_pool_initial_spin"):
+                select["label_first_pool_initial_size"] = int(self.label_first_pool_initial_spin.value())
+            if hasattr(self, "label_first_pool_growth_spin"):
+                select["label_first_pool_growth_step"] = int(self.label_first_pool_growth_spin.value())
+            if hasattr(self, "label_first_pool_max_spin"):
+                select["label_first_pool_max_size"] = int(self.label_first_pool_max_spin.value())
         if select:
             overrides["select"] = select
         if hasattr(self, "ai_final_llm_checkbox"):

--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -114,6 +114,12 @@ class SelectionConfig:
     pct_uncertain: float = 0.3    # LLM-uncertain
     pct_easy_qc: float = 0.1      # LLM-certain
     pct_diversity: float = 0.3
+    sampling_mode: str = "active_learning"  # "active_learning" | "label_first"
+    label_first_targets: list[dict[str, object]] = field(default_factory=list)
+    label_first_pathway: str = "enriched"  # "enriched" | "random_iterative"
+    label_first_pool_initial_size: int = 200
+    label_first_pool_growth_step: int = 100
+    label_first_pool_max_size: int = 2000
 
 
 @dataclass

--- a/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
@@ -8,6 +8,18 @@ from typing import Callable, Dict, List, Optional, Set, Tuple
 import pandas as pd
 
 from ..services import LLM_RECORDER
+from ..services.label_first import (
+    build_target_counts,
+    collect_required_labels,
+    enriched_pool,
+    evaluate_target_hits,
+    finalize_rows,
+    label_unit_single_prompt,
+    parse_label_first_targets,
+    quota_key,
+    random_pool,
+    unresolved_targets,
+)
 from ..utils.runtime import check_cancelled as default_check_cancelled
 from ..utils.runtime import iter_with_bar as default_iter_with_bar
 
@@ -186,6 +198,170 @@ class ActiveLearningPipeline:
         n_cer = int(self.cfg.select.batch_size * self.cfg.select.pct_easy_qc)
         return direct_uncertainty_selection(probe_df, n_cer, select_most_certain=True)
 
+    def _run_label_first_sampling(
+        self,
+        *,
+        current_rules_map: Dict[str, str],
+        current_label_types: Dict[str, str],
+        iter_with_bar: Callable[..., object],
+        check_cancelled: Callable[[], None],
+    ) -> pd.DataFrame:
+        from ..services.family_labeler import build_family_labeler
+
+        selection_cfg = getattr(self.cfg, "select", None)
+        targets = parse_label_first_targets(getattr(selection_cfg, "label_first_targets", []))
+        if not targets:
+            raise RuntimeError("Label-first sampling requires at least one target.")
+
+        required_labels = collect_required_labels(
+            label_config=self.label_config or {},
+            label_types=current_label_types,
+            target_label_ids=[target.label_id for target in targets],
+        )
+        if not required_labels:
+            raise RuntimeError("Label-first targets are not available in the selected label set.")
+
+        pathway = str(getattr(selection_cfg, "label_first_pathway", "enriched") or "enriched").strip().lower()
+        pool_size = max(1, int(getattr(selection_cfg, "label_first_pool_initial_size", 200) or 200))
+        growth_step = max(1, int(getattr(selection_cfg, "label_first_pool_growth_step", 100) or 100))
+        max_pool = max(pool_size, int(getattr(selection_cfg, "label_first_pool_max_size", 2000) or 2000))
+        target_total = max(
+            int(getattr(selection_cfg, "batch_size", 0) or 0),
+            sum(max(0, int(target.quota)) for target in targets),
+        )
+
+        all_units = [str(uid) for uid in self.repo.notes["unit_id"].astype(str).unique().tolist()]
+        seen_units = (
+            set(self.repo.ann["unit_id"].astype(str).unique().tolist())
+            if not self.repo.ann.empty
+            else set()
+        )
+        excluded = set(self.excluded_unit_ids or set()) | seen_units
+        remaining = [uid for uid in all_units if uid not in excluded]
+
+        fam = build_family_labeler(
+            self.llm,
+            self.retriever,
+            self.repo,
+            self.label_config,
+            self.cfg.scjitter,
+            self.cfg.llmfirst,
+        )
+        use_single_prompt = (
+            str(getattr(self.cfg.llmfirst, "inference_labeling_mode", "family")).strip().lower()
+            == "single_prompt"
+        )
+        label_order = [lid for lid in current_label_types.keys() if lid in required_labels]
+        rules_subset = {lid: current_rules_map.get(lid, "") for lid in label_order}
+        types_subset = {lid: current_label_types.get(lid, "categorical") for lid in label_order}
+
+        counts = build_target_counts(targets)
+        selected_units: list[str] = []
+        selected_set: set[str] = set()
+        matched_labels: dict[str, str] = {}
+        rng = __import__("random").Random()
+
+        while remaining and len(selected_units) < target_total:
+            check_cancelled()
+            unresolved = unresolved_targets(targets, counts)
+            if not unresolved:
+                break
+            this_pool_size = min(pool_size, len(remaining))
+            if this_pool_size <= 0:
+                break
+
+            if pathway == "random_iterative":
+                pool = random_pool(candidates=remaining, size=this_pool_size, rng=rng)
+            else:
+                pool = enriched_pool(
+                    candidates=remaining,
+                    size=this_pool_size,
+                    unresolved=unresolved,
+                    context_builder=self.ctx_builder,
+                    rules_map=rules_subset,
+                    rng=rng,
+                )
+            if not pool:
+                break
+
+            _progress_every = float(getattr(self.cfg.llmfirst, "progress_min_interval_s", 1.0) or 1.0)
+            for uid in iter_with_bar(
+                step="Label-first sampling",
+                iterable=pool,
+                total=len(pool),
+                min_interval_s=_progress_every,
+            ):
+                check_cancelled()
+                if uid in selected_set:
+                    continue
+                if use_single_prompt:
+                    predictions = label_unit_single_prompt(
+                        unit_id=uid,
+                        label_ids=label_order,
+                        label_types=types_subset,
+                        rules_map=rules_subset,
+                        llm_labeler=self.llm,
+                        context_builder=self.ctx_builder,
+                        label_config=self.label_config or {},
+                        max_chars=int(getattr(self.cfg.llmfirst, "single_prompt_max_chars", 16000) or 16000),
+                    )
+                else:
+                    probe_rows = fam.label_family_for_unit(
+                        uid,
+                        types_subset,
+                        rules_subset,
+                        json_only=True,
+                        json_n_consistency=int(getattr(self.cfg.llmfirst, "final_llm_label_consistency", 1) or 1),
+                        json_jitter=False,
+                    )
+                    predictions = {
+                        str(row.get("label_id")): row.get("prediction")
+                        for row in probe_rows
+                        if isinstance(row, dict) and row.get("label_id") is not None
+                    }
+                hits = evaluate_target_hits(
+                    unit_id=uid,
+                    predictions=predictions,
+                    targets=targets,
+                    counts=counts,
+                )
+                if not hits:
+                    continue
+                selected_units.append(uid)
+                selected_set.add(uid)
+                matched_labels[uid] = hits[0].label_id
+                for hit in hits:
+                    key = quota_key(hit)
+                    counts[key] = counts.get(key, 0) + 1
+                if len(selected_units) >= target_total or not unresolved_targets(targets, counts):
+                    break
+
+            remaining = [uid for uid in remaining if uid not in set(pool) and uid not in selected_set]
+            if pool_size < max_pool:
+                pool_size = min(max_pool, pool_size + growth_step)
+            elif pathway == "enriched" and unresolved_targets(targets, counts):
+                pathway = "random_iterative"
+
+        batch_size = int(getattr(selection_cfg, "batch_size", 0) or 0)
+        if len(selected_units) < batch_size and remaining:
+            topoff = random_pool(candidates=remaining, size=batch_size - len(selected_units), rng=rng)
+            for uid in topoff:
+                if uid in selected_set:
+                    continue
+                selected_units.append(uid)
+                selected_set.add(uid)
+                matched_labels.setdefault(uid, "")
+
+        final = finalize_rows(
+            selected_units=selected_units,
+            matched_labels=matched_labels,
+            label_types=current_label_types,
+            selection_reason="label_first",
+        )
+        if final.empty:
+            raise RuntimeError("Label-first sampling did not find any matching units.")
+        return final
+
     def run(self) -> pd.DataFrame:
         import pandas as pd
         from ..services.family_labeler import build_family_labeler, run_family_labeling_for_units
@@ -238,6 +414,94 @@ class ActiveLearningPipeline:
         selector.current_label_ids = current_label_ids
         selector.seen_units = seen_units
         selector.unseen_pairs = unseen_pairs_current
+
+        sampling_mode = str(getattr(self.cfg.select, "sampling_mode", "active_learning") or "active_learning").strip().lower()
+        if sampling_mode == "label_first":
+            final = self._run_label_first_sampling(
+                current_rules_map=current_rules_map,
+                current_label_types=current_label_types,
+                iter_with_bar=iter_with_bar,
+                check_cancelled=check_cancelled,
+            )
+            final.to_parquet(os.path.join(self.paths.outdir, "final_selection.parquet"), index=False)
+            empty = final.iloc[0:0].copy()
+            empty.to_parquet(os.path.join(self.paths.outdir, "bucket_disagreement.parquet"), index=False)
+            empty.to_parquet(os.path.join(self.paths.outdir, "bucket_diversity.parquet"), index=False)
+            empty.to_parquet(os.path.join(self.paths.outdir, "bucket_llm_uncertain.parquet"), index=False)
+            empty.to_parquet(os.path.join(self.paths.outdir, "bucket_llm_certain.parquet"), index=False)
+            result_df = final
+
+            final_out = None
+            if getattr(self.cfg, "final_llm_labeling", False):
+                fam = build_family_labeler(
+                    self.llm,
+                    self.retriever,
+                    self.repo,
+                    self.label_config,
+                    self.cfg.scjitter,
+                    self.cfg.llmfirst,
+                )
+                unit_ids = final["unit_id"].tolist()
+                rules_map = current_rules_map
+                types = current_label_types
+                json_n_consistency = int(
+                    getattr(self.cfg.llmfirst, "final_llm_label_consistency", 1) or 1
+                )
+                fam_df = run_family_labeling_for_units(
+                    fam,
+                    unit_ids=unit_ids,
+                    label_types=types,
+                    per_label_rules=rules_map,
+                    json_n_consistency=json_n_consistency,
+                    json_jitter=False,
+                    iter_with_bar_fn=iter_with_bar,
+                    progress_step="Final family labeling",
+                )
+                if not fam_df.empty and self.jsonify_cols:
+                    fam_df = self.jsonify_cols(
+                        fam_df,
+                        [c for c in ["rag_context", "llm_runs", "fc_probs"] if c in fam_df.columns],
+                    )
+                fam_df.to_parquet(os.path.join(self.paths.outdir, "final_llm_family_probe.parquet"), index=False)
+                if not fam_df.empty:
+                    pv = fam_df[["unit_id", "label_id", "llm_prediction"]].copy()
+                    pv["col"] = pv["label_id"].astype(str) + "_llm"
+                    fam_wide = pv.pivot_table(index="unit_id", columns="col", values="llm_prediction", aggfunc="first").reset_index()
+                    if "llm_reasoning" in fam_df.columns:
+                        rv = fam_df[["unit_id", "label_id", "llm_reasoning"]].copy()
+                        rv["colr"] = rv["label_id"].astype(str) + "_llm_reason"
+                        fam_reason_wide = rv.pivot_table(index="unit_id", columns="colr", values="llm_reasoning", aggfunc="first").reset_index()
+                        fam_wide = fam_wide.merge(fam_reason_wide, on="unit_id", how="left")
+                    final_units = final[["unit_id", "label_id", "label_type", "selection_reason"]].drop_duplicates()
+                    final_out = final_units.merge(fam_wide, on="unit_id", how="left")
+                    final_out.to_parquet(os.path.join(self.paths.outdir, "final_selection_with_llm.parquet"), index=False)
+
+                    labels_path = Path(self.paths.outdir) / "final_llm_labels.parquet"
+                    try:
+                        fam_wide.to_parquet(labels_path, index=False)
+                    except Exception:
+                        pass
+                    else:
+                        try:
+                            labels_path.with_suffix(".json").write_text(
+                                fam_wide.to_json(orient="records", indent=2, force_ascii=False),
+                                encoding="utf-8",
+                            )
+                        except TypeError:
+                            labels_path.with_suffix(".json").write_text(
+                                fam_wide.to_json(orient="records"),
+                                encoding="utf-8",
+                            )
+                try:
+                    probe_json_path = Path(self.paths.outdir) / "final_llm_family_probe.json"
+                    fam_df.to_json(probe_json_path, orient="records", indent=2, force_ascii=False)
+                except TypeError:
+                    fam_df.to_json(probe_json_path, orient="records")
+            if final_out is not None:
+                result_df = final_out
+            if self.attach_metadata:
+                result_df = self.attach_metadata(result_df)
+            return result_df
 
         total = int(self.cfg.select.batch_size)
         n_dis = int(total * self.cfg.select.pct_disagreement)

--- a/vaannotate/vaannotate_ai_backend/services/label_first.py
+++ b/vaannotate/vaannotate_ai_backend/services/label_first.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Set
+
+import pandas as pd
+
+from .label_dependencies import build_label_dependencies, evaluate_gating
+
+
+@dataclass(frozen=True)
+class LabelFirstTarget:
+    label_id: str
+    values: tuple[str, ...]
+    quota: int
+    operator: str = "in"
+
+
+def parse_label_first_targets(payload: object) -> list[LabelFirstTarget]:
+    if not isinstance(payload, Sequence):
+        return []
+    targets: list[LabelFirstTarget] = []
+    for item in payload:
+        if not isinstance(item, Mapping):
+            continue
+        label_id = str(item.get("label_id") or "").strip()
+        if not label_id:
+            continue
+        values_raw = item.get("values")
+        if isinstance(values_raw, Sequence) and not isinstance(values_raw, (str, bytes)):
+            values = tuple(str(v).strip().lower() for v in values_raw if str(v).strip())
+        else:
+            single = str(item.get("value") or "").strip().lower()
+            values = (single,) if single else tuple()
+        try:
+            quota = int(item.get("quota") or 0)
+        except (TypeError, ValueError):
+            quota = 0
+        if quota <= 0:
+            continue
+        operator = str(item.get("operator") or "in").strip().lower()
+        targets.append(
+            LabelFirstTarget(
+                label_id=label_id,
+                values=values,
+                quota=quota,
+                operator=operator if operator in {"in", "equals"} else "in",
+            )
+        )
+    return targets
+
+
+def collect_required_labels(
+    *,
+    label_config: Mapping[str, object],
+    label_types: Mapping[str, str],
+    target_label_ids: Iterable[str],
+) -> set[str]:
+    parent_to_children, child_to_parents, _roots = build_label_dependencies(dict(label_config))
+    _ = parent_to_children
+    required: set[str] = set()
+    queue: list[str] = [str(lid) for lid in target_label_ids if str(lid)]
+    seen: set[str] = set()
+    while queue:
+        lid = queue.pop(0)
+        if lid in seen:
+            continue
+        seen.add(lid)
+        required.add(lid)
+        for parent in child_to_parents.get(lid, []):
+            parent_id = str(parent)
+            if parent_id and parent_id not in seen:
+                queue.append(parent_id)
+    # Keep only labels that are known to the current label config maps.
+    return {lid for lid in required if lid in set(label_types.keys())}
+
+
+def build_target_counts(targets: Sequence[LabelFirstTarget]) -> dict[str, int]:
+    return {f"{t.label_id}::{','.join(t.values)}::{t.operator}": 0 for t in targets}
+
+
+def quota_key(target: LabelFirstTarget) -> str:
+    return f"{target.label_id}::{','.join(target.values)}::{target.operator}"
+
+
+def match_target(prediction: object, target: LabelFirstTarget) -> bool:
+    pred = str(prediction or "").strip().lower()
+    if not pred:
+        return False
+    if target.operator == "equals":
+        return bool(target.values) and pred == target.values[0]
+    if not target.values:
+        return bool(pred)
+    return pred in set(target.values)
+
+
+def evaluate_target_hits(
+    *,
+    unit_id: str,
+    predictions: Mapping[str, object],
+    targets: Sequence[LabelFirstTarget],
+    counts: dict[str, int],
+) -> list[LabelFirstTarget]:
+    hits: list[LabelFirstTarget] = []
+    for target in targets:
+        key = quota_key(target)
+        if counts.get(key, 0) >= target.quota:
+            continue
+        value = predictions.get(target.label_id)
+        if match_target(value, target):
+            hits.append(target)
+    return hits
+
+
+def unresolved_targets(
+    targets: Sequence[LabelFirstTarget],
+    counts: Mapping[str, int],
+) -> list[LabelFirstTarget]:
+    return [target for target in targets if counts.get(quota_key(target), 0) < target.quota]
+
+
+def random_pool(
+    *,
+    candidates: Sequence[str],
+    size: int,
+    rng: random.Random,
+) -> list[str]:
+    if size <= 0:
+        return []
+    if len(candidates) <= size:
+        return [str(uid) for uid in candidates]
+    sampled = list(candidates)
+    rng.shuffle(sampled)
+    return sampled[:size]
+
+
+def enriched_pool(
+    *,
+    candidates: Sequence[str],
+    size: int,
+    unresolved: Sequence[LabelFirstTarget],
+    context_builder: object,
+    rules_map: Mapping[str, str],
+    rng: random.Random,
+    max_scored_units: int = 500,
+) -> list[str]:
+    if size <= 0:
+        return []
+    if not unresolved:
+        return random_pool(candidates=candidates, size=size, rng=rng)
+    score_subset = list(candidates)
+    rng.shuffle(score_subset)
+    score_subset = score_subset[: min(len(score_subset), max_scored_units)]
+    rows: list[tuple[str, float]] = []
+    for uid in score_subset:
+        best_score = 0.0
+        for target in unresolved:
+            rules = str(rules_map.get(target.label_id) or "")
+            try:
+                ctx = context_builder.build_context_for_label(uid, target.label_id, rules, topk_override=6)
+            except Exception:
+                ctx = None
+            if not ctx:
+                continue
+            try:
+                top = float(ctx[0].get("score", 0.0))
+            except Exception:
+                top = 0.0
+            if top > best_score:
+                best_score = top
+        rows.append((str(uid), float(best_score)))
+    ranked = [uid for uid, _ in sorted(rows, key=lambda item: item[1], reverse=True)]
+    if len(ranked) >= size:
+        return ranked[:size]
+    leftovers = [str(uid) for uid in candidates if str(uid) not in set(ranked)]
+    return ranked + random_pool(candidates=leftovers, size=max(0, size - len(ranked)), rng=rng)
+
+
+def label_unit_single_prompt(
+    *,
+    unit_id: str,
+    label_ids: Sequence[str],
+    label_types: Mapping[str, str],
+    rules_map: Mapping[str, str],
+    llm_labeler: object,
+    context_builder: object,
+    label_config: Mapping[str, object],
+    max_chars: int = 16000,
+) -> dict[str, object]:
+    ctx = context_builder.build_context_for_family(
+        unit_id,
+        label_ids=label_ids,
+        rules_map=rules_map,
+        topk_per_label=6,
+        max_snippets=None,
+        max_chars=max_chars,
+    )
+    res = llm_labeler.annotate_multi(
+        unit_id=unit_id,
+        label_ids=list(label_ids),
+        label_types=label_types,
+        rules_map=rules_map,
+        ctx_snippets=ctx,
+    )
+    preds = res.get("predictions") if isinstance(res, Mapping) else {}
+    parent_preds: dict[tuple[str, str], object] = {}
+    if isinstance(preds, Mapping):
+        for lid, info in preds.items():
+            prediction = info.get("prediction") if isinstance(info, Mapping) else None
+            parent_preds[(str(unit_id), str(lid))] = prediction
+
+    output: dict[str, object] = {}
+    for lid in label_ids:
+        pred_obj = preds.get(lid) if isinstance(preds, Mapping) else {}
+        prediction = pred_obj.get("prediction") if isinstance(pred_obj, Mapping) else None
+        gated = evaluate_gating(
+            child_id=str(lid),
+            unit_id=str(unit_id),
+            parent_preds=parent_preds,
+            label_types=dict(label_types),
+            label_config=dict(label_config),
+        )
+        output[str(lid)] = prediction if gated else None
+    return output
+
+
+def finalize_rows(
+    *,
+    selected_units: Sequence[str],
+    matched_labels: Mapping[str, str],
+    label_types: Mapping[str, str],
+    selection_reason: str,
+) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    for uid in selected_units:
+        lid = str(matched_labels.get(uid) or "")
+        rows.append(
+            {
+                "unit_id": str(uid),
+                "label_id": lid,
+                "label_type": str(label_types.get(lid, "categorical")),
+                "selection_reason": selection_reason,
+            }
+        )
+    return pd.DataFrame(rows)


### PR DESCRIPTION
### Motivation

- Introduce a "label-first" sampling mode to target specific label/value combinations with quotas when generating rounds. 
- Provide UI controls so admins can configure label-first targets, pathway and pool sizing in the Round Builder. 
- Integrate the label-first flow into the active learning pipeline and expose configuration via the existing AI config overrides.

### Description

- Added a new service module `vaannotate_vaannotate_ai_backend/services/label_first.py` that implements `LabelFirstTarget`, `parse_label_first_targets`, pool builders (`enriched_pool`, `random_pool`), target evaluation (`evaluate_target_hits`, `unresolved_targets`, `quota_key`), single-prompt labeling helper `label_unit_single_prompt`, and `finalize_rows` to assemble selection output. 
- Implemented `_run_label_first_sampling` inside `ActiveLearningPipeline` and hooked `sampling_mode == "label_first"` into `run`, including optional final LLM labeling and output artifact generation. 
- Extended selection config with new fields in `SelectionConfig` (`sampling_mode`, `label_first_targets`, `label_first_pathway`, `label_first_pool_initial_size`, `label_first_pool_growth_step`, and `label_first_pool_max_size`).
- Extended Admin UI in `vaannotate/AdminApp/main.py` to add a `Label-first sampling` radio, a `Label-first targets` container with controls and list rendering, persistence to the AI config snapshot, parsing/validation (`_render_label_first_targets`, `_refresh_label_first_catalog`, `_on_add_label_first_target`, `_on_remove_label_first_target`) and guards when generating rounds.
- Added unit tests in `tests/test_label_first_sampling.py` that cover `parse_label_first_targets` validation and exercise the pipeline path to ensure the sampling flow can hit quotas in a simplified scenario.

### Testing

- Ran the new unit tests in `tests/test_label_first_sampling.py` via `pytest` which exercise `parse_label_first_targets` and the `ActiveLearningPipeline` label-first sampling flow, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8eee61c948327a5af2e4363b98bd9)