### PR TITLE
Add KoboldCpp LLM backend with localhost PHI guardrails and GUI support

### DIFF
--- a/tests/test_kobold_backend.py
+++ b/tests/test_kobold_backend.py
@@ -1,0 +1,18 @@
+from vaannotate.vaannotate_ai_backend.config import LLMConfig
+from vaannotate.vaannotate_ai_backend.llm_backends import KoboldCppBackend, build_llm_backend
+
+
+def test_build_kobold_backend_requires_loopback():
+    cfg = LLMConfig(backend="koboldcpp", koboldcpp_endpoint="http://127.0.0.1:5001")
+    backend = build_llm_backend(cfg)
+    assert isinstance(backend, KoboldCppBackend)
+
+
+def test_kobold_backend_rejects_non_localhost():
+    cfg = LLMConfig(backend="koboldcpp", koboldcpp_endpoint="http://10.0.0.8:5001")
+    try:
+        build_llm_backend(cfg)
+    except ValueError as exc:
+        assert "localhost" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for non-localhost endpoint")

--- a/vaannotate/AdminApp/main.py
+++ b/vaannotate/AdminApp/main.py
@@ -7033,6 +7033,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.random_backend_combo = QtWidgets.QComboBox()
         self.random_backend_combo.addItem("Azure OpenAI", "azure")
         self.random_backend_combo.addItem("Local ExLlamaV2", "exllamav2")
+        self.random_backend_combo.addItem("KoboldCpp (local endpoint)", "koboldcpp")
         self.random_backend_combo.currentIndexChanged.connect(self._update_random_backend_fields)
         random_llm_layout.addRow("Backend", self.random_backend_combo)
 
@@ -7168,6 +7169,7 @@ class RoundBuilderDialog(QtWidgets.QDialog):
         self.ai_backend_combo = QtWidgets.QComboBox()
         self.ai_backend_combo.addItem("Azure OpenAI", "azure")
         self.ai_backend_combo.addItem("Local ExLlamaV2", "exllamav2")
+        self.ai_backend_combo.addItem("KoboldCpp (local endpoint)", "koboldcpp")
         self.ai_backend_combo.currentIndexChanged.connect(self._update_ai_backend_fields)
         ai_config_layout.addRow("LLM backend", self.ai_backend_combo)
         self.ai_azure_key_edit = QtWidgets.QLineEdit()
@@ -8354,6 +8356,16 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             else:
                 env["AZURE_OPENAI_ENDPOINT"] = azure_endpoint
             env["LLM_BACKEND"] = "azure"
+        elif backend_choice == "koboldcpp":
+            endpoint = self.ai_azure_endpoint_edit.text().strip() if hasattr(self, "ai_azure_endpoint_edit") else ""
+            api_key = self.ai_azure_key_edit.text().strip() if hasattr(self, "ai_azure_key_edit") else ""
+            if not endpoint:
+                missing.append("KoboldCpp endpoint URL")
+            else:
+                env["KOBOLDCPP_ENDPOINT"] = endpoint
+            if api_key:
+                env["KOBOLDCPP_API_KEY"] = api_key
+            env["LLM_BACKEND"] = "koboldcpp"
         else:
             model_path = ""
             if hasattr(self, "ai_local_model_path_edit"):
@@ -8464,6 +8476,16 @@ class RoundBuilderDialog(QtWidgets.QDialog):
             else:
                 env["AZURE_OPENAI_ENDPOINT"] = azure_endpoint
             env["LLM_BACKEND"] = "azure"
+        elif backend_choice == "koboldcpp":
+            endpoint = self.random_azure_endpoint_edit.text().strip() if hasattr(self, "random_azure_endpoint_edit") else ""
+            api_key = self.random_azure_key_edit.text().strip() if hasattr(self, "random_azure_key_edit") else ""
+            if not endpoint:
+                missing.append("KoboldCpp endpoint URL")
+            else:
+                env["KOBOLDCPP_ENDPOINT"] = endpoint
+            if api_key:
+                env["KOBOLDCPP_API_KEY"] = api_key
+            env["LLM_BACKEND"] = "koboldcpp"
         else:
             model_path = (
                 self.random_local_model_path_edit.text().strip()

--- a/vaannotate/rounds.py
+++ b/vaannotate/rounds.py
@@ -835,6 +835,14 @@ class RoundBuilder:
                     local_max_new_value = None
                 if local_max_new_value and local_max_new_value > 0:
                     env_overrides["LOCAL_LLM_MAX_NEW_TOKENS"] = str(local_max_new_value)
+        elif backend_choice in {"koboldcpp", "kobold"}:
+            backend_env_value = "koboldcpp"
+            endpoint = str(ai_backend_config.get("koboldcpp_endpoint") or ai_backend_config.get("azure_endpoint") or "").strip()
+            if endpoint:
+                env_overrides["KOBOLDCPP_ENDPOINT"] = endpoint
+            api_key = str(ai_backend_config.get("koboldcpp_api_key") or ai_backend_config.get("azure_api_key") or "").strip()
+            if api_key:
+                env_overrides["KOBOLDCPP_API_KEY"] = api_key
         if backend_env_value:
             env_overrides["LLM_BACKEND"] = backend_env_value
         embed_path = self._resolve_optional_path(ai_backend_config.get("embedding_model_dir"), config_base)

--- a/vaannotate/vaannotate_ai_backend/config.py
+++ b/vaannotate/vaannotate_ai_backend/config.py
@@ -103,6 +103,15 @@ class LLMConfig:
     local_max_new_tokens: Optional[int] = field(
         default_factory=lambda: _env_int("LOCAL_LLM_MAX_NEW_TOKENS")
     )
+    # KoboldCpp OpenAI-compatible endpoint knobs
+    koboldcpp_endpoint: Optional[str] = field(
+        default_factory=lambda: os.getenv("KOBOLDCPP_ENDPOINT")
+    )
+    koboldcpp_api_key: Optional[str] = field(
+        default_factory=lambda: os.getenv("KOBOLDCPP_API_KEY")
+    )
+    koboldcpp_require_localhost: bool = True
+
     # Context ordering for snippets
     context_order: str = "relevance"  # relevance | chronological
 

--- a/vaannotate/vaannotate_ai_backend/llm_backends.py
+++ b/vaannotate/vaannotate_ai_backend/llm_backends.py
@@ -28,6 +28,9 @@ import math
 import os
 import re
 import time
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
 from collections.abc import Mapping as MappingABC, Sequence as SequenceABC
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence
@@ -898,6 +901,94 @@ class ExLlamaV2Backend(LLMBackend):  # pragma: no cover - requires heavy optiona
         )
 
       
+
+class KoboldCppBackend(LLMBackend):
+    """Backend that calls an external KoboldCpp OpenAI-compatible endpoint."""
+
+    def __init__(self, cfg: LLMConfig):
+        super().__init__(cfg)
+        endpoint = (cfg.koboldcpp_endpoint or os.getenv("KOBOLDCPP_ENDPOINT") or "").strip()
+        if not endpoint:
+            raise ValueError("KoboldCpp backend requires koboldcpp_endpoint / KOBOLDCPP_ENDPOINT.")
+        parsed = urlparse(endpoint)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("KoboldCpp endpoint must be a valid http(s) URL.")
+        if getattr(cfg, "koboldcpp_require_localhost", True):
+            host = (parsed.hostname or "").lower()
+            if host not in {"localhost", "127.0.0.1", "::1"}:
+                raise ValueError(
+                    "KoboldCpp endpoint must be localhost/loopback for PHI safety. "
+                    "Override koboldcpp_require_localhost=false only in trusted environments."
+                )
+        self.endpoint = endpoint.rstrip("/") + "/v1/chat/completions"
+        self.api_key = (cfg.koboldcpp_api_key or os.getenv("KOBOLDCPP_API_KEY") or "").strip()
+
+    def _post_chat(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        req = urllib.request.Request(
+            self.endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        timeout = float(getattr(self.cfg, "timeout", 60.0) or 60.0)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = resp.read().decode("utf-8", errors="replace")
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"KoboldCpp request failed: {exc}") from exc
+        return json.loads(body)
+
+    def json_call(self, messages, *, temperature, logprobs, top_logprobs, response_format=None, **_):
+        self._respect_rpm_limit()
+        payload = {
+            "model": self.cfg.model_name,
+            "messages": list(messages),
+            "temperature": float(temperature),
+        }
+        if response_format:
+            payload["response_format"] = {"type": "json_object"}
+        started = time.perf_counter()
+        raw = self._post_chat(payload)
+        self._post_call()
+        latency = time.perf_counter() - started
+        choices = raw.get("choices") or []
+        if not choices:
+            raise RuntimeError("KoboldCpp returned no choices.")
+        msg = choices[0].get("message", {})
+        parsed = msg.get("parsed")
+        content = msg.get("content", "")
+        data_candidate, raw_content = self._parse_json_candidate(content=content, parsed=parsed)
+        self._validate_json_object_candidate(
+            response_format=response_format,
+            data_candidate=data_candidate,
+            raw_content=raw_content,
+        )
+        if not isinstance(data_candidate, MappingABC):
+            data_candidate = {"text": str(data_candidate)}
+        return JSONCallResult(data=data_candidate, content=raw_content, raw_response=raw, latency_s=latency)
+
+    def forced_choice(self, system, user, *, options, letters, top_logprobs=5):
+        prompt = (
+            f"{system.strip()}\n\n{user.strip()}\n\n"
+            f"Choose exactly one option: {', '.join(letters)}. Reply with one letter only."
+        )
+        result = self.json_call(
+            [{"role": "user", "content": prompt}],
+            temperature=0.0,
+            logprobs=False,
+            top_logprobs=top_logprobs,
+            response_format=None,
+        )
+        txt = (result.content or "").strip().upper()
+        pick = next((l for l in letters if l.upper() in txt[:2]), letters[0])
+        probs = {l: (1.0 if l == pick else 0.0) for l in letters}
+        logs = {l: (0.0 if l == pick else -1e9) for l in letters}
+        return ForcedChoiceResult(option_probs=probs, option_logprobs=logs, prediction=pick, entropy=0.0, latency_s=result.latency_s, raw_response=result.raw_response)
+
+
 def build_llm_backend(cfg: LLMConfig) -> LLMBackend:
     """Factory helper that instantiates the requested backend."""
 
@@ -906,4 +997,6 @@ def build_llm_backend(cfg: LLMConfig) -> LLMBackend:
         return AzureOpenAIBackend(cfg)
     if backend_name in {"exllama", "exllamav2", "local"}:
         return ExLlamaV2Backend(cfg)
+    if backend_name in {"koboldcpp", "kobold"}:
+        return KoboldCppBackend(cfg)
     raise ValueError(f"Unsupported LLM backend: {cfg.backend}")


### PR DESCRIPTION
### Motivation
- Provide an additional inference backend option that calls an externally hosted KoboldCpp OpenAI-compatible endpoint so local KoboldCpp deployments can be used as an alternative to `exllamav2` and Azure.
- Ensure PHI safety by default by restricting KoboldCpp endpoints to loopback hosts unless explicitly overridden.
- Keep prompt/JSON contract behavior consistent with existing backends so orchestration and validation remain unchanged.

### Description
- Added a new `KoboldCppBackend` class in `vaannotate/vaannotate_ai_backend/llm_backends.py` that posts to an OpenAI-compatible `/v1/chat/completions` endpoint and preserves the JSON-object parsing/validation flow used by other backends.
- Extended `LLMConfig` in `vaannotate/vaannotate_ai_backend/config.py` with `koboldcpp_endpoint`, `koboldcpp_api_key`, and `koboldcpp_require_localhost` configuration fields (env vars: `KOBOLDCPP_ENDPOINT`, `KOBOLDCPP_API_KEY`) and defaulted the localhost requirement to `True`.
- Wired factory support so `build_llm_backend` recognizes `koboldcpp`/`kobold` as valid backends and rejects invalid or non-loopback endpoints when the guard is enabled.
- Updated orchestration/env plumbing in `vaannotate/rounds.py` to emit `LLM_BACKEND=koboldcpp` and propagate `KOBOLDCPP_ENDPOINT`/`KOBOLDCPP_API_KEY` when configured.
- Updated `AdminApp` GUI (`vaannotate/AdminApp/main.py`) to expose KoboldCpp in the backend selectors for both random/final and active-learning LLM UI flows and collect the endpoint/key using the existing Azure endpoint/key fields to keep the UI change minimal.
- Added `tests/test_kobold_backend.py` to validate backend construction and the default localhost safety check.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_kobold_backend.py tests/test_ai_backend_config.py tests/test_llm_backends_json_retry.py` and all tests passed.
- Test summary: `8 passed` for the selected tests that cover new KoboldCpp construction and existing LLM backend JSON-retry behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd034066dc832794515c8a3b60b47e)