### PR TITLE
Fix final LLM reasoning extraction across runs payload formats

### DIFF
--- a/tests/test_client_annotation_form.py
+++ b/tests/test_client_annotation_form.py
@@ -115,6 +115,12 @@ def test_extract_llm_reasoning_text_supports_legacy_reasoning_fields(
         form._extract_llm_reasoning_text({"llm_runs": [{"raw": {"reasoning": "from-runs"}}]})
         == "from-runs"
     )
+    assert (
+        form._extract_llm_reasoning_text(
+            {"llm_runs": '[{"logprobs":{"yes":-0.1},"reasoning":"run-level-reasoning"}]'}
+        )
+        == "run-level-reasoning"
+    )
 
 
 def test_extract_llm_reasoning_text_respects_reasoning_toggle(

--- a/tests/test_family_labeler_normalization.py
+++ b/tests/test_family_labeler_normalization.py
@@ -40,7 +40,8 @@ def test_run_family_labeling_for_units_normalizes_date_predictions():
         per_label_rules={"dob": "Provide date of birth"},
     )
 
-    assert list(df.columns) == [
+    assert "runtime_s" in df.columns
+    assert [col for col in ["unit_id", "label_id", "llm_prediction", "llm_runs", "llm_consistency", "llm_reasoning"] if col in df.columns] == [
         "unit_id",
         "label_id",
         "llm_prediction",
@@ -83,3 +84,30 @@ def test_probe_units_normalizes_date_predictions():
 
     assert df.iloc[0].llm_prediction == "2021-05-06T12:30:00"
     assert df.iloc[0].llm_reasoning == "observed signature date"
+
+
+def test_normalize_family_predictions_accepts_run_level_reasoning_stringified_runs():
+    class DummyFamilyLabeler:
+        def __init__(self):
+            self.cfg = types.SimpleNamespace(progress_min_interval_s=0.0)
+
+        def label_family_for_unit(self, uid, label_types, per_label_rules, **kwargs):
+            return [
+                {
+                    "unit_id": uid,
+                    "label_id": "flag",
+                    "prediction": "yes",
+                    "runs": '[{"logprobs":{"yes":-0.2},"reasoning":"run-level"}]',
+                    "consistency": 1.0,
+                }
+            ]
+
+    fam = DummyFamilyLabeler()
+    df = run_family_labeling_for_units(
+        fam,
+        unit_ids=["unit-1"],
+        label_types={"flag": "binary"},
+        per_label_rules={"flag": "Decide"},
+    )
+
+    assert df.iloc[0].llm_reasoning == "run-level"

--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -1825,16 +1825,42 @@ class AnnotationForm(QtWidgets.QScrollArea):
         if raw_reasoning is None:
             raw_reasoning = entry.get("reasoning")
         if raw_reasoning is None:
-            runs_value = entry.get("llm_runs") or entry.get("runs")
-            if isinstance(runs_value, Sequence) and runs_value:
-                first_run = runs_value[0]
-                if isinstance(first_run, Mapping):
-                    raw_value = first_run.get("raw")
-                    if isinstance(raw_value, Mapping):
-                        raw_reasoning = raw_value.get("reasoning")
+            runs_value = self._coerce_llm_runs(entry.get("llm_runs") or entry.get("runs"))
+            raw_reasoning = self._extract_reasoning_from_runs(runs_value)
         if raw_reasoning is None:
             return None
         return str(raw_reasoning)
+
+    @staticmethod
+    def _coerce_llm_runs(raw_runs: object) -> Optional[List[Mapping[str, object]]]:
+        runs_value = raw_runs
+        if isinstance(runs_value, str):
+            try:
+                runs_value = json.loads(runs_value)
+            except Exception:  # noqa: BLE001
+                return None
+        if not isinstance(runs_value, Sequence) or isinstance(runs_value, (str, bytes)):
+            return None
+        runs: List[Mapping[str, object]] = []
+        for item in runs_value:
+            if isinstance(item, Mapping):
+                runs.append(item)
+        return runs or None
+
+    @staticmethod
+    def _extract_reasoning_from_runs(
+        runs_value: Optional[Sequence[Mapping[str, object]]],
+    ) -> Optional[object]:
+        if not runs_value:
+            return None
+        first_run = runs_value[0]
+        direct_reasoning = first_run.get("reasoning")
+        if direct_reasoning is not None:
+            return direct_reasoning
+        raw_value = first_run.get("raw")
+        if isinstance(raw_value, Mapping):
+            return raw_value.get("reasoning")
+        return None
 
     def _selected_highlight(self, label_id: str) -> Optional[Dict[str, object]]:
         widgets = self.label_widgets.get(label_id)

--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -1524,9 +1524,7 @@ class RoundBuilder:
             if "prediction" in fam_df.columns:
                 fam_df.rename(columns={"prediction": "llm_prediction"}, inplace=True)
             if include_reasoning and "llm_runs" in fam_df.columns:
-                fam_df["llm_reasoning"] = fam_df["llm_runs"].map(
-                    lambda runs: (runs[0].get("raw", {}).get("reasoning") if isinstance(runs, list) and runs else None)
-                )
+                fam_df["llm_reasoning"] = fam_df["llm_runs"].map(self._extract_reasoning_from_runs)
             fam_df = _jsonify_cols(
                 fam_df,
                 [col for col in ("rag_context", "llm_runs", "fc_probs") if col in fam_df.columns],
@@ -1658,6 +1656,27 @@ class RoundBuilder:
             except Exception:  # noqa: BLE001
                 pass
         return value
+
+    @staticmethod
+    def _extract_reasoning_from_runs(runs: object) -> object:
+        runs_value = runs
+        if isinstance(runs_value, str):
+            try:
+                runs_value = json.loads(runs_value)
+            except Exception:  # noqa: BLE001
+                return None
+        if not isinstance(runs_value, list) or not runs_value:
+            return None
+        first_run = runs_value[0]
+        if not isinstance(first_run, Mapping):
+            return None
+        direct_reasoning = first_run.get("reasoning")
+        if direct_reasoning is not None:
+            return direct_reasoning
+        raw_value = first_run.get("raw")
+        if isinstance(raw_value, Mapping):
+            return raw_value.get("reasoning")
+        return None
 
     @staticmethod
     def _build_label_schema_payload(labelset: Mapping[str, object]) -> Dict[str, object]:

--- a/vaannotate/vaannotate_ai_backend/services/family_labeler.py
+++ b/vaannotate/vaannotate_ai_backend/services/family_labeler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import random
 import time
+import json
 from collections import Counter
 from datetime import date, datetime
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
@@ -154,13 +155,7 @@ def _normalize_family_predictions_df(df: pd.DataFrame) -> pd.DataFrame:
 
     # Extract a single reasoning field from the first run when present
     if "llm_runs" in df.columns and "llm_reasoning" not in df.columns:
-        df["llm_reasoning"] = df["llm_runs"].map(
-            lambda rs: (
-                rs[0].get("raw", {}).get("reasoning")
-                if isinstance(rs, list) and rs
-                else None
-            )
-        )
+        df["llm_reasoning"] = df["llm_runs"].map(_extract_reasoning_from_runs)
 
     if "llm_prediction" in df.columns:
         df["llm_prediction"] = df["llm_prediction"].map(
@@ -168,6 +163,26 @@ def _normalize_family_predictions_df(df: pd.DataFrame) -> pd.DataFrame:
         )
 
     return df
+
+
+def _extract_reasoning_from_runs(runs: Any) -> Any:
+    runs_value = runs
+    if isinstance(runs_value, str):
+        try:
+            runs_value = json.loads(runs_value)
+        except Exception:  # noqa: BLE001
+            return None
+    if not isinstance(runs_value, list) or not runs_value:
+        return None
+    first_run = runs_value[0]
+    if not isinstance(first_run, Mapping):
+        return None
+    if first_run.get("reasoning") is not None:
+        return first_run.get("reasoning")
+    raw_value = first_run.get("raw")
+    if isinstance(raw_value, Mapping):
+        return raw_value.get("reasoning")
+    return None
 
 
 class FamilyLabeler:
@@ -878,6 +893,5 @@ def direct_uncertainty_selection(
                  .drop(columns=["_score"])
                  .reset_index(drop=True))
     return out
-
 
 


### PR DESCRIPTION
### Motivation
- Final LLM reasoning was sometimes not displayed in the ClientApp because reasoning lived inside `llm_runs` (often adjacent to `logprobs`) while the separate `llm_reasoning` field remained null.
- The code only handled a single nested location and did not parse stringified run payloads, so reasoning was not consistently surfaced to the UI.

### Description
- Updated the ClientApp consumer to robustly extract reasoning by adding `AnnotationForm._coerce_llm_runs` and `AnnotationForm._extract_reasoning_from_runs`, and using them from `_extract_llm_reasoning_text` so `llm_runs` can be parsed when it is a JSON string and reasoning may be at `runs[0].reasoning` or `runs[0].raw.reasoning` (`vaannotate/ClientApp/main.py`).
- Standardized reasoning extraction in round building by mapping `llm_runs` through a shared `_extract_reasoning_from_runs` helper so `final_llm_family_probe` writes `llm_reasoning` consistently (`vaannotate/rounds.py`).
- Brought the same extraction logic into family-label normalization, including support for stringified `runs`, and added `_extract_reasoning_from_runs` in the backend service (`vaannotate/vaannotate_ai_backend/services/family_labeler.py`).
- Added and adjusted tests to cover legacy and stringified run payloads: updated `tests/test_client_annotation_form.py` and `tests/test_family_labeler_normalization.py` to assert reasoning is extracted for the new shapes and to tolerate an extra `runtime_s` column in probe outputs.

### Testing
- Ran targeted tests: `pytest -q tests/test_client_annotation_form.py tests/test_family_labeler_normalization.py` and the run completed successfully with the tests passing.
- Result: all targeted tests passed (3 passed, 1 skipped in the targeted run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97d1c20f88327bb081fc8d364e724)