### PR TITLE
Add quota progress logging for label-first sampling

### DIFF
--- a/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
+++ b/vaannotate/vaannotate_ai_backend/pipelines/active_learning.py
@@ -256,6 +256,17 @@ class ActiveLearningPipeline:
         types_subset = {lid: current_label_types.get(lid, "categorical") for lid in label_order}
 
         counts = build_target_counts(targets)
+        target_by_key = {quota_key(target): target for target in targets}
+
+        def _quota_progress_line() -> str:
+            parts: list[str] = []
+            for target in targets:
+                key = quota_key(target)
+                current = int(counts.get(key, 0))
+                parts.append(f"{target.label_id} {current}/{int(target.quota)}")
+            return " | ".join(parts)
+
+        print(f"[label-first quotas] {_quota_progress_line()}")
         selected_units: list[str] = []
         selected_set: set[str] = set()
         matched_labels: dict[str, str] = {}
@@ -333,6 +344,14 @@ class ActiveLearningPipeline:
                 for hit in hits:
                     key = quota_key(hit)
                     counts[key] = counts.get(key, 0) + 1
+                hit_summary = ", ".join(
+                    f"{target_by_key[key].label_id}+{delta}"
+                    for key, delta in {
+                        quota_key(hit): sum(1 for h in hits if quota_key(h) == quota_key(hit))
+                        for hit in hits
+                    }.items()
+                )
+                print(f"[label-first quotas] matched {uid}: {hit_summary} :: {_quota_progress_line()}")
                 if len(selected_units) >= target_total or not unresolved_targets(targets, counts):
                     break
 
@@ -360,6 +379,7 @@ class ActiveLearningPipeline:
         )
         if final.empty:
             raise RuntimeError("Label-first sampling did not find any matching units.")
+        print(f"[label-first quotas] final :: {_quota_progress_line()}")
         return final
 
     def run(self) -> pd.DataFrame:


### PR DESCRIPTION
### Motivation

- Improve visibility into quota fulfillment during `label-first` sampling by reporting per-label progress and per-unit matches as the selection loop runs.

### Description

- Add a `target_by_key` mapping and a `_quota_progress_line()` helper to format current quota progress from `targets` and `counts` for logging.  
- Print initial quota progress before selection with `print(f"[label-first quotas] {_quota_progress_line()}")` and print per-unit match summaries after hits are counted.  
- Compute a concise `hit_summary` for each selected unit showing which target labels changed and by how many, and print a final quota progress line before returning the final selection.  
- Keep existing selection logic and `counts` updates intact while adding these non-invasive diagnostic logs.

### Testing

- No automated tests were added or modified in this change.  
- No project test run was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91150108c8327b0999d060f1a8e6a)