### PR TITLE
Fix NameError in ClientApp LLM reasoning extraction

### DIFF
--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -9,7 +9,7 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Mapping, Optional, Set, Tuple
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 from PySide6 import QtCore, QtGui, QtWidgets
 


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` when opening the "View LLM label" dialog because `_extract_llm_reasoning_text` checks for `Sequence` when inspecting `llm_runs`/`runs`.

### Description
- Add the missing `Sequence` import to the `typing` imports in `vaannotate/ClientApp/main.py` so `_extract_llm_reasoning_text` can use `Sequence` without error.

### Testing
- `python -m py_compile vaannotate/ClientApp/main.py` ran and succeeded.
- `pytest -q tests/test_client_annotation_form.py -k extract_llm_reasoning_text` was executed in this environment and the test selection was skipped (no failing tests reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97bc9bec083278f463486afab4cd7)