### PR TITLE
Round Builder: show prior rounds and surface relabel file path only in file mode

### DIFF
--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -6864,18 +6864,23 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.relabel_source_rounds_radio.setChecked(True)
         relabel_layout.addWidget(self.relabel_source_rounds_radio)
         relabel_layout.addWidget(self.relabel_source_file_radio)
-        relabel_layout.addWidget(QtWidgets.QLabel("Prior rounds to relabel"))
+        self.relabel_rounds_label = QtWidgets.QLabel("Prior rounds to relabel")
+        relabel_layout.addWidget(self.relabel_rounds_label)
         self.relabel_rounds_list = QtWidgets.QListWidget()
         self.relabel_rounds_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.MultiSelection)
         relabel_layout.addWidget(self.relabel_rounds_list)
-        file_row = QtWidgets.QHBoxLayout()
+        self.relabel_file_row_widget = QtWidgets.QWidget()
+        file_row = QtWidgets.QHBoxLayout(self.relabel_file_row_widget)
+        file_row.setContentsMargins(0, 0, 0, 0)
         self.relabel_file_edit = QtWidgets.QLineEdit()
         self.relabel_file_edit.setPlaceholderText("Path to text/CSV file with unit IDs")
         file_row.addWidget(self.relabel_file_edit)
         self.relabel_file_browse_btn = QtWidgets.QPushButton("Browse…")
         self.relabel_file_browse_btn.clicked.connect(self._on_browse_relabel_file)
         file_row.addWidget(self.relabel_file_browse_btn)
-        relabel_layout.addLayout(file_row)
+        relabel_layout.addWidget(self.relabel_file_row_widget)
+        self.relabel_source_rounds_radio.toggled.connect(self._on_relabel_source_changed)
+        self.relabel_source_file_radio.toggled.connect(self._on_relabel_source_changed)
         relabel_form = QtWidgets.QFormLayout()
         relabel_form.addRow("Independent sampling", self.relabel_independent_checkbox)
         relabel_layout.addLayout(relabel_form)
@@ -7733,6 +7738,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             self.label_first_container.setVisible(using_label_first)
         if hasattr(self, "relabel_container"):
             self.relabel_container.setVisible(using_relabel)
+        self._on_relabel_source_changed()
         if hasattr(self, "filter_group"):
             self.filter_group.setVisible(not using_relabel)
         if hasattr(self, "strat_group"):
@@ -7748,6 +7754,15 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             should_enable = using_ai or self._ai_job_running
             self.ai_controls_container.setEnabled(should_enable)
         self._update_ai_buttons()
+
+    def _on_relabel_source_changed(self) -> None:
+        using_file = bool(getattr(self, "relabel_source_file_radio", None) and self.relabel_source_file_radio.isChecked())
+        if hasattr(self, "relabel_rounds_label"):
+            self.relabel_rounds_label.setVisible(not using_file)
+        if hasattr(self, "relabel_rounds_list"):
+            self.relabel_rounds_list.setVisible(not using_file)
+        if hasattr(self, "relabel_file_row_widget"):
+            self.relabel_file_row_widget.setVisible(using_file)
 
     def _update_ai_buttons(self) -> None:
         enabled = self._using_ai_backend()
@@ -9043,7 +9058,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                     if isinstance(value, int):
                         round_numbers.append(value)
         if not round_numbers:
-            raise ValueError("Select at least one completed prior round for re-label sampling.")
+            raise ValueError("Select at least one prior round for re-label sampling.")
         db = self.ctx.require_db()
         with db.connect() as conn:
             placeholders = ",".join("?" for _ in round_numbers)


### PR DESCRIPTION
### Motivation
- The Re-label source controls were not surfacing the prior-rounds list correctly and the external file path row was always visible, causing confusion when selecting relabel sources.
- The UI should show the "Prior rounds to relabel" list when "Use units from prior completed rounds" is selected and only show the path + browse controls when "Load external unit_id file" is selected.
- Validation text should reflect that any prior rounds (not only completed ones) may be selected since rounds are enumerated from `list_rounds` without a completion filter.

### Description
- Added `self.relabel_rounds_label` and `self.relabel_file_row_widget` so the prior-rounds label/list and the file path row can be shown/hidden independently.
- Implemented `_on_relabel_source_changed()` to toggle visibility of the prior-rounds label/list and the file row based on which relabel source radio is selected and connected both source radios to this handler.
- Invoked `_on_relabel_source_changed()` from `_on_generation_mode_changed()` to ensure visibility is refreshed when switching generation modes.
- Updated the validation message in `_load_relabel_unit_ids` from `"Select at least one completed prior round..."` to `"Select at least one prior round..."`.

### Testing
- Compiled the modified module with `python -m py_compile vaannotate/AdminApp/main.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa11bef0a883279f56311303d1f7a4)