### PR TITLE
Match relabel units by any identifier and disable independent sampling for relabel mode

### DIFF
--- a/tests/test_round_import.py
+++ b/tests/test_round_import.py
@@ -1957,3 +1957,35 @@ def test_load_relabel_unit_ids_reads_round_aggregate_units(tmp_path: Path) -> No
 
     unit_ids = admin_main.RoundBuilderDialog._load_relabel_unit_ids(dialog, "unused")
     assert unit_ids == {"unit_a", "unit_b"}
+
+
+def test_independent_sampling_disabled_for_relabel_mode() -> None:
+    dialog = admin_main.RoundBuilderDialog.__new__(admin_main.RoundBuilderDialog)
+    dialog.label_first_radio = types.SimpleNamespace(isChecked=lambda: False)
+    dialog.relabel_sampling_radio = types.SimpleNamespace(isChecked=lambda: True)
+    dialog.active_learning_radio = types.SimpleNamespace(isChecked=lambda: False)
+    dialog.relabel_independent_checkbox = types.SimpleNamespace(isChecked=lambda: True)
+    dialog.random_independent_checkbox = types.SimpleNamespace(isChecked=lambda: True)
+
+    assert admin_main.RoundBuilderDialog._independent_sampling_enabled(dialog) is False
+
+
+def test_current_total_n_uses_relabel_count() -> None:
+    dialog = admin_main.RoundBuilderDialog.__new__(admin_main.RoundBuilderDialog)
+    dialog.label_first_radio = types.SimpleNamespace(isChecked=lambda: False)
+    dialog.relabel_sampling_radio = types.SimpleNamespace(isChecked=lambda: True)
+    dialog._current_relabel_unit_count = lambda: 12
+    dialog._using_ai_backend = lambda: False
+    dialog.random_total_n_spin = types.SimpleNamespace(value=lambda: 250)
+
+    assert admin_main.RoundBuilderDialog._current_total_n(dialog) == 12
+
+
+def test_row_matches_relabel_units_by_any_identifier() -> None:
+    dialog = admin_main.RoundBuilderDialog.__new__(admin_main.RoundBuilderDialog)
+    dialog.pheno_row = {"level": "single_doc"}
+    row = {"unit_id": "unit_001", "doc_id": "doc_abc", "patient_icn": "pat_xyz"}
+
+    identifiers = admin_main.RoundBuilderDialog._row_unit_identifiers(dialog, row)
+
+    assert {"unit_001", "doc_abc", "pat_xyz"} == set(identifiers.values())

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -7682,11 +7682,20 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         return reviewed
 
     def _row_unit_identifier(self, row: sqlite3.Row | Dict[str, object]) -> Optional[str]:
-        keys = ["unit_id"]
-        if self.pheno_row["level"] == "multi_doc":
-            keys.append("patient_icn")
-        else:
-            keys.extend(["doc_id", "patient_icn"])
+        identifiers = self._row_unit_identifiers(row)
+        for key in (
+            ("unit_id", "patient_icn")
+            if self.pheno_row["level"] == "multi_doc"
+            else ("unit_id", "doc_id", "patient_icn")
+        ):
+            value = identifiers.get(key)
+            if value not in (None, ""):
+                return str(value)
+        return None
+
+    def _row_unit_identifiers(self, row: sqlite3.Row | Dict[str, object]) -> Dict[str, str]:
+        keys = ["unit_id", "doc_id", "patient_icn"]
+        identifiers: Dict[str, str] = {}
         for key in keys:
             value: Optional[object] = None
             if isinstance(row, dict):
@@ -7697,8 +7706,8 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 except (KeyError, IndexError, TypeError):
                     value = None
             if value not in (None, ""):
-                return str(value)
-        return None
+                identifiers[key] = str(value)
+        return identifiers
 
     def _prompt_reviewers(self) -> Optional[List[Dict[str, str]]]:
         reviewers: List[Dict[str, str]] = []
@@ -7784,6 +7793,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         if bool(getattr(self, "label_first_radio", None) and self.label_first_radio.isChecked()):
             return bool(getattr(self, "label_first_independent_checkbox", None) and self.label_first_independent_checkbox.isChecked())
         if bool(getattr(self, "relabel_sampling_radio", None) and self.relabel_sampling_radio.isChecked()):
+            # Re-label workflows intentionally sample from known prior units.
             return False
         if bool(getattr(self, "active_learning_radio", None) and self.active_learning_radio.isChecked()):
             return bool(getattr(self, "active_learning_independent_checkbox", None) and self.active_learning_independent_checkbox.isChecked())
@@ -7814,6 +7824,11 @@ class RoundBuilderDialog(QtWidgets.QDialog):
                 label_widget = total_n_label.labelForField(self.random_total_n_spin)
                 if label_widget is not None:
                     label_widget.setVisible(random_total_visible)
+                independent_label = total_n_label.labelForField(getattr(self, "random_independent_checkbox", None))
+                if independent_label is not None:
+                    independent_label.setVisible(not using_relabel)
+        if hasattr(self, "random_independent_checkbox"):
+            self.random_independent_checkbox.setVisible(not using_relabel)
         if hasattr(self, "ai_total_n_spin"):
             ai_total_visible = not using_label_first
             self.ai_total_n_spin.setVisible(ai_total_visible)
@@ -9309,7 +9324,11 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             except ValueError as exc:
                 QtWidgets.QMessageBox.warning(self, "Re-label sampling", str(exc))
                 return False
-            corpus_rows = [row for row in corpus_rows if (self._row_unit_identifier(row) or "") in relabel_units]
+            corpus_rows = [
+                row
+                for row in corpus_rows
+                if any(value in relabel_units for value in self._row_unit_identifiers(row).values())
+            ]
             sampling_metadata["relabel_mode"] = True
             sampling_metadata["relabel_unit_count"] = len(relabel_units)
             if not corpus_rows:


### PR DESCRIPTION
### Motivation

- Improve re-label sampling so rows are matched by any available identifier (`unit_id`, `doc_id`, or `patient_icn`) and prevent independent-sampling options that contradict re-label workflows. 

### Description

- Add `_row_unit_identifiers` to normalize and return all possible unit identifiers for a row and refactor `_row_unit_identifier` to use it when a single identifier is needed. 
- Change the relabel filter to include a row if any identifier from `_row_unit_identifiers(row)` is present in the selected relabel set. 
- Ensure independent sampling is disabled when relabel mode is active and hide the random independent UI controls when re-labeling. 
- Update UI visibility logic in `_on_generation_mode_changed` and add a clarifying comment about re-label behavior. 

### Testing

- Added unit tests in `tests/test_round_import.py` including `test_independent_sampling_disabled_for_relabel_mode`, `test_current_total_n_uses_relabel_count`, and `test_row_matches_relabel_units_by_any_identifier`. 
- Ran `pytest tests/test_round_import.py` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce470c5fc8327a54ba77e8232af31)