### PR TITLE
Fix label set wizard oversized geometry and improve combo sizing

### DIFF
--- a/tests/test_labelset_wizard_dialog.py
+++ b/tests/test_labelset_wizard_dialog.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "PySide6.QtWidgets",
+    reason="PySide6 QtWidgets bindings unavailable (missing libGL)",
+    exc_type=ImportError,
+)
+from PySide6 import QtCore, QtWidgets
+
+from vaannotate.AdminApp.main import LabelSetWizardDialog, _truncate_for_display
+
+
+@pytest.fixture(scope="module")
+def qt_app() -> QtWidgets.QApplication:
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+class _DialogContext:
+    project_row = {"created_by": "admin"}
+
+    def list_label_sets(self):
+        return [
+            {
+                "labelset_id": "set_a",
+                "created_at": "2026-04-20",
+                "notes": "This is an intentionally very long note " * 10,
+            }
+        ]
+
+    def load_labelset_details(self, labelset_id: str):  # pragma: no cover - not exercised here
+        return {"labelset_id": labelset_id, "labels": []}
+
+
+def test_truncate_for_display_clamps_length():
+    result = _truncate_for_display("word " * 100, max_length=32)
+    assert len(result) <= 32
+    assert result.endswith("…")
+
+
+def test_copy_combo_uses_safe_sizing_policy(qt_app):
+    dialog = LabelSetWizardDialog(_DialogContext())
+    assert (
+        dialog.copy_combo.sizeAdjustPolicy()
+        == QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+    )
+    assert dialog.copy_combo.minimumContentsLength() == 36
+    assert dialog.copy_combo.view().textElideMode() == QtCore.Qt.TextElideMode.ElideRight
+
+    item_text = dialog.copy_combo.itemText(1)
+    assert len(item_text) < 220
+    assert "…" in item_text

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -95,6 +95,15 @@ def _resize_for_screen(window: QtWidgets.QWidget, width: int, height: int) -> No
     window.resize(min(width, max_width), min(height, max_height))
 
 
+def _truncate_for_display(text: str, *, max_length: int = 100) -> str:
+    """Clamp long UI strings so widgets do not force oversized minimum widths."""
+
+    normalized = " ".join(str(text).split())
+    if len(normalized) <= max_length:
+        return normalized
+    return normalized[: max_length - 1].rstrip() + "…"
+
+
 def build_round_assignment_units(
     assignments: Mapping[str, ReviewerAssignment],
 ) -> Dict[str, List[RoundAssignmentUnit]]:
@@ -5130,6 +5139,9 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         form.addRow("Label set ID", self.id_edit)
         self.copy_combo = QtWidgets.QComboBox()
         self.copy_combo.addItem("Start from blank", None)
+        self.copy_combo.setSizeAdjustPolicy(QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
+        self.copy_combo.setMinimumContentsLength(36)
+        self.copy_combo.view().setTextElideMode(QtCore.Qt.TextElideMode.ElideRight)
         self.copy_combo.currentIndexChanged.connect(self._on_copy_source_changed)
         form.addRow("Copy from", self.copy_combo)
         self.creator_edit = QtWidgets.QLineEdit()
@@ -5207,7 +5219,7 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
             if created_at:
                 display += f" ({created_at})"
             if notes:
-                display += f" — {notes}"
+                display += f" — {_truncate_for_display(notes)}"
             self.copy_combo.addItem(display, labelset_id)
         self.copy_combo.blockSignals(False)
         self.copy_combo.setCurrentIndex(0)


### PR DESCRIPTION
### Motivation
- The label-set wizard could be forced to an extremely large minimum width by long label-set notes displayed in the "Copy from" dropdown, causing `QWindowsWindow::setGeometry` errors and a non-resizable dialog.
- The combo-box sizing policy needed hardening to avoid relying on full item text for minimum-width calculations.

### Description
- Added `_truncate_for_display(text, *, max_length)` to clamp long UI strings before inserting them into widgets.
- Configured the copy-source `QComboBox` in `LabelSetWizardDialog` to use `AdjustToMinimumContentsLengthWithIcon`, set `minimumContentsLength(36)`, and enable right-side eliding via `view().setTextElideMode(QtCore.Qt.TextElideMode.ElideRight)`.
- Use `_truncate_for_display` when building the combo item display so label-set `notes` cannot inflate the widget minimum width.
- Added `tests/test_labelset_wizard_dialog.py` with unit tests for the truncation helper and the combo-box sizing/elide settings.

### Testing
- Ran `pytest -q tests/test_labelset_wizard_dialog.py`, which was skipped in this environment because PySide6/QtWidgets is unavailable (skip recorded).
- Ran `python -m compileall vaannotate/AdminApp/main.py tests/test_labelset_wizard_dialog.py` which completed successfully (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2ea021f48327ae5133b0e43cf124)