### PR TITLE
Fix final LLM relabel date predictions serialization

### DIFF
--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -1523,6 +1523,10 @@ class RoundBuilder:
                 fam_df.rename(columns={"consistency": "llm_consistency"}, inplace=True)
             if "prediction" in fam_df.columns:
                 fam_df.rename(columns={"prediction": "llm_prediction"}, inplace=True)
+            if "llm_prediction" in fam_df.columns:
+                fam_df["llm_prediction"] = fam_df["llm_prediction"].map(
+                    lambda value: value.isoformat() if isinstance(value, (date, datetime)) else value
+                )
             if include_reasoning and "llm_runs" in fam_df.columns:
                 fam_df["llm_reasoning"] = fam_df["llm_runs"].map(self._extract_reasoning_from_runs)
             fam_df = _jsonify_cols(


### PR DESCRIPTION
### Motivation
- Prevent downstream serialization failures (e.g., parquet/JSON writes) when final LLM relabeling returns Python `date`/`datetime` objects for `llm_prediction`.

### Description
- Normalize `llm_prediction` values in the final LLM labeling path inside `vaannotate/rounds.py` by mapping `date`/`datetime` objects to ISO strings with `value.isoformat()` before further JSON/parquet handling.
- This aligns the relabel/random final-LLM path behavior with the existing family-labeler normalization that already converts date/datetime predictions to ISO strings.

### Testing
- Ran `python -m py_compile vaannotate/rounds.py`, which succeeded.
- Ran `python -m pytest -q tests/test_family_labeler_normalization.py`, which could not be collected in this environment due to a missing `pandas` dependency (test run aborted during collection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0106b028832796f6fd7ef732004d)