### PR TITLE
Auto-save project after round creation

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -9240,6 +9240,15 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.created_round_number = round_number
         ctx.mark_dirty()
         ctx.update_cache_after_round(corpus_id)
+        try:
+            ctx.save_all()
+        except Exception as exc:  # noqa: BLE001
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Round",
+                f"Round {round_number} was created, but auto-save failed: {exc}",
+            )
+            return False
         return True
 
     def _run_random_final_llm_labeling(


### PR DESCRIPTION
### Motivation
- Ensure new rounds are persisted immediately by saving the project as the final step of round creation to avoid losing pending writes or manifests.

### Description
- Added a call to `ctx.save_all()` at the end of `_create_round` in `vaannotate/AdminApp/main.py` so the project is saved after `ctx.mark_dirty()` and `ctx.update_cache_after_round(corpus_id)`.
- Wrapped the auto-save in a `try/except` and show a critical `QMessageBox` with a clear message and return `False` if the save fails.
- No other behavioral changes were made besides the new save and its error handling.

### Testing
- Ran `pytest -q tests/test_round_import.py` and all tests passed: `20 passed, 3 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90d623c7083278b3c39ad604aac6b)