### PR TITLE
Fix relabel unit loading from round aggregates and restore GUI counts

### DIFF
--- a/tests/test_round_import.py
+++ b/tests/test_round_import.py
@@ -1884,3 +1884,76 @@ def test_relabel_rounds_not_cleared_by_latest_defaults() -> None:
         assert dialog.relabel_rounds_list.count() == 2
     finally:
         admin_main.QtWidgets.QListWidgetItem = original_item
+
+
+def test_load_relabel_unit_ids_reads_round_aggregate_units(tmp_path: Path) -> None:
+    class _Item:
+        def __init__(self, value: int, selected: bool) -> None:
+            self._value = value
+            self._selected = selected
+
+        def isSelected(self) -> bool:
+            return self._selected
+
+        def data(self, _role: int) -> object:
+            return self._value
+
+    class _ListWidget:
+        def __init__(self, items: list[_Item]) -> None:
+            self._items = items
+
+        def count(self) -> int:
+            return len(self._items)
+
+        def item(self, index: int) -> _Item:
+            return self._items[index]
+
+    class _Db:
+        def __init__(self, path: Path) -> None:
+            self._path = path
+
+        def connect(self):
+            conn = sqlite3.connect(self._path)
+            conn.row_factory = sqlite3.Row
+            return conn
+
+    class _Ctx:
+        def __init__(self, root: Path) -> None:
+            self.root = root
+
+        def resolve_round_dir(self, pheno_id: str, round_number: int) -> Path:
+            return self.root / "phenotypes" / pheno_id / "rounds" / f"round_{round_number}"
+
+        def get_round_aggregate_db(self, round_dir: Path, *, create: bool = False):
+            _ = create
+            path = round_dir / "round_aggregate.db"
+            if not path.exists():
+                return None
+            return _Db(path)
+
+        def get_assignment_db(self, _path: Path):
+            return None
+
+    round_dir = tmp_path / "phenotypes" / "ph_test" / "rounds" / "round_1"
+    round_dir.mkdir(parents=True)
+    with sqlite3.connect(round_dir / "round_aggregate.db") as conn:
+        conn.execute("CREATE TABLE unit_summary(round_id TEXT, unit_id TEXT, patient_icn TEXT, doc_id TEXT, metadata_json TEXT)")
+        conn.executemany(
+            "INSERT INTO unit_summary(round_id, unit_id, patient_icn, doc_id, metadata_json) VALUES (?,?,?,?,?)",
+            [
+                ("ph_test_r1", "unit_a", "", "", None),
+                ("ph_test_r1", "unit_b", "", "", None),
+                ("ph_test_r1", "unit_a", "", "", None),
+            ],
+        )
+        conn.commit()
+
+    dialog = admin_main.RoundBuilderDialog.__new__(admin_main.RoundBuilderDialog)
+    dialog.ctx = _Ctx(tmp_path)
+    dialog.pheno_row = {"pheno_id": "ph_test", "level": "single_doc"}
+    dialog.relabel_sampling_radio = types.SimpleNamespace(isChecked=lambda: True)
+    dialog.relabel_source_file_radio = types.SimpleNamespace(isChecked=lambda: False)
+    dialog.relabel_rounds_list = _ListWidget([_Item(1, True)])
+
+    unit_ids = admin_main.RoundBuilderDialog._load_relabel_unit_ids(dialog, "unused")
+    assert unit_ids == {"unit_a", "unit_b"}

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -9149,16 +9149,25 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                         round_numbers.append(value)
         if not round_numbers:
             raise ValueError("Select at least one prior round for re-label sampling.")
-        db = self.ctx.require_db()
-        with db.connect() as conn:
-            placeholders = ",".join("?" for _ in round_numbers)
-            rows = conn.execute(
-                f"""SELECT DISTINCT ra.unit_id FROM round_assignments ra
-                    JOIN rounds r ON r.round_id=ra.round_id
-                    WHERE r.pheno_id=? AND r.round_number IN ({placeholders})""",
-                (self.pheno_row["pheno_id"], *round_numbers),
-            ).fetchall()
-        return {str(row[0]) for row in rows if row and row[0]}
+        pheno_id = str(self.pheno_row["pheno_id"])
+        unit_ids: Set[str] = set()
+        for round_number in round_numbers:
+            round_dir = self.ctx.resolve_round_dir(pheno_id, int(round_number))
+            aggregate_db = self.ctx.get_round_aggregate_db(round_dir, create=False)
+            if aggregate_db is not None:
+                with aggregate_db.connect() as agg_conn:
+                    rows = agg_conn.execute("SELECT DISTINCT unit_id FROM unit_summary").fetchall()
+                unit_ids.update(str(row[0]) for row in rows if row and row[0])
+                continue
+            # Fallback for rounds without an aggregate: read units directly from reviewer assignments.
+            for assignment_path in sorted((round_dir / "assignments").glob("*/*assignment.db")):
+                assignment_db = self.ctx.get_assignment_db(assignment_path)
+                if assignment_db is None:
+                    continue
+                with assignment_db.connect() as assign_conn:
+                    rows = assign_conn.execute("SELECT DISTINCT unit_id FROM units").fetchall()
+                unit_ids.update(str(row[0]) for row in rows if row and row[0])
+        return unit_ids
 
     def _create_round(self) -> bool:
         pheno_id = self.pheno_row["pheno_id"]


### PR DESCRIPTION
### Motivation
- Starting relabel round generation failed with "no such table: round_assignments" and the GUI counters for "Unique units selected" and "Total N (calculated)" stayed at 0 because relabel unit IDs were not being loaded from existing round data.

### Description
- Stop querying the nonexistent `round_assignments` table and instead load relabel unit IDs per selected round from the round aggregate DB (`round_aggregate.db`) by reading distinct `unit_id` from `unit_summary`.
- Add a fallback that, when the aggregate DB is missing, scans reviewer assignment databases under `round_dir/assignments/*/*assignment.db` and reads `units.unit_id` to collect unit IDs.
- Deduplicate unit IDs across selected rounds and return them as a `Set[str]` so the GUI counters reflect the selected rounds.
- Add a regression test `test_load_relabel_unit_ids_reads_round_aggregate_units` to verify unit IDs are read from a minimal `round_aggregate.db`.

### Testing
- Added `tests/test_round_import.py::test_load_relabel_unit_ids_reads_round_aggregate_units` to exercise the new loading logic.
- Attempted to run relabel-focused tests with `pytest -k relabel`, but test collection in this environment failed due to a missing optional dependency (`pandas`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd3ac5df88327bbfa48e2d4789311)