### PR TITLE
Handle Python date objects in final LLM labeling JSON normalization

### DIFF
--- a/tests/test_round_import.py
+++ b/tests/test_round_import.py
@@ -1989,3 +1989,9 @@ def test_row_matches_relabel_units_by_any_identifier() -> None:
     identifiers = admin_main.RoundBuilderDialog._row_unit_identifiers(dialog, row)
 
     assert {"unit_001", "doc_abc", "pat_xyz"} == set(identifiers.values())
+
+
+def test_roundbuilder_normalize_for_json_handles_date() -> None:
+    from datetime import date
+
+    assert RoundBuilder._normalize_for_json(date(2026, 5, 7)) == "2026-05-07"

--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -12,7 +12,7 @@ import re
 import sqlite3
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, Set
 
@@ -1639,7 +1639,7 @@ class RoundBuilder:
                 return RoundBuilder._normalize_for_json(value.item())
             except Exception:  # noqa: BLE001
                 return float(value)
-        if isinstance(value, (pd.Timestamp, datetime)):
+        if isinstance(value, (pd.Timestamp, datetime, date)):
             return value.isoformat()
         if isinstance(value, dict):
             return {str(k): RoundBuilder._normalize_for_json(v) for k, v in value.items()}


### PR DESCRIPTION
### Motivation
- Final LLM labeling in the re-label-from-prior-rounds flow could encounter Python `date` objects in note metadata which caused `json.dumps` to fail with `object of type date is not JSON serializable`.

### Description
- Updated `vaannotate/rounds.py` to import `date` and treat `date` the same as `datetime`/`pd.Timestamp` in `RoundBuilder._normalize_for_json` by converting them to ISO-8601 strings via `isoformat()`.
- Added a regression unit test `test_roundbuilder_normalize_for_json_handles_date` in `tests/test_round_import.py` that asserts `RoundBuilder._normalize_for_json(date(2026, 5, 7)) == "2026-05-07"`.
- Small cleanup to ensure JSON normalization covers date-like values coming from prior-round notes so downstream `json.dumps`/parquet writes do not error.

### Testing
- Added and ran a targeted pytest selection for the new test: `pytest -q tests/test_round_import.py -k normalize_for_json_handles_date`, but test collection failed in this environment due to a missing dependency (`pandas`), so the test did not execute here; the regression test file is included in the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfb75600083279e4d0d9da2343755)