### PR TITLE
Show LLM reasoning in round review dialog (support legacy fields)

### DIFF
--- a/tests/test_client_annotation_form.py
+++ b/tests/test_client_annotation_form.py
@@ -100,3 +100,28 @@ def test_gating_expr_or_contains_shows_child_only_when_parent_matches(qt_app: Qt
 
     parent_boxes[0].setChecked(True)  # X
     assert child_row.isVisible() is True
+
+
+def test_extract_llm_reasoning_text_supports_legacy_reasoning_fields(
+    qt_app: QtWidgets.QApplication,
+) -> None:
+    ctx = AssignmentContext()
+    ctx._final_llm_reasoning = True
+    form = AnnotationForm(ctx, _dummy_cursor, lambda: None)
+
+    assert form._extract_llm_reasoning_text({"llm_reasoning": "preferred"}) == "preferred"
+    assert form._extract_llm_reasoning_text({"reasoning": "legacy"}) == "legacy"
+    assert (
+        form._extract_llm_reasoning_text({"llm_runs": [{"raw": {"reasoning": "from-runs"}}]})
+        == "from-runs"
+    )
+
+
+def test_extract_llm_reasoning_text_respects_reasoning_toggle(
+    qt_app: QtWidgets.QApplication,
+) -> None:
+    ctx = AssignmentContext()
+    ctx._final_llm_reasoning = False
+    form = AnnotationForm(ctx, _dummy_cursor, lambda: None)
+
+    assert form._extract_llm_reasoning_text({"llm_reasoning": "hidden"}) is None

--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -1780,11 +1780,7 @@ class AnnotationForm(QtWidgets.QScrollArea):
             label_name = definition.name
         prediction_value = entry.get("llm_prediction") or entry.get("prediction")
         prediction_text = str(prediction_value) if prediction_value is not None else "(none)"
-        reasoning_text = None
-        if self.ctx.final_llm_reasoning_enabled():
-            raw_reasoning = entry.get("llm_reasoning")
-            if raw_reasoning is not None:
-                reasoning_text = str(raw_reasoning)
+        reasoning_text = self._extract_llm_reasoning_text(entry)
         consistency_value = entry.get("llm_consistency") or entry.get("consistency")
         if consistency_value is not None:
             try:
@@ -1821,6 +1817,24 @@ class AnnotationForm(QtWidgets.QScrollArea):
         button_box.accepted.connect(dialog.accept)
         layout.addWidget(button_box)
         dialog.exec()
+
+    def _extract_llm_reasoning_text(self, entry: Mapping[str, object]) -> Optional[str]:
+        if not self.ctx.final_llm_reasoning_enabled():
+            return None
+        raw_reasoning = entry.get("llm_reasoning")
+        if raw_reasoning is None:
+            raw_reasoning = entry.get("reasoning")
+        if raw_reasoning is None:
+            runs_value = entry.get("llm_runs") or entry.get("runs")
+            if isinstance(runs_value, Sequence) and runs_value:
+                first_run = runs_value[0]
+                if isinstance(first_run, Mapping):
+                    raw_value = first_run.get("raw")
+                    if isinstance(raw_value, Mapping):
+                        raw_reasoning = raw_value.get("reasoning")
+        if raw_reasoning is None:
+            return None
+        return str(raw_reasoning)
 
     def _selected_highlight(self, label_id: str) -> Optional[Dict[str, object]]:
         widgets = self.label_widgets.get(label_id)


### PR DESCRIPTION
### Motivation
- Round review currently only displayed final LLM prediction and self-consistency, missing reasoning when payloads used legacy shapes or nested run payloads.
- Make the Client UI reliably surface LLM reasoning when available while honoring the round-level reasoning toggle.

### Description
- Added `AnnotationForm._extract_llm_reasoning_text` to centralize reasoning extraction and fallback logic from `llm_reasoning`, legacy `reasoning`, and the first run `llm_runs`/`runs` raw reasoning.
- Replaced inline extraction in `_show_llm_label` with a call to `self._extract_llm_reasoning_text(entry)` and preserved the existing UI layout behavior.
- Added tests in `tests/test_client_annotation_form.py` exercising `AnnotationForm._extract_llm_reasoning_text` for preferred, legacy, and `llm_runs` sources and the behavior when reasoning display is disabled.

### Testing
- Ran `pytest -q tests/test_client_annotation_form.py`, which executed the new tests but reported skipped due to the test environment lacking `PySide6` (test run showed skipped-only status).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e977398c608327aeac7f4320cd8085)