### PR TITLE
Per-round toggle to hide LLM annotations from annotators

### DIFF
--- a/tests/test_client_annotation_form.py
+++ b/tests/test_client_annotation_form.py
@@ -131,3 +131,45 @@ def test_extract_llm_reasoning_text_respects_reasoning_toggle(
     form = AnnotationForm(ctx, _dummy_cursor, lambda: None)
 
     assert form._extract_llm_reasoning_text({"llm_reasoning": "hidden"}) is None
+
+
+def test_extract_llm_reasoning_text_respects_llm_visibility_toggle(
+    qt_app: QtWidgets.QApplication,
+) -> None:
+    ctx = AssignmentContext()
+    ctx._final_llm_reasoning = True
+    ctx._final_llm_visible_to_annotators = False
+    form = AnnotationForm(ctx, _dummy_cursor, lambda: None)
+
+    assert form._extract_llm_reasoning_text({"llm_reasoning": "hidden"}) is None
+
+
+def test_llm_button_is_disabled_when_round_hides_llm_annotations(
+    qt_app: QtWidgets.QApplication,
+) -> None:
+    ctx = AssignmentContext()
+    ctx.final_llm_enabled = True
+    ctx._final_llm_visible_to_annotators = False
+    ctx._final_llm_labels = {"unit-1": {"flag": {"label_id": "flag", "llm_prediction": "yes"}}}
+    form = AnnotationForm(ctx, _dummy_cursor, lambda: None)
+    label = LabelDefinition(
+        label_id="flag",
+        name="Flag",
+        type="boolean",
+        required=False,
+        na_allowed=False,
+        rules="",
+        unit=None,
+        value_range=None,
+        gating_expr=None,
+        options=[{"value": "yes", "display": "Yes"}, {"value": "no", "display": "No"}],
+    )
+    form.set_schema([label])
+    form.current_unit_id = "unit-1"
+    form._update_llm_button("flag")
+
+    llm_btn = form.label_widgets["flag"]["llm_btn"]  # type: ignore[index]
+    assert isinstance(llm_btn, QtWidgets.QPushButton)
+    assert llm_btn.isVisible() is True
+    assert llm_btn.isEnabled() is False
+    assert llm_btn.toolTip() == "LLM annotations are hidden for this round."

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -3775,6 +3775,10 @@ class AIRoundWorker(QtCore.QObject):
             payload["final_llm_include_reasoning"] = bool(
                 self.cfg_overrides.get("final_llm_include_reasoning")
             )
+        if "final_llm_visible_to_annotators" in self.cfg_overrides:
+            payload["final_llm_visible_to_annotators"] = bool(
+                self.cfg_overrides.get("final_llm_visible_to_annotators")
+            )
         handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8")
         with handle:
             json.dump(payload, handle, indent=2)
@@ -6086,6 +6090,10 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         base_cfg["llm"] = llm_cfg
         if hasattr(self, "ai_final_llm_checkbox"):
             base_cfg["final_llm_labeling"] = bool(self.ai_final_llm_checkbox.isChecked())
+        if hasattr(self, "ai_show_llm_to_annotators_checkbox"):
+            base_cfg["final_llm_visible_to_annotators"] = bool(
+                self.ai_show_llm_to_annotators_checkbox.isChecked()
+            )
         if "final_llm_labeling_n_consistency" not in base_cfg:
             try:
                 base_cfg["final_llm_labeling_n_consistency"] = int(
@@ -6225,6 +6233,16 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             try:
                 self.ai_final_llm_checkbox.setChecked(
                     bool(effective_cfg.get("final_llm_labeling"))
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        if (
+            hasattr(self, "ai_show_llm_to_annotators_checkbox")
+            and "final_llm_visible_to_annotators" in effective_cfg
+        ):
+            try:
+                self.ai_show_llm_to_annotators_checkbox.setChecked(
+                    bool(effective_cfg.get("final_llm_visible_to_annotators"))
                 )
             except Exception:  # noqa: BLE001
                 pass
@@ -6878,6 +6896,11 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         random_llm_layout.setFieldGrowthPolicy(
             QtWidgets.QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow
         )
+        self.random_show_llm_to_annotators_checkbox = QtWidgets.QCheckBox(
+            "Allow annotators to view LLM labels/reasoning"
+        )
+        self.random_show_llm_to_annotators_checkbox.setChecked(True)
+        random_llm_layout.addRow("Client visibility", self.random_show_llm_to_annotators_checkbox)
 
         self.random_backend_combo = QtWidgets.QComboBox()
         self.random_backend_combo.addItem("Azure OpenAI", "azure")
@@ -7119,6 +7142,11 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.ai_final_llm_checkbox.setChecked(True)
         self.ai_final_llm_checkbox.toggled.connect(self._on_ai_final_llm_toggled)
         ai_config_layout.addRow("Final LLM labeling", self.ai_final_llm_checkbox)
+        self.ai_show_llm_to_annotators_checkbox = QtWidgets.QCheckBox(
+            "Allow annotators to view LLM labels/reasoning"
+        )
+        self.ai_show_llm_to_annotators_checkbox.setChecked(True)
+        ai_config_layout.addRow("Client visibility", self.ai_show_llm_to_annotators_checkbox)
 
         self.ai_context_order_combo = QtWidgets.QComboBox()
         self.ai_context_order_combo.addItem("Relevance ranking", "relevance")
@@ -7424,6 +7452,12 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         if hasattr(self, "random_final_llm_checkbox") and isinstance(final_llm_value, bool):
             self.random_final_llm_checkbox.setChecked(final_llm_value)
             self._on_random_final_llm_toggled(final_llm_value)
+        final_llm_visible_value = config.get("final_llm_visible_to_annotators")
+        if (
+            hasattr(self, "random_show_llm_to_annotators_checkbox")
+            and isinstance(final_llm_visible_value, bool)
+        ):
+            self.random_show_llm_to_annotators_checkbox.setChecked(final_llm_visible_value)
 
     def _collect_filters(self) -> SamplingFilters:
         conditions: List[MetadataFilterCondition] = []
@@ -8233,6 +8267,10 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             overrides["select"] = select
         if hasattr(self, "ai_final_llm_checkbox"):
             overrides["final_llm_labeling"] = bool(self.ai_final_llm_checkbox.isChecked())
+        if hasattr(self, "ai_show_llm_to_annotators_checkbox"):
+            overrides["final_llm_visible_to_annotators"] = bool(
+                self.ai_show_llm_to_annotators_checkbox.isChecked()
+            )
         if "final_llm_labeling_n_consistency" not in overrides:
             try:
                 overrides["final_llm_labeling_n_consistency"] = int(
@@ -9071,6 +9109,10 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             if hasattr(self, "random_final_llm_checkbox"):
                 final_llm_enabled = bool(self.random_final_llm_checkbox.isChecked())
                 config_payload["final_llm_labeling"] = final_llm_enabled
+            if hasattr(self, "random_show_llm_to_annotators_checkbox"):
+                config_payload["final_llm_visible_to_annotators"] = bool(
+                    self.random_show_llm_to_annotators_checkbox.isChecked()
+                )
             if final_llm_enabled or assisted_enabled:
                 include_reasoning = bool(getattr(self, "_labelset_include_reasoning", False))
                 if getattr(self, "_label_reasoning_by_label", {}):

--- a/vaannotate/ClientApp/main.py
+++ b/vaannotate/ClientApp/main.py
@@ -327,6 +327,7 @@ class AssignmentContext(QtCore.QObject):
         self._assisted_review_snippets: Dict[str, Dict[str, List[Dict[str, object]]]] = {}
         self.final_llm_enabled: bool = False
         self._final_llm_reasoning: bool = True
+        self._final_llm_visible_to_annotators: bool = True
         self._final_llm_labels: Dict[str, Dict[str, Dict[str, object]]] = {}
 
     @staticmethod
@@ -374,6 +375,7 @@ class AssignmentContext(QtCore.QObject):
         self._assisted_review_snippets = {}
         self.final_llm_enabled = False
         self._final_llm_reasoning = True
+        self._final_llm_visible_to_annotators = True
         self._final_llm_labels = {}
         round_dir: Optional[Path] = None
         try:
@@ -451,12 +453,25 @@ class AssignmentContext(QtCore.QObject):
                     final_enabled = self._parse_bool(round_config.get("final_llm_labeling"), False)
                     outputs_cfg = round_config.get("final_llm_outputs")
                     include_reasoning_value = round_config.get("final_llm_include_reasoning")
+                    visible_to_annotators_value = round_config.get(
+                        "final_llm_visible_to_annotators"
+                    )
+                    self._final_llm_reasoning = self._parse_bool(include_reasoning_value, True)
+                    self._final_llm_visible_to_annotators = self._parse_bool(
+                        visible_to_annotators_value,
+                        True,
+                    )
                     if isinstance(outputs_cfg, Mapping):
                         if not final_enabled:
                             final_enabled = True
                         if include_reasoning_value is None:
                             include_reasoning_value = outputs_cfg.get("final_llm_include_reasoning")
+                        if visible_to_annotators_value is None:
+                            visible_to_annotators_value = outputs_cfg.get(
+                                "final_llm_visible_to_annotators"
+                            )
                         self._final_llm_reasoning = self._parse_bool(include_reasoning_value, True)
+                        self._final_llm_visible_to_annotators = self._parse_bool(visible_to_annotators_value, True)
                         by_unit_value = outputs_cfg.get("final_llm_labels_by_unit")
                         if by_unit_value:
                             try:
@@ -766,6 +781,9 @@ class AssignmentContext(QtCore.QObject):
 
     def has_final_llm_labels(self) -> bool:
         return bool(self.final_llm_enabled)
+
+    def final_llm_visible_to_annotators(self) -> bool:
+        return bool(self._final_llm_visible_to_annotators)
 
     def final_llm_reasoning_enabled(self) -> bool:
         return bool(self._final_llm_reasoning)
@@ -1655,12 +1673,18 @@ class AnnotationForm(QtWidgets.QScrollArea):
         if not isinstance(button, QtWidgets.QPushButton):
             return
         visible = self.ctx.has_final_llm_labels()
+        llm_visible_to_annotators = self.ctx.final_llm_visible_to_annotators()
         has_value = False
         if visible and self.current_unit_id:
             entry = self.ctx.get_final_llm_label(self.current_unit_id, label_id)
             has_value = bool(entry)
         button.setVisible(visible)
+        if not llm_visible_to_annotators:
+            button.setEnabled(False)
+            button.setToolTip("LLM annotations are hidden for this round.")
+            return
         button.setEnabled(has_value)
+        button.setToolTip("" if has_value else "No LLM label is available for this unit and label.")
 
     def _show_assisted_snippets(self, label_id: str) -> None:
         if not self.ctx.has_assisted_review():
@@ -1758,6 +1782,13 @@ class AnnotationForm(QtWidgets.QScrollArea):
                 "Final LLM labels are not available for this assignment.",
             )
             return
+        if not self.ctx.final_llm_visible_to_annotators():
+            QtWidgets.QMessageBox.information(
+                self,
+                "LLM label",
+                "LLM annotations are hidden for this round.",
+            )
+            return
         if not self.current_unit_id:
             QtWidgets.QMessageBox.information(
                 self,
@@ -1819,6 +1850,8 @@ class AnnotationForm(QtWidgets.QScrollArea):
         dialog.exec()
 
     def _extract_llm_reasoning_text(self, entry: Mapping[str, object]) -> Optional[str]:
+        if not self.ctx.final_llm_visible_to_annotators():
+            return None
         if not self.ctx.final_llm_reasoning_enabled():
             return None
         raw_reasoning = entry.get("llm_reasoning")


### PR DESCRIPTION
### Motivation
- Provide a per-round option so admins can hide/lock LLM annotations and reasoning in the annotator UI while still producing final LLM labels and including the LLM as a reviewer.

### Description
- Added a new per-round config flag `final_llm_visible_to_annotators` and threaded it through Round Builder flows and round config payloads and overrides (`AdminApp` changes).
- Exposed a UI control in Round Builder dialogs to set `final_llm_visible_to_annotators` for both random and active-Learning final LLM runs (`AdminApp` additions of checkboxes and wiring to `base_cfg`/`overrides`).
- Persisted and rehydrate the new flag in round config writing/loading so `round_config.json` contains `final_llm_visible_to_annotators` when set (`AdminApp` round config handling).
- Updated `AssignmentContext` in `ClientApp` to load and track `_final_llm_visible_to_annotators` and expose `final_llm_visible_to_annotators()` for UI checks.
- Enforced visibility behavior in the annotation UI by disabling/graying the "View LLM label" button with an explanatory tooltip, showing an informational message when attempts are made to open LLM annotations while hidden, and preventing display of LLM reasoning via `_extract_llm_reasoning_text` when visibility is off (`ClientApp` changes).
- Added unit tests in `tests/test_client_annotation_form.py` to validate reasoning extraction respects the new visibility toggle and that the LLM button is disabled and shows the tooltip when annotations are hidden.

### Testing
- Ran `pytest -q tests/test_client_annotation_form.py` in this environment; the GUI-dependent tests were skipped because `PySide6` is not available (tests exercise Qt UI behavior and were added to cover the new toggles).
- Compiled the modified modules with `python -m compileall vaannotate/ClientApp/main.py vaannotate/AdminApp/main.py tests/test_client_annotation_form.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7c6ff5488327b91a72fdcf19d3a0)