### PR TITLE
Fix oversized Admin label-set wizard dialogs on multi-monitor setups

### DIFF
--- a/tests/test_label_set_wizard_dialog.py
+++ b/tests/test_label_set_wizard_dialog.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+pytest.importorskip(
+    "PySide6.QtWidgets",
+    reason="PySide6 QtWidgets bindings unavailable (missing libGL)",
+    exc_type=ImportError,
+)
+from PySide6 import QtWidgets
+
+from vaannotate.AdminApp.main import LabelSetWizardDialog
+
+
+@pytest.fixture(scope="module")
+def qt_app() -> QtWidgets.QApplication:
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+@dataclass
+class _FakeProjectContext:
+    project_row: dict[str, object] | None = None
+
+    def list_label_sets(self) -> list[dict[str, object]]:
+        return [
+            {
+                "labelset_id": "baseline",
+                "created_at": "2026-04-23",
+                "notes": "x" * 1000,
+            }
+        ]
+
+
+def test_copy_combo_is_width_capped(qt_app: QtWidgets.QApplication) -> None:
+    dialog = LabelSetWizardDialog(_FakeProjectContext())
+    assert (
+        dialog.copy_combo.sizeAdjustPolicy()
+        == QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+    )
+    assert dialog.copy_combo.minimumContentsLength() == 30
+
+
+def test_resources_tabs_use_scroll_areas(qt_app: QtWidgets.QApplication) -> None:
+    dialog = LabelSetWizardDialog(_FakeProjectContext())
+    dialog.labels = [
+        {"label_id": "very_long_identifier", "name": "Very long display name", "type": "text"},
+    ]
+    dialog._refresh_label_resources()
+
+    keyword_scrolls = dialog.keywords_tab.findChildren(QtWidgets.QScrollArea)
+    fewshot_scrolls = dialog.few_shot_tab.findChildren(QtWidgets.QScrollArea)
+
+    assert keyword_scrolls
+    assert fewshot_scrolls
+    assert keyword_scrolls[0].widgetResizable()
+    assert fewshot_scrolls[0].widgetResizable()

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -5117,6 +5117,7 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         self.label_few_shot: Dict[str, List[Dict[str, str]]] = {}
         self.setWindowTitle("Edit label set" if self._editing_existing else "Create label set")
         _resize_for_screen(self, 520, 640)
+        self.setMinimumSize(480, 420)
         self._setup_ui()
         self._populate_copy_sources()
         if self._initial_payload:
@@ -5129,6 +5130,10 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
         self.id_edit.setPlaceholderText("Unique label set ID")
         form.addRow("Label set ID", self.id_edit)
         self.copy_combo = QtWidgets.QComboBox()
+        self.copy_combo.setSizeAdjustPolicy(
+            QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+        )
+        self.copy_combo.setMinimumContentsLength(30)
         self.copy_combo.addItem("Start from blank", None)
         self.copy_combo.currentIndexChanged.connect(self._on_copy_source_changed)
         form.addRow("Copy from", self.copy_combo)
@@ -5334,7 +5339,11 @@ class LabelSetWizardDialog(QtWidgets.QDialog):
                 )
             else:
                 editor = LabelFewShotExamplesEditor(self.labels, self.label_few_shot)
-            tab.layout().addWidget(editor)  # type: ignore[union-attr]
+            scroll = QtWidgets.QScrollArea()
+            scroll.setWidgetResizable(True)
+            scroll.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+            scroll.setWidget(editor)
+            tab.layout().addWidget(scroll)  # type: ignore[union-attr]
             setattr(self, editor_attr, editor)
 
     def _add_label(self) -> None:


### PR DESCRIPTION
### Motivation
- The Label Set create/edit dialog could expand to enormous sizes on multi-monitor setups and push beyond available screen geometry, making content inaccessible and triggering Qt warnings. 
- Large per-label content in the Keywords and Few-shot tabs was forcing the dialog to grow instead of allowing the user to scroll.

### Description
- Constrain the dialog by adding a reasonable minimum size via `self.setMinimumSize(480, 420)` in `LabelSetWizardDialog` so it no longer starts with an oversized footprint.
- Prevent the "Copy from" combo from growing unbounded by setting its size-adjust policy to `QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon` and `setMinimumContentsLength(30)` so very long display text does not force extreme widths.
- Wrap the Keywords and Few-shot tab editors in `QScrollArea` containers with `setWidgetResizable(True)` and `setFrameShape(QtWidgets.QFrame.Shape.NoFrame)` so tab content remains scrollable instead of enlarging the dialog beyond screen bounds.
- Add `tests/test_label_set_wizard_dialog.py` Qt tests that assert the combo sizing policy and that both resource tabs use scroll areas.

### Testing
- Ran `pytest -q tests/test_label_set_wizard_dialog.py`, which was skipped in this environment because the `PySide6.QtWidgets` bindings are unavailable (skip is expected in headless CI without GUI libs). 
- Compiled changed modules with `python -m compileall vaannotate/AdminApp/main.py tests/test_label_set_wizard_dialog.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea31a8c6788327ad568d322ce76925)