### PR TITLE
Preserve prior-round options in Re-label existing units mode

### DIFF
--- a/tests/test_round_import.py
+++ b/tests/test_round_import.py
@@ -1833,3 +1833,54 @@ def test_generate_round_auto_submit_llm_missing_predictions(
         assert missing_row["value"] in (None, "")
         assert missing_row["value_num"] is None
 
+
+def test_relabel_rounds_not_cleared_by_latest_defaults() -> None:
+    class _ListWidget:
+        def __init__(self) -> None:
+            self._items: list[object] = []
+
+        def clear(self) -> None:
+            self._items.clear()
+
+        def addItem(self, item: object) -> None:
+            self._items.append(item)
+
+        def count(self) -> int:
+            return len(self._items)
+
+    class _Item:
+        def __init__(self, text: str) -> None:
+            self.text = text
+            self._data: dict[int, object] = {}
+
+        def setData(self, role: int, value: object) -> None:
+            self._data[role] = value
+
+    class _Ctx:
+        def list_rounds(self, _pheno_id: str):
+            return [
+                {"round_number": 1, "round_id": "ph_test_r1"},
+                {"round_number": 2, "round_id": "ph_test_r2"},
+            ]
+
+        def get_round_config(self, _round_id: str):
+            return {}
+
+    original_item = admin_main.QtWidgets.QListWidgetItem
+    admin_main.QtWidgets.QListWidgetItem = _Item
+    try:
+        dialog = admin_main.RoundBuilderDialog.__new__(admin_main.RoundBuilderDialog)
+        dialog.ctx = _Ctx()
+        dialog.pheno_row = {"pheno_id": "ph_test", "level": "single_doc"}
+        dialog.ai_rounds_list = _ListWidget()
+        dialog.relabel_rounds_list = _ListWidget()
+        dialog._ai_engine_overrides = {}
+        dialog._apply_ai_config_to_controls = lambda _cfg: None
+
+        admin_main.RoundBuilderDialog._refresh_ai_round_options(dialog)
+        assert dialog.relabel_rounds_list.count() == 2
+
+        admin_main.RoundBuilderDialog._apply_latest_round_defaults(dialog)
+        assert dialog.relabel_rounds_list.count() == 2
+    finally:
+        admin_main.QtWidgets.QListWidgetItem = original_item

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -7378,9 +7378,6 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             return
         latest_round: Optional[Mapping[str, object]] = None
         latest_number: Optional[int] = None
-        relabel_widget = getattr(self, "relabel_rounds_list", None)
-        if relabel_widget is not None:
-            relabel_widget.clear()
         for round_row in rounds:
             round_number = self._safe_mapping_get(round_row, "round_number")
             round_id = self._safe_mapping_get(round_row, "round_id")
@@ -7585,9 +7582,6 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             rounds = self.ctx.list_rounds(pheno_id)
         except Exception:
             return reviewed
-        relabel_widget = getattr(self, "relabel_rounds_list", None)
-        if relabel_widget is not None:
-            relabel_widget.clear()
         for round_row in rounds:
             round_number = self._safe_mapping_get(round_row, "round_number")
             if round_number is None:


### PR DESCRIPTION
### Motivation
- The re-label source list could become empty because prior-round entries were being cleared from non-refresh paths, causing “Re-label existing units” to show no prior rounds despite rounds existing. 

### Description
- Stop clearing the re-label rounds list from `RoundBuilderDialog._apply_latest_round_defaults` and `RoundBuilderDialog._load_reviewed_unit_ids`, so entries persist unless explicitly refreshed. 
- Keep the clearing/rebuild behavior in `RoundBuilderDialog._refresh_ai_round_options` where round options are intentionally refreshed. 
- Add a regression test `test_relabel_rounds_not_cleared_by_latest_defaults` in `tests/test_round_import.py` that stubs list widgets and verifies the re-label rounds list remains populated after calling `_apply_latest_round_defaults`.

### Testing
- An initial quick test `pytest -q tests/test_round_builder_relabel_rounds.py` failed during Qt import with `ImportError: libGL.so.1` in the environment. 
- The focused regression test `pytest -q tests/test_round_import.py -k relabel_rounds_not_cleared_by_latest_defaults` passed (1 passed, 20 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa14a334b08327b9c8674ac6f9228c)